### PR TITLE
Load custom scenery airport data in priority order

### DIFF
--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -18,7 +18,6 @@
 #include <chrono>
 #include "XData.h"
 #include "src/platform/Platform.h"
-#include "src/libxdata/world/loaders/AirportLoader.h"
 #include "src/libxdata/world/loaders/FixLoader.h"
 #include "src/libxdata/world/loaders/NavaidLoader.h"
 #include "src/libxdata/world/loaders/AirwayLoader.h"
@@ -69,20 +68,27 @@ void XData::cancelLoading() {
 void XData::loadAirports() {
     const AirportLoader loader(world);
 
-    //Custom scenery
+    try {
+        loadCustomScenery(loader);
+    } catch (const std::exception &e) {
+        logger::warn("Unable to parse custom scenery. Check your scenery_packs.ini file.", e.what());
+    }
+
+    loader.load(xplaneRoot + "Resources/default scenery/default apt dat/Earth nav data/apt.dat");
+}
+
+void XData::loadCustomScenery(const AirportLoader& loader) {
     CustomSceneryParser parser(xplaneRoot + "Custom Scenery/scenery_packs.ini");
     parser.setAcceptor([this,loader] (const std::string &data) {
-        auto customScenaryDir = xplaneRoot + data + "/Earth nav data/apt.dat";
-        if(!platform::fileExists(customScenaryDir))
+        auto customSceneryDir = xplaneRoot + data + "/Earth nav data/apt.dat";
+        
+        if (!platform::fileExists(customSceneryDir))
             return;
 
-        logger::info("Loading custom scenary airport for %s", data.c_str());
-        loader.load(customScenaryDir);
+        logger::info("Loading custom scenery airport for %s", data.c_str());
+        loader.load(customSceneryDir);
     });
     parser.loadCustomScenery();
-
-    //Default scenery
-    loader.load(xplaneRoot + "Resources/default scenery/default apt dat/Earth nav data/apt.dat");
 }
 
 void XData::loadFixes() {

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -71,7 +71,7 @@ void XData::loadAirports() {
     try {
         loadCustomScenery(loader);
     } catch (const std::exception &e) {
-        logger::warn("Unable to parse custom scenery. Check your scenery_packs.ini file.", e.what());
+        logger::warn("Unable to parse custom scenery: %s", e.what());
     }
 
     loader.load(xplaneRoot + "Resources/default scenery/default apt dat/Earth nav data/apt.dat");

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -24,6 +24,7 @@
 #include "src/libxdata/world/loaders/AirwayLoader.h"
 #include "src/libxdata/world/loaders/CIFPLoader.h"
 #include "src/libxdata/world/loaders/MetarLoader.h"
+#include "src/libxdata/parsers/CustomSceneryParser.h"
 #include "src/Logger.h"
 
 namespace xdata {
@@ -66,7 +67,21 @@ void XData::cancelLoading() {
 }
 
 void XData::loadAirports() {
-    AirportLoader loader(world);
+    const AirportLoader loader(world);
+
+    //Custom scenery
+    CustomSceneryParser parser(xplaneRoot + "Custom Scenery/scenery_packs.ini");
+    parser.setAcceptor([this,loader] (const std::string &data) {
+        auto customScenaryDir = xplaneRoot + data + "/Earth nav data/apt.dat";
+        if(!platform::fileExists(customScenaryDir))
+            return;
+
+        logger::info("Loading custom scenary airport for %s", data.c_str());
+        loader.load(customScenaryDir);
+    });
+    parser.loadCustomScenery();
+
+    //Default scenery
     loader.load(xplaneRoot + "Resources/default scenery/default apt dat/Earth nav data/apt.dat");
 }
 

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <memory>
 #include "src/libxdata/world/World.h"
+#include "src/libxdata/world/loaders/AirportLoader.h"
 
 namespace xdata {
 
@@ -44,6 +45,7 @@ private:
     void loadAirways();
     void loadProcedures();
     void loadMetar();
+    void loadCustomScenery(const AirportLoader& loader);
 };
 
 } /* namespace xdata */

--- a/src/libxdata/parsers/CMakeLists.txt
+++ b/src/libxdata/parsers/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/NavaidParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/AirwayParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MetarParser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/CustomSceneryParser.cpp
 )

--- a/src/libxdata/parsers/CustomSceneryParser.cpp
+++ b/src/libxdata/parsers/CustomSceneryParser.cpp
@@ -1,0 +1,50 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "CustomSceneryParser.h"
+
+namespace xdata {
+
+CustomSceneryParser::CustomSceneryParser(const std::string &file):
+    parser(file)
+{
+}
+
+void CustomSceneryParser::setAcceptor(Acceptor a) {
+    acceptor = a;
+}
+
+void CustomSceneryParser::loadCustomScenery() {
+    using namespace std::placeholders;
+    parser.eachLine(std::bind(&CustomSceneryParser::parseLine, this));
+}
+
+void CustomSceneryParser::parseLine() {
+    auto firstWord = parser.parseWord();
+
+    if (firstWord.empty() || firstWord != "SCENERY_PACK") {
+        return;
+    }
+
+    parser.skipWhiteSpace();
+
+    curData = parser.restOfLine();
+    acceptor(curData);
+    curData = {};
+}
+
+} /* namespace xdata */

--- a/src/libxdata/parsers/CustomSceneryParser.h
+++ b/src/libxdata/parsers/CustomSceneryParser.h
@@ -1,0 +1,44 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_LIBXDATA_PARSERS_CUSTOMSCENERYPARSER_H_
+#define SRC_LIBXDATA_PARSERS_CUSTOMSCENERYPARSER_H_
+
+#include <string>
+#include <functional>
+#include "BaseParser.h"
+
+namespace xdata {
+
+class CustomSceneryParser {
+public:
+    using Acceptor = std::function<void(const std::string &)>;
+
+    CustomSceneryParser(const std::string &file);
+    void setAcceptor(Acceptor a);
+    void loadCustomScenery();
+private:
+    Acceptor acceptor;
+    BaseParser parser;
+    std::string curData {};
+
+    void parseLine();
+};
+
+} /* namespace xdata */
+
+#endif /* SRC_LIBXDATA_PARSERS_CUSTOMSCENERYPARSER_H_ */

--- a/src/libxdata/world/loaders/AirportLoader.cpp
+++ b/src/libxdata/world/loaders/AirportLoader.cpp
@@ -51,7 +51,7 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
     }
 
     auto airport = world->findAirportByID(port.id);
-    if(airport != nullptr) {
+    if (airport != nullptr) {
         //Airport already exists so lets skip it.
         return;
     }

--- a/src/libxdata/world/loaders/AirportLoader.cpp
+++ b/src/libxdata/world/loaders/AirportLoader.cpp
@@ -27,7 +27,7 @@ AirportLoader::AirportLoader(std::shared_ptr<World> worldPtr):
 {
 }
 
-void AirportLoader::load(const std::string& file) {
+void AirportLoader::load(const std::string& file) const {
     AirportParser parser(file);
     parser.setAcceptor([this] (const AirportData &data) {
         try {
@@ -42,7 +42,7 @@ void AirportLoader::load(const std::string& file) {
     parser.loadAirports();
 }
 
-void AirportLoader::onAirportLoaded(const AirportData& port) {
+void AirportLoader::onAirportLoaded(const AirportData& port) const {
     if (std::isnan(port.latitude) || std::isnan(port.longitude)) {
         if (port.runways.empty() && port.heliports.empty()) {
             logger::warn("Airport %s has no location or landing points, discarding", port.id.c_str());
@@ -50,7 +50,13 @@ void AirportLoader::onAirportLoaded(const AirportData& port) {
         }
     }
 
-    auto airport = world->findOrCreateAirport(port.id);
+    auto airport = world->findAirportByID(port.id);
+    if(airport != nullptr) {
+        //Airport already exists so lets skip it.
+        return;
+    }
+
+    airport = world->findOrCreateAirport(port.id);
     airport->setName(port.name);
     airport->setElevation(port.elevation);
 

--- a/src/libxdata/world/loaders/AirportLoader.h
+++ b/src/libxdata/world/loaders/AirportLoader.h
@@ -28,11 +28,11 @@ namespace xdata {
 class AirportLoader {
 public:
     AirportLoader(std::shared_ptr<World> worldPtr);
-    void load(const std::string &file);
+    void load(const std::string &file) const;
 private:
     std::shared_ptr<World> world;
 
-    void onAirportLoaded(const AirportData &port);
+    void onAirportLoaded(const AirportData &port) const;
 };
 
 } /* namespace xdata */


### PR DESCRIPTION
According to [https://www.x-plane.com/kb/prioritization-scenery-packs/](url), custom scenery is loaded in a prioritization order before default scenery data is loaded. 

In this PR we parse the scene `scenery_packs.ini` to determine the priority order of custom scenery. Once we have the priority we begin loading airports from most important to least and if we see that an airport is already loaded, we ignore any further attempts for that specific airport.

Have tested overriding multiple custom scenery and is correctly displaying highest priority data only.

This PR is in response to issue #34 

This is my first PR (of many hopefully) for this project. The AviTab team has done a tremendous job and I would be honored to be apart of it. I would appreciate any criticism/comments with regards to this PR. 