### PR TITLE
feature/105 Show course for all runways

### DIFF
--- a/src/libxdata/world/loaders/AirportLoader.cpp
+++ b/src/libxdata/world/loaders/AirportLoader.cpp
@@ -102,12 +102,14 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
     }
 
     for (auto &entry: port.runways) {
+        float heading = std::numeric_limits<float>::quiet_NaN();
         float length = std::numeric_limits<float>::quiet_NaN();
         if (entry.ends.size() == 2) {
             auto &end1 = entry.ends[0];
             auto &end2 = entry.ends[1];
             Location end1Loc(end1.latitude, end1.longitude);
             Location end2Loc(end2.latitude, end2.longitude);
+            heading = end1Loc.bearingTo(end2Loc);
             length = end1Loc.distanceTo(end2Loc) - end1.displace - end2.displace;
         } else {
             LOG_WARN("%s has runway with %d ends!", port.id.c_str(), entry.ends.size());
@@ -119,6 +121,9 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
             rwy->setLocation(Location(end->latitude, end->longitude));
             rwy->setWidth(entry.width);
             rwy->setSurfaceType((Runway::SurfaceType) entry.surfaceType);
+            if (!std::isnan(heading)) {
+                rwy->setHeading(end == entry.ends.begin() ? heading : std::fmod(heading + 180.0, 360.0));
+            }
             if (!std::isnan(length)) {
                 rwy->setLength(length);
             }

--- a/src/libxdata/world/models/Location.cpp
+++ b/src/libxdata/world/models/Location.cpp
@@ -30,6 +30,19 @@ bool Location::isValid() const {
     return (!std::isnan(latitude) && !std::isnan(longitude));
 }
 
+double Location::bearingTo(const Location& other) const {
+    // using the haversine formula
+    double phi1 = latitude * M_PI / 180;
+    double phi2 = other.latitude * M_PI / 180;
+    double deltaLambda = (other.longitude - longitude) * M_PI / 180.0;
+
+    double y = std::sin(deltaLambda) * std::cos(phi2);
+    double x = std::cos(phi1) * std::sin(phi2) -
+               std::sin(phi1) * std::cos(phi2) * std::cos(deltaLambda);
+    double theta =std::atan2(y, x);
+    return std::fmod((theta * 180.0 / M_PI) + 360.0, 360.0);
+}
+
 double Location::distanceTo(const Location& other) const {
     // using the haversine formula
     double R = 6371000; // earth radius in meters

--- a/src/libxdata/world/models/Location.h
+++ b/src/libxdata/world/models/Location.h
@@ -31,6 +31,8 @@ struct Location {
 
     bool isValid() const;
 
+    double bearingTo(const Location &other) const;
+
     double distanceTo(const Location &other) const;
 };
 

--- a/src/libxdata/world/models/airport/Runway.cpp
+++ b/src/libxdata/world/models/airport/Runway.cpp
@@ -34,6 +34,10 @@ void Runway::setWidth(float w) {
     this->width = w;
 }
 
+void Runway::setHeading(float b) {
+    this->heading = b;
+}
+
 void Runway::setLength(float l) {
     this->length = l;
 }
@@ -77,6 +81,10 @@ std::shared_ptr<Fix> Runway::getILSData() const {
 
 const Location &Runway::getLocation() const {
     return location;
+}
+
+float xdata::Runway::getHeading() const {
+    return heading;
 }
 
 float xdata::Runway::getLength() const {

--- a/src/libxdata/world/models/airport/Runway.h
+++ b/src/libxdata/world/models/airport/Runway.h
@@ -46,9 +46,11 @@ public:
     Runway(const std::string &name);
     void rename(const std::string &newName);
     void setWidth(float w);
+    void setHeading(float b);
     void setLength(float l);
     void setLocation(const Location &loc);
     void setSurfaceType(SurfaceType surfaceType);
+    float getHeading() const; // can be NaN
     float getLength() const; // can be NaN
 
     const std::string &getID() const override;
@@ -67,6 +69,7 @@ private:
     std::string name;
     Location location;
     float width = std::numeric_limits<float>::quiet_NaN(); // meters
+    float heading = std::numeric_limits<float>::quiet_NaN(); // degrees
     float length = std::numeric_limits<float>::quiet_NaN(); // meters
     SurfaceType surfaceType;
 


### PR DESCRIPTION
See fpw/avitab#105

Changes made:
- Add haversine bearingTo function. [Source](https://www.movable-type.co.uk/scripts/latlong.html) - another option would be to use rhumb bearings.
- Calculate bearing along the runway. As we're dealing with short distances, the initial and final bearings can be assumed to be equal.
- Calculate the magnetic variation for the airport. The variation differences will be negligable across small distances.
- Always show the runway course
- Only display the ILS course if it differs from the runway course.