### PR TITLE
Configurable colours for other aircraft overlays.

### DIFF
--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -99,6 +99,9 @@ void Settings::loadOverlayConfig() {
     overlayConfig = std::make_shared<maps::OverlayConfig>();
     overlayConfig->drawMyAircraft = getSetting("/overlay/my_aircraft", true);
     overlayConfig->drawOtherAircraft = getSetting("/overlay/other_aircraft", true);
+    overlayConfig->colorOtherAircraftBelow = getSetting("/overlay/colors/other_aircraft/below", std::string("GREEN"));
+    overlayConfig->colorOtherAircraftSame = getSetting("/overlay/colors/other_aircraft/same", std::string("BLACK"));
+    overlayConfig->colorOtherAircraftAbove = getSetting("/overlay/colors/other_aircraft/above", std::string("BLUE"));
     overlayConfig->drawAirports = getSetting("/overlay/airports", false);
     overlayConfig->drawAirstrips = getSetting("/overlay/airstrips", false);
     overlayConfig->drawHeliportsSeaports = getSetting("/overlay/heliports_seaports", false);
@@ -111,6 +114,9 @@ void Settings::loadOverlayConfig() {
 void Settings::saveOverlayConfig() {
     setSetting("/overlay/my_aircraft", overlayConfig->drawMyAircraft);
     setSetting("/overlay/other_aircraft", overlayConfig->drawOtherAircraft);
+    setSetting("/overlay/colors/other_aircraft/below", overlayConfig->colorOtherAircraftBelow);
+    setSetting("/overlay/colors/other_aircraft/same", overlayConfig->colorOtherAircraftSame);
+    setSetting("/overlay/colors/other_aircraft/above", overlayConfig->colorOtherAircraftAbove);
     setSetting("/overlay/airports", overlayConfig->drawAirports);
     setSetting("/overlay/airstrips", overlayConfig->drawAirstrips);
     setSetting("/overlay/heliports_seaports", overlayConfig->drawHeliportsSeaports);

--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -29,6 +29,14 @@ namespace avitab {
 Settings::Settings(const std::string &settingsFile)
 :   filePath(settingsFile)
 {
+    colorTable.push_back({"BLACK",  0xFF000000});
+    colorTable.push_back({"GREY",   0xFF303030});
+    colorTable.push_back({"WHITE",  0xFFFFFFFF});
+    colorTable.push_back({"RED",    0xFF800000});
+    colorTable.push_back({"BLUE",   0xFF0000A0});
+    colorTable.push_back({"GREEN",  0xFF008000});
+    colorTable.push_back({"YELLOW", 0xFF808000});
+    
     database = std::make_shared<json>();
     init();
     load();
@@ -99,9 +107,6 @@ void Settings::loadOverlayConfig() {
     overlayConfig = std::make_shared<maps::OverlayConfig>();
     overlayConfig->drawMyAircraft = getSetting("/overlay/my_aircraft", true);
     overlayConfig->drawOtherAircraft = getSetting("/overlay/other_aircraft", true);
-    overlayConfig->colorOtherAircraftBelow = getSetting("/overlay/colors/other_aircraft/below", std::string("GREEN"));
-    overlayConfig->colorOtherAircraftSame = getSetting("/overlay/colors/other_aircraft/same", std::string("BLACK"));
-    overlayConfig->colorOtherAircraftAbove = getSetting("/overlay/colors/other_aircraft/above", std::string("BLUE"));
     overlayConfig->drawAirports = getSetting("/overlay/airports", false);
     overlayConfig->drawAirstrips = getSetting("/overlay/airstrips", false);
     overlayConfig->drawHeliportsSeaports = getSetting("/overlay/heliports_seaports", false);
@@ -109,14 +114,15 @@ void Settings::loadOverlayConfig() {
     overlayConfig->drawNDBs = getSetting("/overlay/NDBs", false);
     overlayConfig->drawILSs = getSetting("/overlay/ILSs", false);
     overlayConfig->drawWaypoints = getSetting("/overlay/waypoints", false);
+
+    overlayConfig->colorOtherAircraftBelow = colorStringToInt(getSetting("/overlay/colors/other_aircraft/below", std::string("GREEN")), "GREEN");
+    overlayConfig->colorOtherAircraftSame = colorStringToInt(getSetting("/overlay/colors/other_aircraft/same", std::string("BLACK")), "BLACK");
+    overlayConfig->colorOtherAircraftAbove = colorStringToInt(getSetting("/overlay/colors/other_aircraft/above", std::string("BLUE")), "BLUE");
 }
 
 void Settings::saveOverlayConfig() {
     setSetting("/overlay/my_aircraft", overlayConfig->drawMyAircraft);
     setSetting("/overlay/other_aircraft", overlayConfig->drawOtherAircraft);
-    setSetting("/overlay/colors/other_aircraft/below", overlayConfig->colorOtherAircraftBelow);
-    setSetting("/overlay/colors/other_aircraft/same", overlayConfig->colorOtherAircraftSame);
-    setSetting("/overlay/colors/other_aircraft/above", overlayConfig->colorOtherAircraftAbove);
     setSetting("/overlay/airports", overlayConfig->drawAirports);
     setSetting("/overlay/airstrips", overlayConfig->drawAirstrips);
     setSetting("/overlay/heliports_seaports", overlayConfig->drawHeliportsSeaports);
@@ -124,6 +130,10 @@ void Settings::saveOverlayConfig() {
     setSetting("/overlay/NDBs", overlayConfig->drawNDBs);
     setSetting("/overlay/ILSs", overlayConfig->drawILSs);
     setSetting("/overlay/waypoints", overlayConfig->drawWaypoints);
+
+    setSetting("/overlay/colors/other_aircraft/below", colorIntToString(overlayConfig->colorOtherAircraftBelow));
+    setSetting("/overlay/colors/other_aircraft/same", colorIntToString(overlayConfig->colorOtherAircraftSame));
+    setSetting("/overlay/colors/other_aircraft/above", colorIntToString(overlayConfig->colorOtherAircraftAbove));
 }
 
 void Settings::upgrade() {
@@ -147,6 +157,52 @@ void Settings::save() {
     } catch (const std::exception &e) {
         LOG_ERROR("Could not save user settings to %s", filePath.c_str());
     }
+}
+
+uint32_t Settings::colorStringToInt(std::string colString, const char* colDefault)
+{
+    std::string cstr(colString);
+    for (auto i = cstr.begin(); i != cstr.end(); ++i) *i = toupper(*i);
+
+    for (auto i = colorTable.begin(); i != colorTable.end(); ++i) {
+        if (cstr == i->first) {
+            return i->second;
+        }
+    }
+    
+    if ((cstr[0] == '#') && (cstr.size() >= 7)) {
+        cstr.erase(0,1);
+        uint32_t c = 0;
+        size_t p = 0;
+        try {
+            long long l = std::stoll(cstr, &p, 16);
+            c = static_cast<uint32_t>(static_cast<unsigned long long>(l) & 0xFFFFFFFF);
+        } catch (...) {
+            p = 0;
+        }
+        if (p == 6) c |= 0xFF000000;// make color opaque if alpha-channel not defined
+        if (p) return c;
+    }
+    
+    cstr = colDefault;
+    for (auto i = colorTable.begin(); i != colorTable.end(); ++i) {
+        if (cstr == i->first) {
+            return i->second;
+        }
+    }
+    return 0xFFFFFFFF;
+}
+
+std::string Settings::colorIntToString(uint32_t color)
+{
+    for (auto i = colorTable.begin(); i != colorTable.end(); ++i) {
+        if (color == i->second) {
+            return std::string(i->first);
+        }
+    }
+    std::stringstream s;
+    s << "#" << std::setfill('0') << std::setw(8) << std::hex << color;
+    return s.str();
 }
 
 } /* namespace avitab */

--- a/src/environment/Settings.h
+++ b/src/environment/Settings.h
@@ -19,6 +19,7 @@
 #define SRC_ENVIRONMENT_SETTINGS_H_
 
 #include <nlohmann/json_fwd.hpp>
+#include <list>
 #include <memory>
 #include "src/maps/OverlayConfig.h"
 
@@ -55,6 +56,11 @@ private:
 
     template<typename T>
     void setSetting(const std::string &id, const T value);
+    
+    std::list<std::pair<const char *, uint32_t> > colorTable;
+    uint32_t colorStringToInt(std::string colString, const char* colDefault);
+    std::string colorIntToString(uint32_t color);
+    
 };
 
 } /* namespace avitab */

--- a/src/maps/OverlayConfig.h
+++ b/src/maps/OverlayConfig.h
@@ -25,9 +25,9 @@ namespace maps {
 struct OverlayConfig {
     bool drawMyAircraft = true;
     bool drawOtherAircraft = true;
-    std::string colorOtherAircraftBelow;
-    std::string colorOtherAircraftSame;
-    std::string colorOtherAircraftAbove;
+    uint32_t colorOtherAircraftBelow;
+    uint32_t colorOtherAircraftSame;
+    uint32_t colorOtherAircraftAbove;
     bool drawAirports = false;
     bool drawAirstrips = false;
     bool drawHeliportsSeaports = false;

--- a/src/maps/OverlayConfig.h
+++ b/src/maps/OverlayConfig.h
@@ -18,11 +18,16 @@
 #ifndef SRC_MAPS_OVERLAY_CONFIG_H_
 #define SRC_MAPS_OVERLAY_CONFIG_H_
 
+#include <string>
+
 namespace maps {
 
 struct OverlayConfig {
     bool drawMyAircraft = true;
     bool drawOtherAircraft = true;
+    std::string colorOtherAircraftBelow;
+    std::string colorOtherAircraftSame;
+    std::string colorOtherAircraftAbove;
     bool drawAirports = false;
     bool drawAirstrips = false;
     bool drawHeliportsSeaports = false;

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -54,9 +54,9 @@ OverlayedMap::OverlayedMap(std::shared_ptr<img::Stitcher> stitchedMap, std::shar
         cosTable[angle] = std::cos(angle * M_PI / 180);
     }
 
-    otherAircraftColors[RelativeHeight::below] = colorFromString(overlayConfig->colorOtherAircraftBelow, "GREEN", img::COLOR_DARK_GREEN);
-    otherAircraftColors[RelativeHeight::same] = colorFromString(overlayConfig->colorOtherAircraftSame, "BLACK", img::COLOR_BLACK);
-    otherAircraftColors[RelativeHeight::above] = colorFromString(overlayConfig->colorOtherAircraftAbove, "BLUE", img::COLOR_BLUE);
+    otherAircraftColors[RelativeHeight::below] = overlayConfig->colorOtherAircraftBelow;
+    otherAircraftColors[RelativeHeight::same] = overlayConfig->colorOtherAircraftSame;
+    otherAircraftColors[RelativeHeight::above] = overlayConfig->colorOtherAircraftAbove;
 
     dbg = false;
 }
@@ -469,60 +469,6 @@ std::shared_ptr<img::Image> OverlayedMap::getMapImage() {
 
 OverlayConfig &OverlayedMap::getOverlayConfig() const {
     return *overlayConfig;
-}
-
-inline static int hexval(const char c)
-{
-    if (isdigit(c)) {
-        return c - '0';
-    } else if ((c >= 'A') && (c <= 'F')) {
-        return 10 + c - 'A';
-    }
-    return -1;
-}
-
-uint32_t OverlayedMap::colorFromString(std::string& setting, const char *defName, uint32_t defCode)
-{
-    std::string cstr(setting);
-    for (auto i = cstr.begin(); i != cstr.end(); ++i) *i = toupper(*i);
-
-    setting = defName;
-
-    if (cstr == "BLACK") {
-        setting = "BLACK";
-        return img::COLOR_BLACK;
-    } else if (cstr == "WHITE") {
-        setting = "WHITE";
-        return img::COLOR_WHITE;
-    } else if (cstr == "RED") {
-        setting = "RED";
-        return img::COLOR_RED;
-    } else if (cstr == "BLUE") {
-        setting = "BLUE";
-        return img::COLOR_BLUE;
-    } else if (cstr == "YELLOW") {
-        setting = "YELLOW";
-        return img::COLOR_YELLOW;
-    } else if (cstr == "GREEN") {
-        setting = "GREEN";
-        return img::COLOR_DARK_GREEN;
-    } else if (cstr == "GREY") {
-        setting = "GREY";
-        return img::COLOR_DARK_GREY;
-    } else if ((cstr[0] == '#') && (cstr.size() == 7)) {
-        uint32_t c = 0;
-        for (auto i = cstr.begin() + 1; i != cstr.end(); ++i) {
-            int d = hexval(*i);
-            if (d < 0) {
-                return defCode;
-            }
-            c = (c << 4) | d;
-        }
-        setting = cstr;
-        return (0xFF000000 | c); // make opaque
-    }
-
-    return defCode;
 }
 
 

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -88,6 +88,8 @@ private:
     std::shared_ptr<xdata::World> navWorld;
     std::vector<avitab::Location> planeLocations;
     img::Image planeIcon;
+    enum RelativeHeight { below, same, above };
+    uint32_t otherAircraftColors[RelativeHeight::above + 1];
     img::Image ndbIcon;
     int calibrationStep = 0;
     img::TTFStamper copyrightStamp;
@@ -107,6 +109,8 @@ private:
     float cosDegrees(int angleDegrees) const;
     float sinDegrees(int angleDegrees) const;
     void polarToCartesian(float radius, float angleRadians, double& x, double& y);
+
+    uint32_t colorFromString(std::string& setting, const char *defName, uint32_t defCode);
 
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_TEXT = 200;
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_DETAILED_TEXT = 40;

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -88,8 +88,8 @@ private:
     std::shared_ptr<xdata::World> navWorld;
     std::vector<avitab::Location> planeLocations;
     img::Image planeIcon;
-    enum RelativeHeight { below, same, above };
-    uint32_t otherAircraftColors[RelativeHeight::above + 1];
+    enum RelativeHeight { below, same, above, total };
+    uint32_t otherAircraftColors[RelativeHeight::total];
     img::Image ndbIcon;
     int calibrationStep = 0;
     img::TTFStamper copyrightStamp;

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -110,8 +110,6 @@ private:
     float sinDegrees(int angleDegrees) const;
     void polarToCartesian(float radius, float angleRadians, double& x, double& y);
 
-    uint32_t colorFromString(std::string& setting, const char *defName, uint32_t defCode);
-
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_TEXT = 200;
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_DETAILED_TEXT = 40;
 };


### PR DESCRIPTION
Add preference file entries for other aircraft display colours.
This feature is to improve accessibility when using maps which
have background areas that match the default overlay settings.
Colours may be defined using some basic names (BLACK, WHITE, RED,
GREEN, BLUE, YELLOW, GREY) or '#RRGGBB' hex-coded. Three colours
can be defined, for aircraft that are below, above, or at the same
flight level. There is no UI for setting the overlay colours.