### PR TITLE
Feature/66 List custom charts in the Airports app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 # Project specific ignores
 build
 build-third
+cmake-build-debug
 
 # Jetbrains IDE
 .idea/

--- a/src/avitab/AviTab.cpp
+++ b/src/avitab/AviTab.cpp
@@ -35,7 +35,7 @@ AviTab::AviTab(std::shared_ptr<Environment> environment):
     if (env->getConfig()->getBool("/AviTab/loadNavData")) {
         env->loadNavWorldInBackground();
     }
-    chartService = std::make_shared<apis::ChartService>(env->getProgramPath() + "/Navigraph/", env->getProgramPath());
+    chartService = std::make_shared<apis::ChartService>(env->getProgramPath());
     jsRuntime = std::make_shared<js::Runtime>();
     env->resumeEnvironmentJobs();
 }

--- a/src/avitab/AviTab.cpp
+++ b/src/avitab/AviTab.cpp
@@ -35,7 +35,7 @@ AviTab::AviTab(std::shared_ptr<Environment> environment):
     if (env->getConfig()->getBool("/AviTab/loadNavData")) {
         env->loadNavWorldInBackground();
     }
-    chartService = std::make_shared<apis::ChartService>(env->getProgramPath() + "/Navigraph/");
+    chartService = std::make_shared<apis::ChartService>(env->getProgramPath() + "/Navigraph/", env->getProgramPath());
     jsRuntime = std::make_shared<js::Runtime>();
     env->resumeEnvironmentJobs();
 }

--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -319,9 +319,9 @@ void AirportApp::onChartsLoaded(std::shared_ptr<Page> page, const apis::ChartSer
         tab.chartSelect->add("Departure (" + std::to_string(countCharts(charts, apis::ChartCategory::DEP)) + ")", -3);
         tab.chartSelect->add("Approach (" + std::to_string(countCharts(charts, apis::ChartCategory::APP)) + ")", -4);
         tab.chartSelect->add("Reference (" + std::to_string(countCharts(charts, apis::ChartCategory::REF)) + ")", -5);
-        tab.chartSelect->add("Other (" + std::to_string(countCharts(charts, apis::ChartCategory::OTHER)) + ")", 6);
+        tab.chartSelect->add("Other (" + std::to_string(countCharts(charts, apis::ChartCategory::OTHER)) + ")", -6);
     } else {
-        tab.chartSelect->add("Back", Widget::Symbol::LEFT, -6);
+        tab.chartSelect->add("Back", Widget::Symbol::LEFT, -7);
         for (size_t i = 0; i < charts.size(); i++) {
             if (charts[i]->getCategory() == tab.requestedList) {
                 tab.chartSelect->add(charts[i]->getIndex() + ": " + charts[i]->getName(), i);
@@ -341,7 +341,8 @@ void AirportApp::onChartsLoaded(std::shared_ptr<Page> page, const apis::ChartSer
                 case -3: listTab.requestedList = apis::ChartCategory::DEP; break;
                 case -4: listTab.requestedList = apis::ChartCategory::APP; break;
                 case -5: listTab.requestedList = apis::ChartCategory::REF; break;
-                case -6: listTab.requestedList = apis::ChartCategory::ROOT; break;
+                case -6: listTab.requestedList = apis::ChartCategory::OTHER; break;
+                case -7: listTab.requestedList = apis::ChartCategory::ROOT; break;
                 }
                 onChartsLoaded(page, listTab.charts);
                 return;

--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -319,6 +319,7 @@ void AirportApp::onChartsLoaded(std::shared_ptr<Page> page, const apis::ChartSer
         tab.chartSelect->add("Departure (" + std::to_string(countCharts(charts, apis::ChartCategory::DEP)) + ")", -3);
         tab.chartSelect->add("Approach (" + std::to_string(countCharts(charts, apis::ChartCategory::APP)) + ")", -4);
         tab.chartSelect->add("Reference (" + std::to_string(countCharts(charts, apis::ChartCategory::REF)) + ")", -5);
+        tab.chartSelect->add("Other (" + std::to_string(countCharts(charts, apis::ChartCategory::OTHER)) + ")", 6);
     } else {
         tab.chartSelect->add("Back", Widget::Symbol::LEFT, -6);
         for (size_t i = 0; i < charts.size(); i++) {

--- a/src/charts/CMakeLists.txt
+++ b/src/charts/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/libchartfox/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/libnavigraph/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/liblocalfile/CMakeLists.txt)
 
 target_sources(avitab_common PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/Crypto.cpp

--- a/src/charts/Chart.h
+++ b/src/charts/Chart.h
@@ -30,6 +30,7 @@ enum class ChartCategory {
     DEP,
     ARR,
     APP,
+    OTHER,
 };
 
 class Chart {

--- a/src/charts/ChartService.cpp
+++ b/src/charts/ChartService.cpp
@@ -22,10 +22,10 @@
 
 namespace apis {
 
-ChartService::ChartService(const std::string &cachePath, const std::string &dataPath) {
-    navigraph = std::make_shared<navigraph::NavigraphAPI>(cachePath);
+ChartService::ChartService(const std::string &programPath) {
+    navigraph = std::make_shared<navigraph::NavigraphAPI>(programPath + "/Navigraph/");
     chartfox = std::make_shared<chartfox::ChartFoxAPI>();
-    localFile= std::make_shared<localfile::LocalFileAPI>(dataPath);
+    localFile= std::make_shared<localfile::LocalFileAPI>(programPath + "/charts/");
 
     keepAlive = true;
     apiThread = std::make_unique<std::thread>(&ChartService::workLoop, this);

--- a/src/charts/ChartService.h
+++ b/src/charts/ChartService.h
@@ -33,7 +33,7 @@ class ChartService {
 public:
     using ChartList = std::vector<std::shared_ptr<Chart>>;
 
-    ChartService(const std::string &cachePath, const std::string &dataPath);
+    ChartService(const std::string &programPath);
     ~ChartService();
 
     // synchronous calls

--- a/src/charts/ChartService.h
+++ b/src/charts/ChartService.h
@@ -24,6 +24,7 @@
 #include "APICall.h"
 #include "Chart.h"
 #include "src/charts/libchartfox/ChartFoxAPI.h"
+#include "src/charts/liblocalfile/LocalFileAPI.h"
 #include "src/charts/libnavigraph/NavigraphAPI.h"
 
 namespace apis {
@@ -32,7 +33,7 @@ class ChartService {
 public:
     using ChartList = std::vector<std::shared_ptr<Chart>>;
 
-    ChartService(const std::string &cachePath);
+    ChartService(const std::string &cachePath, const std::string &dataPath);
     ~ChartService();
 
     // synchronous calls
@@ -53,9 +54,11 @@ public:
 private:
     std::shared_ptr<navigraph::NavigraphAPI> navigraph;
     std::shared_ptr<chartfox::ChartFoxAPI> chartfox;
+    std::shared_ptr<localfile::LocalFileAPI> localFile;
 
     bool useNavigraph = false;
     bool useChartFox = false;
+    bool useLocalFile = true;
 
     std::mutex mutex;
     std::condition_variable workCondition;

--- a/src/charts/liblocalfile/CMakeLists.txt
+++ b/src/charts/liblocalfile/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(avitab_common PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/LocalFileAPI.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/LocalFileChart.cpp
+        )

--- a/src/charts/liblocalfile/CMakeLists.txt
+++ b/src/charts/liblocalfile/CMakeLists.txt
@@ -1,4 +1,4 @@
 target_sources(avitab_common PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/LocalFileAPI.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/LocalFileChart.cpp
-        )
+    ${CMAKE_CURRENT_LIST_DIR}/LocalFileAPI.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/LocalFileChart.cpp
+)

--- a/src/charts/liblocalfile/LocalFileAPI.cpp
+++ b/src/charts/liblocalfile/LocalFileAPI.cpp
@@ -29,7 +29,7 @@ namespace localfile {
 
 LocalFileAPI::LocalFileAPI(const std::string chartsPath) {
     this->chartsPath = chartsPath;
-    this->filter  = std::regex(".(pdf|png|jpeg|jpg|bmp)$", std::regex_constants::ECMAScript | std::regex_constants::icase);
+    this->filter = std::regex("\\.(pdf|png|jpeg|jpg|bmp)$", std::regex::icase);
 }
 
 bool LocalFileAPI::isSupported() {
@@ -40,11 +40,15 @@ std::vector<std::shared_ptr<apis::Chart>> LocalFileAPI::getChartsFor(const std::
     std::vector<std::shared_ptr<apis::Chart>> charts;
     std::string path = chartsPath + icao + "/";
 
+    if (!platform::fileExists(path)) {
+        return charts;
+    }
+
     try {
         std::vector<platform::DirEntry> entries = platform::readDirectory(path);
         size_t idx = 1;
 
-        std::sort(entries.begin(), entries.end(), [](const platform::DirEntry &a, const platform::DirEntry &b) -> bool {
+        std::sort(entries.begin(), entries.end(), [] (const platform::DirEntry &a, const platform::DirEntry &b) -> bool {
             return a.utf8Name < b.utf8Name;
         });
 
@@ -57,16 +61,14 @@ std::vector<std::shared_ptr<apis::Chart>> LocalFileAPI::getChartsFor(const std::
             charts.push_back(chart);
         }
     } catch (const std::exception &e) {
-        logger::verbose(e.what());
+        logger::verbose("Couldn't get local charts for %s: %s", icao.c_str(), e.what());
     }
 
     return charts;
 }
 
 void LocalFileAPI::loadChart(std::shared_ptr<LocalFileChart> chart) {
-    fs::ifstream instream(fs::u8path(chart->getPath()), std::ios::in | std::ios::binary);
-    std::vector<uint8_t> fileData((std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
-    chart->attachData(fileData);
+    // since the file is stored locally, we don't need to do any special loading
 }
 
 LocalFileAPI::~LocalFileAPI() {

--- a/src/charts/liblocalfile/LocalFileAPI.cpp
+++ b/src/charts/liblocalfile/LocalFileAPI.cpp
@@ -30,7 +30,7 @@ LocalFileAPI::LocalFileAPI(const std::string dataPath) {
     chartsPath = dataPath + "charts/";
 
     // Only PDFs are supported
-    filter  = std::regex(".pdf$", std::regex_constants::ECMAScript | std::regex_constants::icase);
+    filter  = std::regex(".(pdf|png|jpeg|jpg|bmp)$", std::regex_constants::ECMAScript | std::regex_constants::icase);
 }
 
 bool LocalFileAPI::isSupported() {
@@ -61,8 +61,8 @@ std::vector<std::shared_ptr<apis::Chart>> LocalFileAPI::getChartsFor(const std::
 
 void LocalFileAPI::loadChart(std::shared_ptr<LocalFileChart> chart) {
     std::ifstream instream(chart->getPath(), std::ios::in | std::ios::binary);
-    std::vector<uint8_t> pdfData((std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
-    chart->attachPDF(pdfData);
+    std::vector<uint8_t> fileData((std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
+    chart->attachData(fileData);
 }
 
 LocalFileAPI::~LocalFileAPI() {

--- a/src/charts/liblocalfile/LocalFileAPI.cpp
+++ b/src/charts/liblocalfile/LocalFileAPI.cpp
@@ -1,0 +1,71 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+#include <stdexcept>
+#include <algorithm>
+#include <regex>
+#include "LocalFileAPI.h"
+#include "src/charts/Crypto.h"
+#include "src/platform/Platform.h"
+
+namespace localfile {
+
+LocalFileAPI::LocalFileAPI(const std::string dataPath) {
+    chartsPath = dataPath + "charts/";
+
+    // Only PDFs are supported
+    filter  = std::regex(".pdf$", std::regex_constants::ECMAScript | std::regex_constants::icase);
+}
+
+bool LocalFileAPI::isSupported() {
+    return true;
+}
+
+std::vector<std::shared_ptr<apis::Chart>> LocalFileAPI::getChartsFor(const std::string &icao) {
+    std::vector<std::shared_ptr<apis::Chart>> charts;
+    std::string path = chartsPath + icao + "/";
+    std::vector<platform::DirEntry> entries = platform::readDirectory(path);
+    size_t idx = 1;
+
+    std::sort(entries.begin(), entries.end(), [](const platform::DirEntry &a, const platform::DirEntry &b) -> bool {
+        return a.utf8Name < b.utf8Name;
+    });
+
+    for (auto item: entries) {
+        if (item.isDirectory || !std::regex_search(item.utf8Name, filter)) {
+            continue;
+        }
+
+        auto chart = std::make_shared<LocalFileChart>(path, item.utf8Name, icao, idx++);
+        charts.push_back(chart);
+    }
+
+    return charts;
+}
+
+void LocalFileAPI::loadChart(std::shared_ptr<LocalFileChart> chart) {
+    std::ifstream instream(chart->getPath(), std::ios::in | std::ios::binary);
+    std::vector<uint8_t> pdfData((std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
+    chart->attachPDF(pdfData);
+}
+
+LocalFileAPI::~LocalFileAPI() {
+}
+
+} // namespace localfile

--- a/src/charts/liblocalfile/LocalFileAPI.cpp
+++ b/src/charts/liblocalfile/LocalFileAPI.cpp
@@ -64,7 +64,7 @@ std::vector<std::shared_ptr<apis::Chart>> LocalFileAPI::getChartsFor(const std::
 }
 
 void LocalFileAPI::loadChart(std::shared_ptr<LocalFileChart> chart) {
-    std::ifstream instream(chart->getPath(), std::ios::in | std::ios::binary);
+    fs::ifstream instream(fs::u8path(chart->getPath()), std::ios::in | std::ios::binary);
     std::vector<uint8_t> fileData((std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
     chart->attachData(fileData);
 }

--- a/src/charts/liblocalfile/LocalFileAPI.cpp
+++ b/src/charts/liblocalfile/LocalFileAPI.cpp
@@ -26,11 +26,9 @@
 
 namespace localfile {
 
-LocalFileAPI::LocalFileAPI(const std::string dataPath) {
-    chartsPath = dataPath + "charts/";
-
-    // Only PDFs are supported
-    filter  = std::regex(".(pdf|png|jpeg|jpg|bmp)$", std::regex_constants::ECMAScript | std::regex_constants::icase);
+LocalFileAPI::LocalFileAPI(const std::string chartsPath) {
+    this->chartsPath = chartsPath;
+    this->filter  = std::regex(".(pdf|png|jpeg|jpg|bmp)$", std::regex_constants::ECMAScript | std::regex_constants::icase);
 }
 
 bool LocalFileAPI::isSupported() {

--- a/src/charts/liblocalfile/LocalFileAPI.h
+++ b/src/charts/liblocalfile/LocalFileAPI.h
@@ -28,7 +28,7 @@ namespace localfile {
 
 class LocalFileAPI {
 public:
-    LocalFileAPI(const std::string dataPath);
+    LocalFileAPI(const std::string chartsPath);
     ~LocalFileAPI();
 
     bool isSupported();

--- a/src/charts/liblocalfile/LocalFileAPI.h
+++ b/src/charts/liblocalfile/LocalFileAPI.h
@@ -1,0 +1,46 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef AVITAB_LOCALFILEAPI_H
+#define AVITAB_LOCALFILEAPI_H
+
+#include <string>
+#include <vector>
+#include <regex>
+#include "LocalFileChart.h"
+
+namespace localfile {
+
+class LocalFileAPI {
+public:
+    LocalFileAPI(const std::string dataPath);
+    ~LocalFileAPI();
+
+    bool isSupported();
+
+    std::vector<std::shared_ptr<apis::Chart>> getChartsFor(const std::string &icao);
+    void loadChart(std::shared_ptr<LocalFileChart> chart);
+
+private:
+    std::string chartsPath;
+    std::regex filter;
+};
+
+} // namespace localfile
+
+#endif //AVITAB_LOCALFILEAPI_H

--- a/src/charts/liblocalfile/LocalFileChart.cpp
+++ b/src/charts/liblocalfile/LocalFileChart.cpp
@@ -1,0 +1,92 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include <stdexcept>
+#include "src/maps/sources/PDFSource.h"
+#include "LocalFileChart.h"
+
+namespace localfile {
+
+LocalFileChart::LocalFileChart(const std::string path, const std::string name, const std::string &icao, size_t idx):
+    icao(icao),
+    index(idx)
+{
+    // Prettify the file name by replacing underscores and removing the extension
+    std::string id = name;
+    std::replace(id.begin(), id.end(), '_', ' ');
+    auto extPos = id.rfind('.');
+    if (extPos != std::string::npos) {
+        id = id.substr(0, extPos);
+    }
+
+    this->path = path + name;
+    this->category = apis::ChartCategory::OTHER;
+    this->identifier = id;
+}
+
+std::string LocalFileChart::getICAO() const {
+    return icao;
+}
+
+std::string LocalFileChart::getIndex() const {
+    return std::string("LF-") +
+           std::to_string(static_cast<int>(category)) + "-" +
+           std::to_string(index);
+}
+
+apis::ChartCategory LocalFileChart::getCategory() const {
+    return category;
+}
+
+std::string LocalFileChart::getName() const {
+    return identifier;
+}
+
+bool LocalFileChart::isLoaded() const {
+    return !pdfData.empty();
+}
+
+std::string LocalFileChart::getPath() const {
+    return path;
+}
+
+void LocalFileChart::attachPDF(const std::vector<uint8_t> &data) {
+    pdfData = data;
+}
+
+std::shared_ptr<img::TileSource> LocalFileChart::createTileSource(bool nightMode) {
+    if (!isLoaded()) {
+        throw std::runtime_error("Chart not loaded");
+    }
+
+    auto pdfSrc = std::make_shared<maps::PDFSource>(pdfData);
+    pdfSrc->setNightMode(nightMode);
+    return pdfSrc;
+}
+
+void LocalFileChart::changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) {
+    auto pdfSrc = std::dynamic_pointer_cast<maps::PDFSource>(src);
+    if (!pdfSrc) {
+        return;
+    }
+
+    pdfSrc->setNightMode(nightMode);
+}
+
+} // namespace localfile

--- a/src/charts/liblocalfile/LocalFileChart.h
+++ b/src/charts/liblocalfile/LocalFileChart.h
@@ -26,7 +26,7 @@ namespace localfile {
 
 class LocalFileChart: public apis::Chart {
 public:
-    LocalFileChart(const std::string path, const std::string name, const std::string &icao, size_t idx);
+    LocalFileChart(const std::string dir, const std::string name, const std::string &icao, size_t idx);
     virtual ~LocalFileChart() = default;
 
     virtual std::string getICAO() const override;
@@ -46,8 +46,6 @@ private:
     apis::ChartCategory category;
     std::string identifier;
     std::string path;
-    std::vector<uint8_t> fileData;
-    bool isPdf;
 };
 
 } // namespace localfile

--- a/src/charts/liblocalfile/LocalFileChart.h
+++ b/src/charts/liblocalfile/LocalFileChart.h
@@ -39,14 +39,15 @@ public:
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
 
     std::string getPath() const;
-    void attachPDF(const std::vector<uint8_t> &data);
+    void attachData(const std::vector<uint8_t> &data);
 private:
     std::string icao;
     size_t index;
     apis::ChartCategory category;
     std::string identifier;
     std::string path;
-    std::vector<uint8_t> pdfData;
+    std::vector<uint8_t> fileData;
+    bool isPdf;
 };
 
 } // namespace localfile

--- a/src/charts/liblocalfile/LocalFileChart.h
+++ b/src/charts/liblocalfile/LocalFileChart.h
@@ -1,0 +1,54 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef AVITAB_LOCALFILECHART_H
+#define AVITAB_LOCALFILECHART_H
+
+#include <vector>
+#include <string>
+#include "src/charts/Chart.h"
+
+namespace localfile {
+
+class LocalFileChart: public apis::Chart {
+public:
+    LocalFileChart(const std::string path, const std::string name, const std::string &icao, size_t idx);
+    virtual ~LocalFileChart() = default;
+
+    virtual std::string getICAO() const override;
+    virtual std::string getIndex() const override;
+    virtual apis::ChartCategory getCategory() const override;
+    virtual std::string getName() const override;
+
+    virtual bool isLoaded() const override;
+    virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) override;
+    virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
+
+    std::string getPath() const;
+    void attachPDF(const std::vector<uint8_t> &data);
+private:
+    std::string icao;
+    size_t index;
+    apis::ChartCategory category;
+    std::string identifier;
+    std::string path;
+    std::vector<uint8_t> pdfData;
+};
+
+} // namespace localfile
+
+#endif //AVITAB_LOCALFILECHART_H

--- a/src/libimg/Rasterizer.cpp
+++ b/src/libimg/Rasterizer.cpp
@@ -77,7 +77,7 @@ void Rasterizer::loadMemory(const std::vector<uint8_t> &data) {
 }
 
 void Rasterizer::loadDocument() {
-    logger::info("Loading document in thread %d'", std::this_thread::get_id());
+    logger::info("Loading document in thread %d", std::this_thread::get_id());
 
     fz_try(ctx) {
         totalPages = fz_count_pages(ctx, doc);


### PR DESCRIPTION
See #66 

The new LocalFile API looks for any PDF or image files in the `charts/{ICAO}` directory, and adds them as a new "Other" category. The new files are given a prefix of `LF-{index}`.

Changes made:
- Add "Other" chart type
- Change `ChartService` constructor to only pass the program path instead of navigraph path.
- Add LocalFile chart API

Double check the following, I've added comments to the relevant changes:
- [ ] Method for checking if the file is a PDF. It's nominally case insensitive, but won't match XYZ.PdF
- [ ] Method for loading the image. I cobbled this together, but even though it works, I'm not convinced it's the best method
- [ ] I've probably missed out some error handling

Screenshots:
![image](https://user-images.githubusercontent.com/3430117/141775932-564068f7-ef29-49b2-a995-5bd18aa15651.png)
![image](https://user-images.githubusercontent.com/3430117/141775990-a1999452-90eb-402b-8706-ed2c593ff7c8.png)
![image](https://user-images.githubusercontent.com/3430117/141776082-71ea70df-aa34-4f7b-b8b0-a6e1e81270a7.png)
