### PR TITLE
More airport overlay tweaks

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -77,7 +77,7 @@ void MapApp::createSettingsLayout() {
     openTopoLabel->alignRightOf(openTopoButton, 10);
     openTopoLabel->setManaged();
 
-    epsgButton = std::make_shared<Button>(settingsContainer, "EPSG-3875");
+    epsgButton = std::make_shared<Button>(settingsContainer, "EPSG-3857");
     epsgButton->setCallback([this] (const Button &) { setMapSource(MapSource::EPSG3857); });
     epsgButton->setFit(false, true);
     epsgButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());

--- a/src/libimg/Image.cpp
+++ b/src/libimg/Image.cpp
@@ -366,8 +366,8 @@ void Image::drawLineAA(float x0, float y0, float x1, float y1, uint32_t color) {
 void Image::fillCircleCacheImage(int x_centre, int y_centre, int radius, uint32_t color) {
     float d;
     int alpha;
-    for (int y = y_centre - radius; y < y_centre + radius; y++) {
-        for (int x = x_centre - radius; x < x_centre + radius; x++) {
+    for (int y = y_centre - radius; y <= y_centre + radius; y++) {
+        for (int x = x_centre - radius; x <= x_centre + radius; x++) {
             d = sqrt(pow((x - x_centre), 2) + pow((y - y_centre), 2));
             if (d > (radius + 0.5)) {
                 alpha = 0; // Definitely outside
@@ -385,6 +385,9 @@ void Image::fillCircleCacheImage(int x_centre, int y_centre, int radius, uint32_
 void Image::fillCircle(int x_centre, int y_centre, int radius, uint32_t color) {
     // Due to compute complexity, all filled circles are rendered and cached with a
     // key consisting of the radius and color. So typically just a small image blend.
+    if (radius <= 0) {
+        return;
+    }
     uint64_t key = (uint64_t)(radius) << 32 | color;
     std::shared_ptr<img::Image> pImage;
     auto it = circleCache.find(key);

--- a/src/libimg/Image.cpp
+++ b/src/libimg/Image.cpp
@@ -750,15 +750,20 @@ void Image::rotate(Image& dst, int angle) {
     }
 }
 
-void Image::drawText(const std::string text, int size, int x, int y, uint32_t color) {
-    // Centered around x,y
+void Image::drawText(const std::string text, int size, int x, int y, uint32_t fgColor, uint32_t bgColor, Align al) {
     static TTFStamper textBox("Inconsolata.ttf");
     textBox.setSize(size);
-    textBox.setColor(color & 0x00FFFFFF);
+    textBox.setColor(fgColor & 0x00FFFFFF);
     textBox.setText(text.c_str());
     int width = textBox.getTextWidth(text);
-    fillRectangle(x - width / 2, y, x + width / 2, y + size, img::COLOR_WHITE & 0xA0FFFFFF);
-    textBox.applyStamp(*this, x - width / 2, y);
+    int xOffset = 0;
+    if (al == Align::CENTRE) {
+        xOffset = -width / 2;
+    } else if (al == Align::RIGHT) {
+        xOffset = -width;
+    }
+    fillRectangle(x + xOffset, y, x + xOffset + width, y + size, bgColor);
+    textBox.applyStamp(*this, x + xOffset, y);
 }
 
 } /* namespace img */

--- a/src/libimg/Image.h
+++ b/src/libimg/Image.h
@@ -38,6 +38,11 @@ constexpr const uint32_t COLOR_DARK_GREEN   = 0xFF006000;
 constexpr const uint32_t COLOR_ICAO_BLUE    = 0xFF307090;
 constexpr const uint32_t COLOR_ICAO_MAGENTA = 0xFF906080;
 
+enum class Align {
+    LEFT,
+    CENTRE,
+    RIGHT
+};
 
 class Image {
 public:
@@ -76,7 +81,7 @@ public:
     void fillCircle(int x, int y, int radius, uint32_t color);
     void fillRectangle(int x0, int y0, int x1, int y1, int x2, int y2, int x3, int y3, uint32_t color);
     void fillRectangle(int x0, int y0, int x1, int y1, uint32_t color);
-    void drawText(const std::string text, int size, int x, int y, uint32_t color);
+    void drawText(const std::string text, int size, int x, int y, uint32_t fgColor, uint32_t bgColor, Align al);
 
     // the source image must be square with edge len = max(srcWidth, srcHeight)
     void rotate0(Image &dst);

--- a/src/libimg/Image.h
+++ b/src/libimg/Image.h
@@ -38,6 +38,8 @@ constexpr const uint32_t COLOR_DARK_GREEN   = 0xFF006000;
 constexpr const uint32_t COLOR_ICAO_BLUE    = 0xFF107090;
 constexpr const uint32_t COLOR_ICAO_MAGENTA = 0xFF803070;
 
+constexpr const uint32_t DARKER = -0x00101010;
+
 enum class Align {
     LEFT,
     CENTRE,

--- a/src/libimg/Image.h
+++ b/src/libimg/Image.h
@@ -35,8 +35,8 @@ constexpr const uint32_t COLOR_BLUE         = 0xFF0000FF;
 constexpr const uint32_t COLOR_YELLOW       = 0xFF808000;
 constexpr const uint32_t COLOR_DARK_GREY    = 0xFF303030;
 constexpr const uint32_t COLOR_DARK_GREEN   = 0xFF006000;
-constexpr const uint32_t COLOR_ICAO_BLUE    = 0xFF307090;
-constexpr const uint32_t COLOR_ICAO_MAGENTA = 0xFF906080;
+constexpr const uint32_t COLOR_ICAO_BLUE    = 0xFF107090;
+constexpr const uint32_t COLOR_ICAO_MAGENTA = 0xFF803070;
 
 enum class Align {
     LEFT,

--- a/src/libxdata/world/models/Frequency.cpp
+++ b/src/libxdata/world/models/Frequency.cpp
@@ -33,7 +33,7 @@ const std::string& Frequency::getDescription() const {
     return description;
 }
 
-std::string Frequency::getFrequencyString() const {
+std::string Frequency::getFrequencyString(bool appendUnits) const {
     if (unit == Unit::MHZ) {
         std::ostringstream str;
         int factor = 1;
@@ -42,10 +42,10 @@ std::string Frequency::getFrequencyString() const {
         }
         int beforeDot = frequency / factor;
         int afterDot = frequency % factor;
-        str << beforeDot << "." << std::setw(2) << std::setfill('0') << afterDot << " MHz";
+        str << beforeDot << "." << std::setw(2) << std::setfill('0') << afterDot << (appendUnits ? " MHz" : "");
         return str.str();
     } else if (unit == Unit::KHZ) {
-        return std::to_string(frequency) + " kHz";
+        return std::to_string(frequency) + (appendUnits ? " kHz" : "");
     } else {
         return "<unit error>";
     }

--- a/src/libxdata/world/models/Frequency.h
+++ b/src/libxdata/world/models/Frequency.h
@@ -32,7 +32,7 @@ public:
 
     Frequency() = default;
     Frequency(int frq, int places, Unit unit, const std::string &desc);
-    std::string getFrequencyString() const;
+    std::string getFrequencyString(bool appendUnits = true) const;
     const std::string &getDescription() const;
 
     operator bool() const;

--- a/src/libxdata/world/models/airport/Airport.cpp
+++ b/src/libxdata/world/models/airport/Airport.cpp
@@ -205,12 +205,8 @@ bool Airport::hasWaterRunway() const {
     return false;
 }
 
-bool Airport::hasTowerFrequency() const {
+bool Airport::hasControlTower() const {
     return (atcFrequencies.count(ATCFrequency::TWR) >= 1);
-}
-
-bool Airport::hasMultipleATCFrequencies() const {
-    return (atcFrequencies.size() > 1);
 }
 
 bool Airport::hasHardRunway() const {

--- a/src/libxdata/world/models/airport/Airport.cpp
+++ b/src/libxdata/world/models/airport/Airport.cpp
@@ -17,7 +17,7 @@
  */
 #include <algorithm>
 #include <cstdlib>
-#include <math.h>
+#include <cmath>
 #include "Airport.h"
 #include "src/libxdata/world/models/navaids/Fix.h"
 #include "src/Logger.h"
@@ -288,6 +288,15 @@ const Location& Airport::getLocationDownRight() const {
 }
 
 std::string Airport::getInitialATCContactInfo() const {
+    static const ATCFrequency prioritisedATCType[] {
+        ATCFrequency::RECORDED,
+        ATCFrequency::TWR,
+        ATCFrequency::UNICOM,
+        ATCFrequency::APP,
+        ATCFrequency::DEP,
+        ATCFrequency::CLD,
+        ATCFrequency::GND
+    };
     std::string initialATCContact = "";
     for (auto atcType: prioritisedATCType) {
         if (atcFrequencies.count(atcType) > 0) {

--- a/src/libxdata/world/models/airport/Airport.h
+++ b/src/libxdata/world/models/airport/Airport.h
@@ -50,10 +50,20 @@ public:
         DEP
     };
 
+    ATCFrequency prioritisedATCType[7] {
+        ATCFrequency::RECORDED,
+        ATCFrequency::TWR,
+        ATCFrequency::UNICOM,
+        ATCFrequency::APP,
+        ATCFrequency::DEP,
+        ATCFrequency::CLD,
+        ATCFrequency::GND
+    };
+
     Airport(const std::string &airportId);
     void setName(const std::string &name);
     void setElevation(int elevation);
-    int getElevation();
+    int getElevation() const;
 
     const std::string& getID() const override;
     const Location &getLocation() const override;
@@ -73,6 +83,7 @@ public:
 
     void addRunway(std::shared_ptr<Runway> rwy);
     void forEachRunway(std::function<void(const std::shared_ptr<Runway>)> f) const;
+    float getLongestRunwayLength() const;
     void addRunwayEnds(std::shared_ptr<Runway> rwy1, std::shared_ptr<Runway> rwy2);
     void forEachRunwayPair(std::function<void(const std::shared_ptr<Runway>, const std::shared_ptr<Runway>)> f) const;
     const std::shared_ptr<Runway> getRunwayByName(const std::string &rw) const;
@@ -95,6 +106,7 @@ public:
     std::vector<std::shared_ptr<SID>> getSIDs() const;
     std::vector<std::shared_ptr<STAR>> getSTARs() const;
     std::vector<std::shared_ptr<Approach>> getApproaches() const;
+    std::string getInitialATCContactInfo() const;
 
     Airport(const Airport &other) = delete;
     void operator=(const Airport &other) = delete;

--- a/src/libxdata/world/models/airport/Airport.h
+++ b/src/libxdata/world/models/airport/Airport.h
@@ -50,16 +50,6 @@ public:
         DEP
     };
 
-    ATCFrequency prioritisedATCType[7] {
-        ATCFrequency::RECORDED,
-        ATCFrequency::TWR,
-        ATCFrequency::UNICOM,
-        ATCFrequency::APP,
-        ATCFrequency::DEP,
-        ATCFrequency::CLD,
-        ATCFrequency::GND
-    };
-
     Airport(const std::string &airportId);
     void setName(const std::string &name);
     void setElevation(int elevation);

--- a/src/libxdata/world/models/airport/Airport.h
+++ b/src/libxdata/world/models/airport/Airport.h
@@ -90,12 +90,10 @@ public:
     void addHeliport(std::shared_ptr<Heliport> port);
 
     bool hasOnlyHeliports() const;
-
     bool hasWaterRunway() const;
-    bool hasTowerFrequency() const;
-    bool hasMultipleATCFrequencies() const;
     bool hasHardRunway() const;
-    
+    bool hasControlTower() const;
+
     void addTerminalFix(std::shared_ptr<Fix> fix);
     std::shared_ptr<Fix> getTerminalFix(const std::string &id);
     void attachILSData(const std::string &rwy, std::weak_ptr<Fix> ils);

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -250,8 +250,7 @@ void OverlayedMap::drawAirport(const xdata::Airport& airport, double mapWidthNM)
     int px, py;
     positionToPixel(loc.latitude, loc.longitude, px, py);
 
-    bool hasControlTower = airport.hasTowerFrequency(); // ?
-    // bool hasControlTower = airport.hasMultipleATCFrequencies(); // Better than airport.hasTowerFrequency() ?
+    bool hasControlTower = airport.hasControlTower();
     uint32_t color = hasControlTower ? img::COLOR_ICAO_BLUE : img::COLOR_ICAO_MAGENTA;
     bool hasHardRunway = airport.hasHardRunway();
 
@@ -297,14 +296,14 @@ void OverlayedMap::drawAirport(const xdata::Airport& airport, double mapWidthNM)
             getRunwaysCentre(airport, stitcher->getZoomLevel(), xCentre, yCentre);
             int maxDistance = getMaxRunwayDistanceFromCentre(airport, stitcher->getZoomLevel(), xCentre, yCentre);
             if (maxDistance > ICAO_RADIUS) {
-                drawAirportICAOGeographicRunways(airport);
+                drawAirportICAOGeographicRunways(airport, color);
             } else {
                 drawAirportICAOCircleAndRwyPattern(airport, px, py, ICAO_RADIUS, color);
             }
         }
     }
 
-    drawAirportText(airport, px, py, mapWidthNM, color);
+    drawAirportText(airport, px, py, mapWidthNM, color - 0x00101010);
 }
 
 void OverlayedMap::drawAirportBlob(int x, int y, int mapWidthNM, uint32_t color) {
@@ -329,7 +328,7 @@ void OverlayedMap::drawAirportGeographicRunways(const xdata::Airport& airport) {
         if (std::isnan(rwyWidth) || (rwyWidth == 0)) {
             return;
         }
-        float aspectRatio = rwyLength / (rwyWidth * 1.2);
+        float aspectRatio = rwyLength / (rwyWidth * 1.1);
         uint32_t color = (rwy1->hasHardSurface()) ? img::COLOR_DARK_GREY : img::COLOR_DARK_GREEN;
         int xo = (px1 - px2) / aspectRatio;
         int yo = (py1 - py2) / aspectRatio;
@@ -341,9 +340,9 @@ void OverlayedMap::drawAirportGeographicRunways(const xdata::Airport& airport) {
    });
 }
 
-void OverlayedMap::drawAirportICAOGeographicRunways(const xdata::Airport& airport) {
+void OverlayedMap::drawAirportICAOGeographicRunways(const xdata::Airport& airport, uint32_t color) {
     LOG_INFO(dbg, "%s", airport.getID().c_str());
-    drawRunwayRectangles(airport, 10, img::COLOR_BLUE);
+    drawRunwayRectangles(airport, 10, color);
     drawRunwayRectangles(airport,  3, img::COLOR_WHITE);
 }
 

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -412,10 +412,25 @@ void OverlayedMap::drawAirportICAORing(const xdata::Airport& airport, int x, int
 }
 
 void OverlayedMap::drawAirportText(const xdata::Airport& airport, int x, int y, double mapWidthNM, uint32_t color) {
-    int idSize = 16;
-    mapImage->drawText(airport.getID(), idSize, x, y + 20, color, img::COLOR_WHITE & 0xB8FFFFFF, img::Align::CENTRE);
-    if (mapWidthNM <= 40) {
-        mapImage->drawText(airport.getName(), idSize * 0.7, x, y + 20 + idSize, color, img::COLOR_WHITE & 0xB8FFFFFF, img::Align::CENTRE);
+    // Place text below southern airport boundary and below symbol
+    int yOffset = y + 15;
+    auto &locDownRight = airport.getLocationDownRight();
+    if (locDownRight.isValid()) {
+        int xIgnored;
+        positionToPixel(locDownRight.latitude, locDownRight.longitude, xIgnored, yOffset);
+        yOffset += 15;
+    }
+    if (mapWidthNM > 40) {
+        mapImage->drawText(airport.getID(), 16, x, yOffset, color, img::COLOR_WHITE & 0xA0FFFFFF, img::Align::CENTRE);
+    } else {
+        std::string nameAndID = airport.getName() + " (" + airport.getID() + ")";
+        std::string elevationFeet = std::to_string(airport.getElevation());
+        int rwyLengthHundredsFeet = (int)((airport.getLongestRunwayLength() * 3.28) / 100.0);
+        std::string rwyLength = (rwyLengthHundredsFeet == 0) ? "" : (" " + std::to_string(rwyLengthHundredsFeet));
+        std::string atcInfo = airport.getInitialATCContactInfo();
+        std::string airportInfo = " " + elevationFeet + rwyLength + " " + atcInfo + " ";
+        mapImage->drawText(nameAndID,   14, x, yOffset,      color, img::COLOR_WHITE & 0xB8FFFFFF, img::Align::CENTRE);
+        mapImage->drawText(airportInfo, 12, x, yOffset + 14, color, img::COLOR_WHITE & 0xB8FFFFFF, img::Align::CENTRE);
     }
 }
 

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -89,20 +89,21 @@ private:
     void drawAircraftOverlay();
     void drawDataOverlays();
     void drawCalibrationOverlay();
+    void drawScale(double nmPerPixel);
 
-    void drawAirport(const xdata::Airport &airport, double scale);
+    void drawAirport(const xdata::Airport &airport, double mapWidthNM);
     bool isAirportVisible(const xdata::Airport& airport);
-    void drawAirportBlob(int x, int y, uint32_t color);
-    void drawAirportICAOCircleAndRwyPattern(const xdata::Airport& airport, int x, int y, int radius, uint32_t color);        
+    void drawAirportBlob(int x, int y, int mapWidthNM, uint32_t color);
+    void drawAirportICAOCircleAndRwyPattern(const xdata::Airport& airport, int x, int y, int radius, uint32_t color);
     void drawAirportICAORing(const xdata::Airport& airport, int x, int y, uint32_t color);
     void drawAirportICAOGeographicRunways(const xdata::Airport& airport);
     void drawAirportGeographicRunways(const xdata::Airport& airport);
     void drawRunwayRectangles(const xdata::Airport& airport, float size, uint32_t color);
-    void drawAirportText(const xdata::Airport& airport, int x, int y, uint32_t color);
+    void drawAirportText(const xdata::Airport& airport, int x, int y, double mapWidthNM, uint32_t color);
     void getRunwaysCentre(const xdata::Airport& airport, int zoomLevel, int & xCentre, int & yCentre);
     int  getMaxRunwayDistanceFromCentre(const xdata::Airport& airport, int zoomLevel, int xCentre, int yCentre);
 
-    void drawFix(const xdata::Fix &fix, double scale);
+    void drawFix(const xdata::Fix &fix, double mapWidthNM);
 
     void positionToPixel(double lat, double lon, int &px, int &py) const;
     void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const;

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -108,6 +108,15 @@ private:
     void positionToPixel(double lat, double lon, int &px, int &py) const;
     void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const;
     void pixelToPosition(int px, int py, double &lat, double &lon) const;
+
+    static const int DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM = 200;
+    static const int MAX_BLOB_SIZE = 12;
+    static const int BLOB_SIZE_DIVIDEND = DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM * MAX_BLOB_SIZE;
+    static const int DRAW_GEOGRAPHIC_RUNWAYS_AT_MAPWIDTHNM = 5;
+    static const int SHOW_DETAILED_AIRPORT_INFO_AT_MAPWIDTHNM = 40;
+    static const int ICAO_CIRCLE_RADIUS = 15;
+    static const int ICAO_RING_RADIUS = 12;
+
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -96,7 +96,7 @@ private:
     void drawAirportBlob(int x, int y, int mapWidthNM, uint32_t color);
     void drawAirportICAOCircleAndRwyPattern(const xdata::Airport& airport, int x, int y, int radius, uint32_t color);
     void drawAirportICAORing(const xdata::Airport& airport, int x, int y, uint32_t color);
-    void drawAirportICAOGeographicRunways(const xdata::Airport& airport);
+    void drawAirportICAOGeographicRunways(const xdata::Airport& airport, uint32_t color);
     void drawAirportGeographicRunways(const xdata::Airport& airport);
     void drawRunwayRectangles(const xdata::Airport& airport, float size, uint32_t color);
     void drawAirportText(const xdata::Airport& airport, int x, int y, double mapWidthNM, uint32_t color);


### PR DESCRIPTION
Hi Folko,
I've implemented the tile-source independent scaling. Tested on all tile sources.
As part of developing this I also ended up adding a scale legend top left. 
I've also added some more detailed text info to airports at higher zoom levels - elevation, longest runway length and initial ATC contact info.
I will be taking another look at the "has control tower" implementation which determines colour - the overlay colour doesn't 100% match other aviation chart sources. But there's enough already in this pull request.
David