### PR TITLE
Fix misclasssification of custom scenery airports/airstrips

### DIFF
--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -215,7 +215,7 @@ std::string AirportApp::toRunwayInfo(std::shared_ptr<xdata::Airport> airport) {
 
     str << "Runways (Length in X-Plane might differ from real length):\n";
     airport->forEachRunway([this, &str, &magneticVariation] (const std::shared_ptr<xdata::Runway> rwy) {
-        str << "    Runway " + rwy->getID();
+        str << "  " + rwy->getID();
         auto ils = rwy->getILSData();
         if (ils) {
             double heading = ils->getILSLocalizer()->getRunwayHeading();
@@ -231,10 +231,10 @@ std::string AirportApp::toRunwayInfo(std::shared_ptr<xdata::Airport> airport) {
                 heading = 360 + heading;
             }
 
-            str << ", " << ils->getILSLocalizer()->getFrequency().getDescription();
+            str << " " << ils->getILSLocalizer()->getFrequency().getDescription();
             str << " (ID " << ils->getID();
             str << " on " << ils->getILSLocalizer()->getFrequency().getFrequencyString() << ")";
-            str << ", CRS " << heading << "° magnetic";
+            str << ", CRS " << heading << "° mag";
         } else {
             str << " without ILS";
         }
@@ -242,6 +242,7 @@ std::string AirportApp::toRunwayInfo(std::shared_ptr<xdata::Airport> airport) {
         if (!std::isnan(length)) {
             str << ", " << std::to_string((int) (length * 3.28084 + 0.5)) << " ft";
         }
+        str << ", " << rwy->getSurfaceTypeDescription();
         str << "\n";
     });
     return str.str();

--- a/src/libxdata/world/loaders/AirportLoader.h
+++ b/src/libxdata/world/loaders/AirportLoader.h
@@ -33,6 +33,8 @@ private:
     std::shared_ptr<World> world;
 
     void onAirportLoaded(const AirportData &port) const;
+
+    void patchCustomSceneryRunwaySurfaces(const AirportData& port, std::shared_ptr<Airport> airport) const;
 };
 
 } /* namespace xdata */

--- a/src/libxdata/world/models/airport/Runway.cpp
+++ b/src/libxdata/world/models/airport/Runway.cpp
@@ -87,9 +87,25 @@ xdata::Runway::SurfaceType xdata::Runway::getSurfaceType() const{
     return surfaceType;
 }
 
+const std::string xdata::Runway::getSurfaceTypeDescription() const {
+    switch(surfaceType) {
+    case SurfaceType::ASPHALT:              return "Asphalt";
+    case SurfaceType::CONCRETE:             return "Concrete";
+    case SurfaceType::TURF_GRASS:           return "Turf/Grass";
+    case SurfaceType::DIRT_BROWN:           return "Dirt";
+    case SurfaceType::GRAVEL_GREY:          return "Gravel";
+    case SurfaceType::DRY_LAKEBED:          return "Dry lakebed";
+    case SurfaceType::WATER_RUNWAY:         return "Water";
+    case SurfaceType::SNOW_OR_ICE:          return "Snow/Ice";
+    case SurfaceType::TRANSPARENT_SURFACE:  return "Hard?";
+    default: return "Unknown surface";
+    }
+}
+
 bool xdata::Runway::hasHardSurface() const{
-    return ((surfaceType == xdata::Runway::SurfaceType::ASPHALT) ||
-            (surfaceType == xdata::Runway::SurfaceType::CONCRETE));
+    return ((surfaceType == SurfaceType::ASPHALT) ||
+            (surfaceType == SurfaceType::CONCRETE) ||
+            (surfaceType == SurfaceType::TRANSPARENT_SURFACE));
 }
 
 } /* namespace xdata */

--- a/src/libxdata/world/models/airport/Runway.h
+++ b/src/libxdata/world/models/airport/Runway.h
@@ -37,10 +37,10 @@ public:
         TURF_GRASS = 3,
         DIRT_BROWN = 4,
         GRAVEL_GREY = 5,
-        DRY_LAKEBED = 12,
-        WATER_RUNWAY = 13,
-        SNOW_OR_ICE = 14,
-        TRANSPARENT_SURFACE = 15
+        DRY_LAKEBED = 12, // "Example: KEDW (Edwards AFB)"
+        WATER_RUNWAY = 13, // "Nothing displayed"
+        SNOW_OR_ICE = 14, // "Poor friction. Runway markings cannot be added"
+        TRANSPARENT_SURFACE = 15 // "Hard surface, but no texture/markings (use in custom scenery)"
     };
 
     Runway(const std::string &name);
@@ -57,6 +57,7 @@ public:
     float getWidth() const;
     bool hasHardSurface() const;
     SurfaceType getSurfaceType() const;
+    const std::string getSurfaceTypeDescription() const;
     void attachILSData(std::weak_ptr<Fix> ils);
 
     // Optional, can return nullptr


### PR DESCRIPTION
Treat runway surface type transparent (15) as hard.
Patch default scenery runway surface types into custom scenery where runway surface type is transparent.
Add surface type to AirportApp runway info