### PR TITLE
Disable incomplete code

### DIFF
--- a/src/scripting/Runtime.cpp
+++ b/src/scripting/Runtime.cpp
@@ -23,7 +23,7 @@
 namespace js {
 
 Runtime::Runtime() {
-/*
+#if 0 // experimental
     runtime = JS_NewRuntime();
     if (!runtime) {
         throw std::runtime_error("Couldn't initialize QuickJS");
@@ -33,14 +33,14 @@ Runtime::Runtime() {
     if (!ctx) {
         throw std::runtime_error("Couldn't create QuickJS context");
     }
-*/
+#endif
 }
 
 Runtime::~Runtime() {
-/*
+#if 0 // experimental
     JS_FreeContext(ctx);
     JS_FreeRuntime(runtime);
-*/
+#endif
 }
 
 }

--- a/src/scripting/Runtime.h
+++ b/src/scripting/Runtime.h
@@ -28,8 +28,10 @@ public:
     Runtime();
     ~Runtime();
 private:
+#if 0 // experimental
     JSRuntime *runtime;
     JSContext *ctx;
+#endif
 };
 
 }


### PR DESCRIPTION
Fixes build issue on OS X due to warnings as errors. Changed to using PP macros to disable as these will also surround any comments (none in this fragment), and are simple to edit to re-enable the code during deveopment.