### PR TITLE
On tab closing, open next tab instead of last

### DIFF
--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -178,6 +178,8 @@ void ChartsApp::removeTab(std::shared_ptr<Page> page) {
             size_t index = tabs->getTabIndex(it->page);
             pages.erase(it);
             tabs->removeTab(index);
+            if (index > pages.size()) index--;
+            tabs->setActiveTab(index);
             break;
         }
     }


### PR DESCRIPTION
Hi Folke, I made a minor update to the tabbed pdf viewer: it now shows the next tab instead of the last one when closing a pdf file. I found this a bit more practical during flight, e.g. when closing the STAR chart to automatically jump to the approach, etc.
Cheers,
Tom