### PR TITLE
Support n*90 pre-rotate for Mercator calibration

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -45,6 +45,8 @@ MapApp::MapApp(FuncsPtr funcs):
     window->addSymbol(Widget::Symbol::PLUS, std::bind(&MapApp::onPlusButton, this));
     trackButton = window->addSymbol(Widget::Symbol::GPS, std::bind(&MapApp::onTrackButton, this));
     trackButton->setToggleState(trackPlane);
+    rotateButton = window->addSymbol(Widget::Symbol::ROTATE, std::bind(&MapApp::onRotate, this));
+    rotateButton->setVisible(false);
 
     mapImage = std::make_shared<img::Image>(window->getContentWidth(), window->getContentHeight(), img::COLOR_TRANSPARENT);
 
@@ -527,6 +529,11 @@ void MapApp::onTrackButton() {
     onTimer();
 }
 
+void MapApp::onRotate() {
+    tileSource->rotate();
+    mapStitcher->invalidateCache();
+}
+
 void MapApp::startCalibration() {
     messageBox = std::make_unique<avitab::MessageBox>(
             getUIContainer(),
@@ -537,6 +544,7 @@ void MapApp::startCalibration() {
     messageBox->addButton("Ok", [this] () {
         api().executeLater([this] () {
             messageBox.reset();
+            rotateButton->setVisible(true);
             if (map) {
                 map->beginCalibration();
             }
@@ -631,6 +639,7 @@ void MapApp::processCalibrationPoint(int step) {
     } catch (const std::exception &e) {
         LOG_ERROR("Failed to parse '%s': %s", coords.c_str(), e.what());
     }
+    rotateButton->setVisible(false);
 }
 
 bool MapApp::handleNonNumericContent(std::string coords)  {

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -69,6 +69,7 @@ private:
     std::shared_ptr<Window> window;
     std::shared_ptr<PixMap> mapWidget;
     std::shared_ptr<Button> trackButton;
+    std::shared_ptr<Button> rotateButton;
     std::shared_ptr<Container> settingsContainer, chooserContainer, overlaysContainer;
     std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton;
     std::shared_ptr<Label> overlayLabel;
@@ -109,6 +110,7 @@ private:
     void onPlusButton();
     void onMinusButton();
     void onTrackButton();
+    void onRotate();
     void startCalibration();
     double getCoordinate(const std::string &str);
     void processCalibrationPoint(int step);

--- a/src/libimg/Rasterizer.h
+++ b/src/libimg/Rasterizer.h
@@ -36,6 +36,7 @@ public:
     int getPageWidth(int page, int zoom);
     int getPageHeight(int page, int zoom);
     std::unique_ptr<Image> loadTile(int page, int x, int y, int zoom, bool nightMode);
+    void setPreRotate(int angle);
 
     int getPageCount() const;
 
@@ -47,6 +48,7 @@ private:
     int tileSize = 1024;
     int totalPages = 0;
     int currentPageNum = 0;
+    int preRotateAngle = 0;
     fz_context *ctx {};
     fz_stream *stream{};
     fz_document *doc{};

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -55,6 +55,7 @@ public:
     virtual Point<double> xyToWorld(double x, double y, int zoom) = 0;
     virtual void attachCalibration1(double x, double y, double lat, double lon, int zoom) {}
     virtual void attachCalibration2(double x, double y, double lat, double lon, int zoom) {}
+    virtual void rotate() {}
 
     virtual std::string getCopyrightInfo() { return ""; }
 

--- a/src/maps/sources/Calibration.cpp
+++ b/src/maps/sources/Calibration.cpp
@@ -43,11 +43,17 @@ void Calibration::setPoint2(double x, double y, double lat, double lon) {
     calculateCalibration();
 }
 
+void Calibration::setPreRotate(int angle) {
+    preRotate = angle;
+}
+
 std::string Calibration::toString() {
     nlohmann::json json;
 
     json["calibration"] =
                     {
+                        {"prerotate", preRotate},
+
                         {"x1", regX1},
                         {"y1", regY1},
                         {"longitude1", regLon1},
@@ -66,6 +72,8 @@ void Calibration::fromString(const std::string& s) {
     nlohmann::json json = nlohmann::json::parse(s);
 
     using j = nlohmann::json;
+
+    preRotate = json[j::json_pointer("/calibration/prerotate")];
 
     regLon1 = json[j::json_pointer("/calibration/longitude1")];
     regLat1 = json[j::json_pointer("/calibration/latitude1")];
@@ -144,6 +152,10 @@ img::Point<double> Calibration::pixelsToWorld(double x, double y) const {
     lat = invMercator(lat);
 
     return img::Point<double>{lon, lat};
+}
+
+int Calibration::getPreRotate() {
+    return preRotate;
 }
 
 } /* namespace maps */

--- a/src/maps/sources/Calibration.cpp
+++ b/src/maps/sources/Calibration.cpp
@@ -73,7 +73,7 @@ void Calibration::fromString(const std::string& s) {
 
     using j = nlohmann::json;
 
-    preRotate = json[j::json_pointer("/calibration/prerotate")];
+    preRotate = json.value("/calibration/prerotate"_json_pointer, 0);
 
     regLon1 = json[j::json_pointer("/calibration/longitude1")];
     regLat1 = json[j::json_pointer("/calibration/latitude1")];

--- a/src/maps/sources/Calibration.h
+++ b/src/maps/sources/Calibration.h
@@ -28,6 +28,7 @@ class Calibration {
 public:
     void setPoint1(double x, double y, double lat, double lon);
     void setPoint2(double x, double y, double lat, double lon);
+    void setPreRotate(int angle);
 
     std::string toString();
     void fromString(const std::string &s);
@@ -36,9 +37,10 @@ public:
 
     img::Point<double> worldToPixels(double lon, double lat) const;
     img::Point<double> pixelsToWorld(double x, double y) const;
-
+    int getPreRotate();
 
 private:
+    int preRotate{};
     double regX1{}, regY1{}, regLat1{}, regLon1{};
     double regX2{}, regY2{}, regLat2{}, regLon2{};
     double leftLongitude{}, coverLon{};

--- a/src/maps/sources/PDFSource.cpp
+++ b/src/maps/sources/PDFSource.cpp
@@ -158,6 +158,12 @@ img::Point<double> PDFSource::xyToWorld(double x, double y, int zoom) {
     return calibration.pixelsToWorld(normX, normY);
 }
 
+void PDFSource::rotate() {
+    rotateAngle = (rotateAngle + 90) % 360;
+    calibration.setPreRotate(rotateAngle);
+    rasterizer.setPreRotate(rotateAngle);
+}
+
 void PDFSource::storeCalibration() {
     std::string calFileName = utf8FileName + ".json";
     fs::ofstream jsonFile(fs::u8path(calFileName));
@@ -176,6 +182,8 @@ void PDFSource::loadCalibration() {
                      std::istreambuf_iterator<char>());
 
     calibration.fromString(jsonStr);
+    rotateAngle = calibration.getPreRotate();
+    rasterizer.setPreRotate(rotateAngle);
 }
 
 void PDFSource::setNightMode(bool night) {

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -54,12 +54,14 @@ public:
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
 
     void setNightMode(bool night);
+    void rotate();
 
 private:
     std::string utf8FileName;
     img::Rasterizer rasterizer;
     Calibration calibration;
     bool nightMode = false;
+    int rotateAngle = 0;
 
     void storeCalibration();
     void loadCalibration();


### PR DESCRIPTION
In calibration process, add a rotate (by 90) button, which is disabled after first reference point.
PDF tile rendering includes a rotate/translate transformation.
Save and load calibration includes a pre-rotation angle

Intermediate PNG no longer required for PDFs where portrait/landscape orientation isn't grid north up, so :
Simplifies calibration
Better render quality at higher zoom levels than PNG
Smaller chart file size
