### PR TITLE
Fix missing text for VOR/NDB with same identifier

### DIFF
--- a/src/libimg/TTFStamper.cpp
+++ b/src/libimg/TTFStamper.cpp
@@ -72,9 +72,6 @@ void TTFStamper::setSize(float size) {
 }
 
 void TTFStamper::setText(const std::string& newText) {
-    if (newText == text) {
-        return;
-    }
     text = newText;
     width = calculateTextWidth();
     if (width == 0) {

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -240,9 +240,9 @@ void OverlayedMap::drawCalibrationOverlay() {
 }
 
 bool OverlayedMap::isHotspot(std::shared_ptr<OverlayedNode> node) {
-    return (node->getID() == closestNodeToLastClicked->getID()) ||
-           (node->getID() == closestNodeToPlane->getID()) ||
-           (node->getID() == closestNodeToCentre->getID());
+    return (node->isEqual(*closestNodeToLastClicked)) ||
+           (node->isEqual(*closestNodeToPlane)) ||
+           (node->isEqual(*closestNodeToCentre));
 }
 
 void OverlayedMap::showHotspotDetailedText() {
@@ -250,12 +250,12 @@ void OverlayedMap::showHotspotDetailedText() {
         closestNodeToLastClicked->drawText(true);
     }
     if (closestNodeToCentre &&
-        (closestNodeToCentre->getID() != closestNodeToLastClicked->getID())) {
+        (!closestNodeToCentre->isEqual(*closestNodeToLastClicked))) {
         closestNodeToCentre->drawText(true);
     }
     if (closestNodeToPlane && overlayConfig->drawMyAircraft &&
-        (closestNodeToPlane->getID() != closestNodeToLastClicked->getID()) &&
-        (closestNodeToPlane->getID() != closestNodeToCentre->getID())) {
+        (!closestNodeToPlane->isEqual(*closestNodeToLastClicked)) &&
+        (!closestNodeToPlane->isEqual(*closestNodeToCentre))) {
         closestNodeToPlane->drawText(true);
     }
 }

--- a/src/maps/OverlayedNode.cpp
+++ b/src/maps/OverlayedNode.cpp
@@ -19,6 +19,7 @@
 #include "OverlayedNode.h"
 #include "OverlayedFix.h"
 #include "OverlayedAirport.h"
+#include <typeinfo>
 
 namespace maps {
 
@@ -50,6 +51,13 @@ int OverlayedNode::getHotspotX() {
 
 int OverlayedNode::getHotspotY() {
     return py;    
+}
+
+bool OverlayedNode::isEqual(OverlayedNode & node) {
+   return (this->getID() == node.getID()) &&
+          (typeid(*this) == typeid(node)) &&
+          (this->px == node.px) &&
+          (this->py == node.py);
 }
 
 } /* namespace maps */

--- a/src/maps/OverlayedNode.h
+++ b/src/maps/OverlayedNode.h
@@ -37,6 +37,7 @@ public:
     virtual int getHotspotX();
     virtual int getHotspotY();
     virtual std::string getID() = 0;
+    bool isEqual(OverlayedNode &node);
 protected:
     OverlayedNode(OverlayHelper helper);
 


### PR DESCRIPTION
e.g. PTB near Budapest
And don't short circuit TTFStamper::setText() if text is the the same - color may change with same text