### PR TITLE
Pseudo hotspots

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -454,7 +454,7 @@ void MapApp::onMapPan(int x, int y, bool start, bool end) {
     } else if (!end) {
         int panVecX = panPosX - x;
         int panVecY = panPosY - y;
-        map->pan(panVecX, panVecY);
+        map->pan(panVecX, panVecY, x, y);
     }
     panPosX = x;
     panPosY = y;

--- a/src/libimg/stitcher/Stitcher.cpp
+++ b/src/libimg/stitcher/Stitcher.cpp
@@ -137,6 +137,17 @@ std::shared_ptr<TileSource> Stitcher::getTileSource() {
     return tileSource;
 }
 
+void Stitcher::convertSourceImageToRenderedCoords(int &x, int &y) {
+    int unrotatedCentreX = unrotatedImage->getWidth() / 2;
+    int unrotatedCentreY = unrotatedImage->getHeight() / 2;
+    int dstCentreX = dstImage->getWidth() / 2;
+    int dstCentreY = dstImage->getHeight() / 2;
+    int offsetX = unrotatedCentreX - dstCentreX;
+    int offsetY = unrotatedCentreY - dstCentreY;
+    x += offsetX;
+    y += offsetY;
+}
+
 void Stitcher::rotateRight() {
     rotAngle = (rotAngle + 90) % 360;
     updateImage();

--- a/src/libimg/stitcher/Stitcher.h
+++ b/src/libimg/stitcher/Stitcher.h
@@ -57,6 +57,7 @@ public:
     std::shared_ptr<Image> getPreRotatedImage();
     std::shared_ptr<Image> getTargetImage();
     std::shared_ptr<TileSource> getTileSource();
+    void convertSourceImageToRenderedCoords(int &x, int &y);
 
 private:
     int page = 0;

--- a/src/libxdata/world/models/airport/Airport.cpp
+++ b/src/libxdata/world/models/airport/Airport.cpp
@@ -197,13 +197,16 @@ bool Airport::hasOnlyHeliports() const {
     return runways.empty() && !heliports.empty();
 }
 
-bool Airport::hasWaterRunway() const {
+bool Airport::hasOnlyWaterRunways() const {
+    bool foundWater = false;
     for (const auto &rwy: runways) {
-        if (rwy.second->getSurfaceType() == xdata::Runway::SurfaceType::WATER_RUNWAY) {
-            return true;
+        if (rwy.second->isWater()) {
+            foundWater = true;
+        } else {
+            return false;
         }
     }
-    return false;
+    return foundWater;
 }
 
 bool Airport::hasControlTower() const {

--- a/src/libxdata/world/models/airport/Airport.h
+++ b/src/libxdata/world/models/airport/Airport.h
@@ -80,7 +80,7 @@ public:
     void addHeliport(std::shared_ptr<Heliport> port);
 
     bool hasOnlyHeliports() const;
-    bool hasWaterRunway() const;
+    bool hasOnlyWaterRunways() const;
     bool hasHardRunway() const;
     bool hasControlTower() const;
 

--- a/src/libxdata/world/models/airport/Runway.cpp
+++ b/src/libxdata/world/models/airport/Runway.cpp
@@ -108,4 +108,8 @@ bool xdata::Runway::hasHardSurface() const{
             (surfaceType == SurfaceType::TRANSPARENT_SURFACE));
 }
 
+bool xdata::Runway::isWater() const{
+    return (surfaceType == SurfaceType::WATER_RUNWAY);
+}
+
 } /* namespace xdata */

--- a/src/libxdata/world/models/airport/Runway.h
+++ b/src/libxdata/world/models/airport/Runway.h
@@ -56,6 +56,7 @@ public:
     bool isRunway() const override;
     float getWidth() const;
     bool hasHardSurface() const;
+    bool isWater() const;
     SurfaceType getSurfaceType() const;
     const std::string getSurfaceTypeDescription() const;
     void attachILSData(std::weak_ptr<Fix> ils);

--- a/src/maps/OverlayedAirport.cpp
+++ b/src/maps/OverlayedAirport.cpp
@@ -48,7 +48,7 @@ void OverlayedAirport::drawGraphics() {
     if (isBlob()) {
         drawAirportBlob();
     } else if (overlayHelper->getMapWidthNM() < DRAW_GEOGRAPHIC_RUNWAYS_AT_MAPWIDTHNM) {
-        if ((type == AerodromeType::HELIPORT) || (type == AerodromeType::SEAPORT)) {
+        if (type == AerodromeType::HELIPORT) {
             drawAirportICAORing();
         } else {
             drawAirportGeographicRunways();
@@ -125,7 +125,7 @@ bool OverlayedAirport::isEnabled(OverlayHelper helper, const xdata::Airport *air
 }
 
 OverlayedAirport::AerodromeType OverlayedAirport::getAerodromeType(const xdata::Airport *airport) {
-    if (airport->hasWaterRunway()) {
+    if (airport->hasOnlyWaterRunways()) {
         return AerodromeType::SEAPORT;
     } else if (airport->hasOnlyHeliports()) {
         return AerodromeType::HELIPORT;
@@ -210,7 +210,7 @@ void OverlayedAirport::drawAirportICAORing() {
         mapImage->drawLine(px - 3, py - 5, px - 3, py + 5, color); // Left vertical
         mapImage->drawLine(px + 3, py - 5, px + 3, py + 5, color); // Right vertical
         mapImage->drawLine(px - 3, py    , px + 3, py    , color); // Horizonatal
-    } else if (airport->hasWaterRunway()) {
+    } else if (airport->hasOnlyWaterRunways()) {
         // Draw anchor
         mapImage->drawLine(  px - 3, py - 4, px + 3, py - 4, color); // Top
         mapImage->drawLine(  px    , py - 4, px    , py + 4, color); // Vertical
@@ -236,7 +236,8 @@ void OverlayedAirport::drawAirportGeographicRunways() {
             return;
         }
         float aspectRatio = rwyLength / (rwyWidth * 1.1);
-        uint32_t surfColor = (rwy1->hasHardSurface()) ? img::COLOR_DARK_GREY : img::COLOR_DARK_GREEN;
+        uint32_t surfColor = rwy1->hasHardSurface() ? img::COLOR_DARK_GREY :
+            rwy1->isWater() ? img::COLOR_ICAO_BLUE : img::COLOR_DARK_GREEN;
         int xo = (px1 - px2) / aspectRatio;
         int yo = (py1 - py2) / aspectRatio;
         auto mapImage = overlayHelper->getMapImage();

--- a/src/maps/OverlayedAirport.cpp
+++ b/src/maps/OverlayedAirport.cpp
@@ -40,6 +40,10 @@ std::shared_ptr<OverlayedAirport> OverlayedAirport::getInstanceIfVisible(Overlay
     }
 }
 
+std::string OverlayedAirport::getID() {
+    return airport->getID();
+}
+
 void OverlayedAirport::drawGraphics() {
     if (isBlob()) {
         drawAirportBlob();
@@ -67,7 +71,8 @@ void OverlayedAirport::drawGraphics() {
 }
 
 void OverlayedAirport::drawText(bool detailed) {
-    if (isBlob()) {
+    // Allow detailed text to be rendered for hotspots, even if just blob
+    if (isBlob() && !detailed) {
         return;
     }
     // Place text below southern airport boundary and below symbol

--- a/src/maps/OverlayedAirport.h
+++ b/src/maps/OverlayedAirport.h
@@ -33,6 +33,7 @@ public:
 
     void drawGraphics();
     void drawText(bool detailed);
+    virtual std::string getID();
 
 private:
 
@@ -46,8 +47,6 @@ private:
     const xdata::Airport *airport;
     AerodromeType type = AerodromeType::AIRPORT;
     uint32_t color = 0;
-    int px = 0;
-    int py = 0;
 
     static bool isVisible(OverlayHelper helper, const xdata::Airport *airport);
     static bool isEnabled(OverlayHelper helper, const xdata::Airport *airport);

--- a/src/maps/OverlayedDME.cpp
+++ b/src/maps/OverlayedDME.cpp
@@ -33,6 +33,14 @@ std::shared_ptr<OverlayedDME> OverlayedDME::getInstanceIfVisible(OverlayHelper h
     }
 }
 
+int OverlayedDME::getHotspotX() {
+    return px - 20;
+}
+
+int OverlayedDME::getHotspotY() {
+    return py - 20;
+}
+
 void OverlayedDME::drawGraphics() {
     drawGraphicsStatic(overlayHelper, fix, px, py);
 }
@@ -54,7 +62,8 @@ void OverlayedDME::drawText(bool detailed) {
         drawNavTextBox(overlayHelper, "DME", fix->getID(), freqString, px - 47, py - 37, img::COLOR_ICAO_VOR_DME);
     } else {
         auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawText(fix->getID(), 12, px - 20, py - 20, img::COLOR_ICAO_VOR_DME, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
+        mapImage->drawText(fix->getID(), 12, getHotspotX(), getHotspotY(),
+            img::COLOR_ICAO_VOR_DME, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
     }
 }
 

--- a/src/maps/OverlayedDME.h
+++ b/src/maps/OverlayedDME.h
@@ -34,6 +34,8 @@ public:
 
     void drawGraphics();
     void drawText(bool detailed);
+    int getHotspotX();
+    int getHotspotY();
 
 private:
     static const int MARGIN = 60;

--- a/src/maps/OverlayedFix.cpp
+++ b/src/maps/OverlayedFix.cpp
@@ -63,6 +63,9 @@ std::shared_ptr<OverlayedFix> OverlayedFix::getInstanceIfVisible(OverlayHelper h
     }
 }
 
+std::string OverlayedFix::getID() {
+    return fix->getID();
+}
 void OverlayedFix::drawNavTextBox(OverlayHelper helper, const std::string &type, const std::string &id, const std::string &freq, int x, int y, uint32_t color, const std::string &ilsHeadingMagnetic) {
     auto mapImage = helper->getMapImage();
     // x, y is top left corner of rectangular border. If type is not required, pass in as ""

--- a/src/maps/OverlayedFix.h
+++ b/src/maps/OverlayedFix.h
@@ -31,6 +31,7 @@ public:
 
     virtual void drawGraphics() = 0;
     virtual void drawText(bool detailed) = 0;
+    virtual std::string getID();
 
 protected:
     OverlayedFix(OverlayHelper helper, const xdata::Fix *fix);
@@ -39,8 +40,6 @@ protected:
     static void drawNavTextBox(OverlayHelper helper, const std::string &type, const std::string &id, const std::string &freq, int x, int y, uint32_t color,
                                const std::string &ilsHeadingMagnetic = "");
     const xdata::Fix *fix;
-    int px;
-    int py;
 
     static const int TEXT_SIZE = 10;
 

--- a/src/maps/OverlayedILSLocalizer.h
+++ b/src/maps/OverlayedILSLocalizer.h
@@ -27,16 +27,27 @@ class OverlayedILSLocalizer : public OverlayedFix {
 public:
     static std::shared_ptr<OverlayedILSLocalizer> getInstanceIfVisible(OverlayHelper helper, const xdata::Fix &fix);
 
-    OverlayedILSLocalizer(OverlayHelper helper, const xdata::Fix *m_fix);
+    OverlayedILSLocalizer(OverlayHelper helper, const xdata::Fix *m_fix,
+                          int lx, int ly, int cx, int cy, int rx, int ry);
 
     void drawGraphics();
     void drawText(bool detailed);
+    int getHotspotX();
+    int getHotspotY();
 
 private:
     static void getTailCoords(OverlayHelper helper, const xdata::Fix *fix, int &lx, int &ly, int &cx, int &cy, int &rx, int &ry);
     static void polarToCartesian(float radius, float angleDegrees, double& x, double& y);
 
     static const uint32_t color = img::COLOR_DARK_GREEN;
+    
+    int textLocationX = 0;
+    int textLocationY = 0;
+
+    // End of tail vertices
+    int lx, ly; // End of tail, left feather (as viewed from airport)
+    int cx, cy; // End of tail, centre indented
+    int rx, ry; // End of tail, right feather (as viewed from airport)
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <cmath>
 #include "OverlayedMap.h"
-#include "OverlayedNode.h"
 #include "src/Logger.h"
 
 namespace maps {
@@ -128,7 +127,11 @@ void OverlayedMap::getCenterLocation(double& latitude, double& longitude) {
     pixelToPosition(mapImage->getWidth() / 2, mapImage->getHeight() / 2, latitude, longitude);
 }
 
-void OverlayedMap::pan(int dx, int dy) {
+void OverlayedMap::pan(int dx, int dy, int relx, int rely) {
+    if ((relx >= 0) && (rely >= 0)) {
+        stitcher->convertSourceImageToRenderedCoords(relx, rely);
+        pixelToPosition(relx, rely, lastLatClicked, lastLongClicked);
+    }
     stitcher->pan(dx, dy);
 }
 
@@ -236,6 +239,27 @@ void OverlayedMap::drawCalibrationOverlay() {
     mapImage->drawLine(centerX, centerY + r / 2, centerX, centerY - r / 2, color);
 }
 
+bool OverlayedMap::isHotspot(std::shared_ptr<OverlayedNode> node) {
+    return (node->getID() == closestNodeToLastClicked->getID()) ||
+           (node->getID() == closestNodeToPlane->getID()) ||
+           (node->getID() == closestNodeToCentre->getID());
+}
+
+void OverlayedMap::showHotspotDetailedText() {
+    if (closestNodeToLastClicked) {
+        closestNodeToLastClicked->drawText(true);
+    }
+    if (closestNodeToPlane &&
+        (closestNodeToPlane->getID() != closestNodeToLastClicked->getID())) {
+        closestNodeToPlane->drawText(true);
+    }
+    if (closestNodeToCentre &&
+        (closestNodeToCentre->getID() != closestNodeToLastClicked->getID()) &&
+        (closestNodeToCentre->getID() != closestNodeToPlane->getID())) {
+        closestNodeToCentre->drawText(true);
+    }
+}
+
 void OverlayedMap::drawDataOverlays() {
     if (!navWorld) {
         return;
@@ -268,16 +292,50 @@ void OverlayedMap::drawDataOverlays() {
     double nmPerPixel = metresPerPixel / 1852;
     mapWidthNM = nmPerPixel * mapImage->getWidth();
 
+    // Define last clicked, centre and plane positions for establishing hotspots
+    int lastXClicked, lastYClicked; // Last lat, long clicked, converted to x, y
+    positionToPixel(lastLatClicked, lastLongClicked, lastXClicked, lastYClicked);
+    int centreX = mapImage->getWidth() / 2;
+    int centreY = mapImage->getHeight() / 2;
+    int planeX = centreX;
+    int planeY = centreY;
+    if (!planeLocations.empty()) {
+        positionToPixel(planeLocations[0].latitude, planeLocations[0].longitude, planeX, planeY);
+    }
+    int closestDistanceToLastClicked = std::numeric_limits<int>::max();
+    int closestDistanceToPlane = std::numeric_limits<int>::max();
+    int closestDistanceToCentre = std::numeric_limits<int>::max();
+
     // Gather list of visible OverlayedNodes, instancing those that are visible
     std::vector<std::shared_ptr<OverlayedNode>> overlayedAerodromes;
     std::vector<std::shared_ptr<OverlayedNode>> overlayedFixes;
-    navWorld->visitNodes(upLeft, downRight, [this, &overlayedAerodromes, &overlayedFixes] (const xdata::NavNode &node) {
+    navWorld->visitNodes(upLeft, downRight, [this, &overlayedAerodromes, &overlayedFixes,
+                                             lastXClicked, lastYClicked, &closestDistanceToLastClicked,
+                                             planeX, planeY, &closestDistanceToPlane,
+                                             centreX, centreY, &closestDistanceToCentre]
+                                             (const xdata::NavNode &node) {
         auto overlayedNode = OverlayedNode::getInstanceIfVisible(shared_from_this(), node);
         if (overlayedNode) {
             if (dynamic_cast<const xdata::Airport *>(&node)) {
                 overlayedAerodromes.push_back(overlayedNode);
             } else if (dynamic_cast<const xdata::Fix *>(&node)) {
                 overlayedFixes.push_back(overlayedNode);
+            }
+            // Consider new node as candidate for hotspots
+            int distanceToLastClicked = overlayedNode->getDistanceFromHotspot(lastXClicked, lastYClicked);
+            if (distanceToLastClicked < closestDistanceToLastClicked) {
+                closestDistanceToLastClicked = distanceToLastClicked;
+                closestNodeToLastClicked = overlayedNode;
+            }
+            int distanceToPlane = overlayedNode->getDistanceFromHotspot(planeX, planeY);
+            if (distanceToPlane < closestDistanceToPlane) {
+                closestDistanceToPlane = distanceToPlane;
+                closestNodeToPlane = overlayedNode;
+            }
+            int distanceToCentre = overlayedNode->getDistanceFromHotspot(centreX, centreY);
+            if (distanceToCentre < closestDistanceToCentre) {
+                closestDistanceToCentre = distanceToCentre;
+                closestNodeToCentre = overlayedNode;
             }
         }
     });
@@ -286,7 +344,7 @@ void OverlayedMap::drawDataOverlays() {
     LOG_INFO(dbg, "%d aerodromes, %d fixes visible", numAerodromesVisible, overlayedFixes.size());
 
     // Render the list of visible OverlayedNodes:
-    // Fix graphics, aerodrome graphics, then fix text and aerodrome text.
+    // Fix graphics, aerodrome graphics, then fix text and aerodrome text, then hotspot text
     for (auto overlayedNode : overlayedFixes) {
         overlayedNode->drawGraphics();
     }
@@ -299,12 +357,18 @@ void OverlayedMap::drawDataOverlays() {
     if (numNodesVisible < MAX_VISIBLE_OBJECTS_TO_SHOW_TEXT) {
         bool detailedText = numNodesVisible < MAX_VISIBLE_OBJECTS_TO_SHOW_DETAILED_TEXT;
         for (auto overlayedNode : overlayedFixes) {
-            overlayedNode->drawText(detailedText);
+            if (!isHotspot(overlayedNode)) {
+                overlayedNode->drawText(detailedText);
+            }
         }
         for (auto overlayedNode : overlayedAerodromes) {
-            overlayedNode->drawText(detailedText);
+            if (!isHotspot(overlayedNode)) {
+                overlayedNode->drawText(detailedText);
+            }
         }
     }
+
+    showHotspotDetailedText();
 
     LOG_INFO(dbg, "zoom = %2d, deltaLon = %7.3f, %5.4f nm/pix, mapWidth = %6.1f nm",
         stitcher->getZoomLevel(), deltaLon, nmPerPixel, mapWidthNM);

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -249,14 +249,14 @@ void OverlayedMap::showHotspotDetailedText() {
     if (closestNodeToLastClicked) {
         closestNodeToLastClicked->drawText(true);
     }
-    if (closestNodeToPlane &&
-        (closestNodeToPlane->getID() != closestNodeToLastClicked->getID())) {
-        closestNodeToPlane->drawText(true);
-    }
     if (closestNodeToCentre &&
-        (closestNodeToCentre->getID() != closestNodeToLastClicked->getID()) &&
-        (closestNodeToCentre->getID() != closestNodeToPlane->getID())) {
+        (closestNodeToCentre->getID() != closestNodeToLastClicked->getID())) {
         closestNodeToCentre->drawText(true);
+    }
+    if (closestNodeToPlane && overlayConfig->drawMyAircraft &&
+        (closestNodeToPlane->getID() != closestNodeToLastClicked->getID()) &&
+        (closestNodeToPlane->getID() != closestNodeToCentre->getID())) {
+        closestNodeToPlane->drawText(true);
     }
 }
 
@@ -305,6 +305,9 @@ void OverlayedMap::drawDataOverlays() {
     int closestDistanceToLastClicked = std::numeric_limits<int>::max();
     int closestDistanceToPlane = std::numeric_limits<int>::max();
     int closestDistanceToCentre = std::numeric_limits<int>::max();
+    closestNodeToLastClicked.reset();
+    closestNodeToPlane.reset();
+    closestNodeToCentre.reset();
 
     // Gather list of visible OverlayedNodes, instancing those that are visible
     std::vector<std::shared_ptr<OverlayedNode>> overlayedAerodromes;

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -26,6 +26,7 @@
 #include "src/environment/Environment.h"
 #include "OverlayHelper.h"
 #include "OverlayConfig.h"
+#include "OverlayedNode.h"
 
 namespace maps {
 
@@ -38,7 +39,7 @@ public:
     void setRedrawCallback(OverlaysDrawnCallback cb);
     void setNavWorld(std::shared_ptr<xdata::World> world);
 
-    void pan(int dx, int dy);
+    void pan(int dx, int dy, int relx = -1, int rely = -1);
 
     void centerOnWorldPos(double latitude, double longitude);
     void centerOnPlane();
@@ -94,6 +95,12 @@ private:
     int calibrationStep = 0;
     img::TTFStamper copyrightStamp;
     bool dbg;
+    double lastLatClicked = 0;
+    double lastLongClicked = 0;
+
+    std::shared_ptr<OverlayedNode> closestNodeToLastClicked;
+    std::shared_ptr<OverlayedNode> closestNodeToPlane;
+    std::shared_ptr<OverlayedNode> closestNodeToCentre;
 
     // Tiles
     std::shared_ptr<img::Stitcher> stitcher;
@@ -109,6 +116,8 @@ private:
     float cosDegrees(int angleDegrees) const;
     float sinDegrees(int angleDegrees) const;
     void polarToCartesian(float radius, float angleRadians, double& x, double& y);
+    bool isHotspot(std::shared_ptr<OverlayedNode> node);
+    void showHotspotDetailedText();
 
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_TEXT = 200;
     static const int MAX_VISIBLE_OBJECTS_TO_SHOW_DETAILED_TEXT = 40;

--- a/src/maps/OverlayedNDB.cpp
+++ b/src/maps/OverlayedNDB.cpp
@@ -59,6 +59,14 @@ void OverlayedNDB::createNDBIcon() {
     radius = ndbIcon.getWidth() / 2;
 }
 
+int OverlayedNDB::getHotspotX() {
+    return px + radius + 5;
+}
+
+int OverlayedNDB::getHotspotY() {
+    return py - radius - 5;
+}
+
 void OverlayedNDB::drawGraphics() {
     auto mapImage = overlayHelper->getMapImage();
     mapImage->blendImage0(ndbIcon, px - radius, py - radius);
@@ -70,7 +78,8 @@ void OverlayedNDB::drawText(bool detailed) {
         drawNavTextBox(overlayHelper, "", fix->getID(), freqString, px + radius, py - radius - 10, img::COLOR_ICAO_MAGENTA);
     } else {
         auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawText(fix->getID(), 12, px + radius + 5, py - radius - 5, img::COLOR_ICAO_MAGENTA, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
+        mapImage->drawText(fix->getID(), 12, getHotspotX(), getHotspotY(),
+            img::COLOR_ICAO_MAGENTA, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
     }
 }
 

--- a/src/maps/OverlayedNDB.h
+++ b/src/maps/OverlayedNDB.h
@@ -30,8 +30,9 @@ public:
     OverlayedNDB(OverlayHelper helper, const xdata::Fix *m_fix);
 
     void drawGraphics();
-
     void drawText(bool detailed);
+    int getHotspotX();
+    int getHotspotY();
 
 private:
     static img::Image ndbIcon;

--- a/src/maps/OverlayedNode.cpp
+++ b/src/maps/OverlayedNode.cpp
@@ -39,5 +39,18 @@ std::shared_ptr<OverlayedNode> OverlayedNode::getInstanceIfVisible(OverlayHelper
     return nullptr;
 }
 
+int OverlayedNode::getDistanceFromHotspot(int x, int y) {
+    // Taxicab distance ok for use-case, instead of more compute intensive full pythagoras
+    return std::abs(getHotspotX() - x) + std::abs(getHotspotY() - y);
+}
+
+int OverlayedNode::getHotspotX() {
+    return px;    
+}
+
+int OverlayedNode::getHotspotY() {
+    return py;    
+}
+
 } /* namespace maps */
 

--- a/src/maps/OverlayedNode.h
+++ b/src/maps/OverlayedNode.h
@@ -33,11 +33,16 @@ public:
 
     virtual void drawGraphics() = 0;
     virtual void drawText(bool detailed) = 0;
-
+    virtual int getDistanceFromHotspot(int x, int y);
+    virtual int getHotspotX();
+    virtual int getHotspotY();
+    virtual std::string getID() = 0;
 protected:
     OverlayedNode(OverlayHelper helper);
 
     OverlayHelper overlayHelper;
+    int px = 0;
+    int py = 0;
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedVOR.cpp
+++ b/src/maps/OverlayedVOR.cpp
@@ -34,6 +34,14 @@ std::shared_ptr<OverlayedVOR> OverlayedVOR::getInstanceIfVisible(OverlayHelper h
     }
 }
 
+int OverlayedVOR::getHotspotX() {
+    return px - 20;
+}
+
+int OverlayedVOR::getHotspotY() {
+    return py - 20;
+}
+
 void OverlayedVOR::drawGraphics() {
     auto vor = fix->getVOR();
     double r = 8;
@@ -90,7 +98,8 @@ void OverlayedVOR::drawText(bool detailed) {
         drawNavTextBox(overlayHelper, type, fix->getID(), freqString, px - 47, py - 37, img::COLOR_ICAO_VOR_DME);
     } else {
         auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawText(fix->getID(), 12, px - 20, py - 20, img::COLOR_ICAO_VOR_DME, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
+        mapImage->drawText(fix->getID(), 12, getHotspotX(), getHotspotY(),
+            img::COLOR_ICAO_VOR_DME, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
     }
 }
 

--- a/src/maps/OverlayedVOR.h
+++ b/src/maps/OverlayedVOR.h
@@ -31,6 +31,8 @@ public:
 
     void drawGraphics();
     void drawText(bool detailed);
+    int getHotspotX();
+    int getHotspotY();
 
 private:
     static const int CIRCLE_RADIUS = 70;


### PR DESCRIPTION
Show detailed text for up to 3 overlayed objects. The hotspots are closest to centre of map, closest to plane, and closest to last clicked lat/long