### PR TITLE
Enhance file system navigation and selection

### DIFF
--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -24,13 +24,13 @@ ChartsApp::ChartsApp(FuncsPtr appFuncs):
     App(appFuncs),
     updateTimer(std::bind(&ChartsApp::onTimer, this), 200)
 {
-    currentPath = api().getDataPath() + "charts/";
+    fsBrowser.goTo(api().getDataPath() + "charts");
     overlays = std::make_shared<maps::OverlayConfig>();
 
     resetLayout();
 
     setFilterRegex("\\.(pdf|png|jpg|jpeg|bmp)$");
-    showDirectory(currentPath);
+    showDirectory();
 }
 
 void ChartsApp::resetLayout() {
@@ -41,7 +41,7 @@ void ChartsApp::resetLayout() {
 
 void ChartsApp::createBrowseTab() {
     browsePage = tabs->addTab(tabs, "Files");
-    browseWindow = std::make_shared<Window>(browsePage, "Files");
+    browseWindow = std::make_shared<Window>(browsePage, "Charts in:");
     browseWindow->setDimensions(browsePage->getContentWidth(), browsePage->getHeight());
     browseWindow->centerInParent();
 
@@ -57,42 +57,14 @@ void ChartsApp::createBrowseTab() {
     });
 }
 
-void ChartsApp::showDirectory(const std::string& path) {
-    currentPath = path;
-    currentEntries = platform::readDirectory(path);
-    filterEntries();
-    sortEntries();
+void ChartsApp::showDirectory() {
+    browseWindow->setCaption(std::string("Charts: ") + fsBrowser.rtrimmed(62));
+    currentEntries = fsBrowser.entries();
     showCurrentEntries();
 }
 
 void ChartsApp::setFilterRegex(const std::string ext) {
-    filter = std::regex(ext, std::regex_constants::ECMAScript | std::regex_constants::icase);
-}
-
-void ChartsApp::filterEntries() {
-    auto iter = std::remove_if(std::begin(currentEntries), std::end(currentEntries), [this] (const auto &a) -> bool {
-        if (a.isDirectory) {
-            return false;
-        }
-        return !std::regex_search(a.utf8Name, filter);
-    });
-    currentEntries.erase(iter, std::end(currentEntries));
-}
-
-void ChartsApp::sortEntries() {
-    auto comparator = [] (const platform::DirEntry &a, const platform::DirEntry &b) -> bool {
-        if (a.isDirectory && !b.isDirectory) {
-            return true;
-        }
-
-        if (!a.isDirectory && b.isDirectory) {
-            return false;
-        }
-
-        return a.utf8Name < b.utf8Name;
-    };
-
-    std::sort(begin(currentEntries), end(currentEntries), comparator);
+    fsBrowser.setFilter(ext);
 }
 
 void ChartsApp::showCurrentEntries() {
@@ -121,15 +93,16 @@ void ChartsApp::onSelect(int data) {
 
     auto &entry = currentEntries.at(data);
     if (entry.isDirectory) {
-        showDirectory(currentPath + entry.utf8Name + "/");
+        fsBrowser.goDown(entry.utf8Name);
+        showDirectory();
     } else {
-        createPdfTab(currentPath + entry.utf8Name);
+        createPdfTab(fsBrowser.path() + entry.utf8Name);
     }
 }
 
 void ChartsApp::upOneDirectory() {
-    std::string upOne = platform::realPath(currentPath +  "../") + "/";
-    showDirectory(upOne);
+    fsBrowser.goUp();
+    showDirectory();
 }
 
 void ChartsApp::createPdfTab(const std::string &pdfPath) {

--- a/src/avitab/apps/ChartsApp.h
+++ b/src/avitab/apps/ChartsApp.h
@@ -20,7 +20,6 @@
 
 #include <memory>
 #include <vector>
-#include <regex>
 #include "src/platform/Platform.h"
 #include "App.h"
 #include "src/gui_toolkit/widgets/TabGroup.h"
@@ -33,6 +32,7 @@
 #include "src/libimg/stitcher/Stitcher.h"
 #include "src/maps/OverlayedMap.h"
 #include "src/maps/sources/PDFSource.h"
+#include "components/FilesysBrowser.h"
 
 namespace avitab {
 
@@ -50,16 +50,13 @@ private:
     std::shared_ptr<Page> browsePage;
     std::shared_ptr<Window> browseWindow;
     std::shared_ptr<List> list;
-    std::string currentPath;
+    FilesystemBrowser fsBrowser;
     std::vector<platform::DirEntry> currentEntries;
-    std::regex filter;
     std::shared_ptr<maps::OverlayConfig> overlays;
 
     void createBrowseTab();
-    void showDirectory(const std::string &path);
+    void showDirectory();
     void setFilterRegex(const std::string regex);
-    void filterEntries();
-    void sortEntries();
     void showCurrentEntries();
     void upOneDirectory();
     void onDown();

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -172,7 +172,7 @@ void MapApp::setMapSource(MapSource style) {
 }
 
 void MapApp::selectGeoTIFF() {
-    fileChooser = std::make_unique<FileChooser>(&api());
+    fileChooser = std::make_unique<FileChooser>(&api(), "GeoTIFF: ");
     fileChooser->setBaseDirectory(api().getDataPath() + "/MapTiles/GeoTIFFs/");
     fileChooser->setFilterRegex("\\.(tif|tiff)$");
     fileChooser->setSelectCallback([this] (const std::string &selectedUTF8) {
@@ -193,12 +193,12 @@ void MapApp::selectGeoTIFF() {
             chooserContainer->setVisible(false);
         });
     });
-    fileChooser->show(chooserContainer, "Select a GeoTIFF");
+    fileChooser->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 
 void MapApp::selectMercator() {
-    fileChooser = std::make_unique<FileChooser>(&api());
+    fileChooser = std::make_unique<FileChooser>(&api(), "Mercator: ");
     fileChooser->setBaseDirectory(api().getDataPath() + "/MapTiles/Mercator/");
     fileChooser->setFilterRegex("\\.(pdf|png|jpg|jpeg|bmp)$");
     fileChooser->setSelectCallback([this] (const std::string &selectedUTF8) {
@@ -219,14 +219,13 @@ void MapApp::selectMercator() {
             chooserContainer->setVisible(false);
         });
     });
-    fileChooser->show(chooserContainer, "Select a Mercator map image");
+    fileChooser->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 
 void MapApp::selectEPSG() {
-    fileChooser = std::make_unique<FileChooser>(&api());
+    fileChooser = std::make_unique<FileChooser>(&api(), "EPSG: ", true);
     fileChooser->setBaseDirectory(api().getDataPath() + "/MapTiles/EPSG-3857/");
-    fileChooser->setDirectorySelect(true);
     fileChooser->setSelectCallback([this] (const std::string &selectedUTF8) {
         api().executeLater([this, selectedUTF8] () {
             try {
@@ -245,7 +244,7 @@ void MapApp::selectEPSG() {
             chooserContainer->setVisible(false);
         });
     });
-    fileChooser->show(chooserContainer, "Select a SlippyTiles directory");
+    fileChooser->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 
@@ -420,7 +419,7 @@ void MapApp::showOverlaySettings() {
 
 void MapApp::selectUserFixesFile() {
     resetWidgets();
-    fileChooser = std::make_unique<FileChooser>(&api());
+    fileChooser = std::make_unique<FileChooser>(&api(), "Fixes: ");
     std::string userfixes_file = savedSettings->getGeneralSetting<std::string>("userfixes_file");
     if ((userfixes_file == "") || !platform::fileExists(platform::getDirNameFromPath(userfixes_file))) {
         fileChooser->setBaseDirectory(api().getDataPath());
@@ -449,7 +448,7 @@ void MapApp::selectUserFixesFile() {
             showOverlaySettings();
         });
     });
-    fileChooser->show(chooserContainer, "Select a user fixes .csv file");
+    fileChooser->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 

--- a/src/avitab/apps/PlaneManualApp.h
+++ b/src/avitab/apps/PlaneManualApp.h
@@ -22,6 +22,7 @@
 #include "App.h"
 #include "src/platform/Platform.h"
 #include "src/gui_toolkit/widgets/MessageBox.h"
+#include "components/FilesysBrowser.h"
 
 namespace avitab {
 
@@ -34,6 +35,7 @@ private:
     std::string currentAircraft;
     std::shared_ptr<MessageBox> errorMsg;
     std::string currentPath;
+    FilesystemBrowser fsBrowser;
     std::shared_ptr<App> childApp;
 
     void showFileSelect();

--- a/src/avitab/apps/components/CMakeLists.txt
+++ b/src/avitab/apps/components/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(avitab_common PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/FilesysBrowser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileSelect.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileChooser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/PDFViewer.cpp

--- a/src/avitab/apps/components/FileChooser.h
+++ b/src/avitab/apps/components/FileChooser.h
@@ -22,44 +22,45 @@
 #include <functional>
 #include <vector>
 #include <string>
-#include <regex>
 #include "src/avitab/apps/App.h"
 #include "src/gui_toolkit/widgets/Window.h"
 #include "src/gui_toolkit/widgets/List.h"
 #include "src/platform/Platform.h"
 #include "src/gui_toolkit/widgets/Container.h"
+#include "FilesysBrowser.h"
 
 namespace avitab {
 
 class FileChooser {
+    // dialog to allow choosing of file with name filtering
+    // or choosing of directory (navigation not possible, is this intended?)
+    // currently used by MapApp only
 public:
     using CancelCallback = std::function<void(void)>;
     using SelectCallback = std::function<void(const std::string &)>;
 
-    FileChooser(App::FuncsPtr appFunctions);
+    FileChooser(App::FuncsPtr appFunctions, const std::string &prefix, bool dirSelect = false);
 
     void setCancelCallback(CancelCallback cb);
     void setSelectCallback(SelectCallback cb);
     void setFilterRegex(const std::string &regex);
     void setBaseDirectory(const std::string &path);
-    void setDirectorySelect(bool dirSel);
-    void show(std::shared_ptr<Container> parent, const std::string &caption);
+    void show(std::shared_ptr<Container> parent);
 private:
     App::FuncsPtr api{};
-    bool selectDirOnly = false;
+    const std::string captionPrefix;
+    const bool selectDirOnly;
     std::shared_ptr<Window> window;
     std::shared_ptr<List> list;
 
     CancelCallback onCancel;
     SelectCallback onSelect;
 
+    FilesystemBrowser fsBrowser;
     std::vector<platform::DirEntry> currentEntries;
-    std::string basePath;
-    std::regex filterRegex;
 
-    void showDirectory(const std::string &path);
-    void filterEntries();
-    void sortEntries();
+    void showDirectory();
+    void removeFiles();
     void showCurrentEntries();
     void onListSelect(int data);
     void upOneDirectory();

--- a/src/avitab/apps/components/FileSelect.h
+++ b/src/avitab/apps/components/FileSelect.h
@@ -20,34 +20,36 @@
 
 #include <functional>
 #include <string>
-#include <regex>
 #include "src/avitab/apps/App.h"
 #include "src/gui_toolkit/widgets/Window.h"
 #include "src/gui_toolkit/widgets/List.h"
 #include "src/platform/Platform.h"
+#include "FilesysBrowser.h"
 
 namespace avitab {
 
 class FileSelect: public App {
+    // dialog to allow choosing of file with name filtering
+    // currently used by PlaneManualApp only
 public:
     using SelectCallback = std::function<void(const std::vector<platform::DirEntry> &, size_t)>;
 
     FileSelect(FuncsPtr appFuncs);
+    void setPrefix(const std::string &prefix);
     void setSelectCallback(SelectCallback cb);
+    void setDirectory(const std::string &dir);
     void setFilterRegex(const std::string regex);
-    void showDirectory(const std::string &path);
+    void showDirectory();
     std::string getCurrentPath();
 private:
+    std::string captionPrefix;
     std::shared_ptr<Window> window;
     std::shared_ptr<List> list;
 
-    std::regex filter;
-    std::string currentPath;
+    FilesystemBrowser fsBrowser;
     std::vector<platform::DirEntry> currentEntries;
     SelectCallback selectCallback;
 
-    void filterEntries();
-    void sortEntries();
     void showCurrentEntries();
     void onDown();
     void onUp();

--- a/src/avitab/apps/components/FilesysBrowser.cpp
+++ b/src/avitab/apps/components/FilesysBrowser.cpp
@@ -27,7 +27,7 @@ FilesystemBrowser::FilesystemBrowser(const std::string &path) {
             cwd = platform::realPath(platform::getProgramPath());
         }
     } catch (...) {
-        cwd = platform::fsRoot();
+        cwd = platform::FS_ROOT;
     }
 }
 
@@ -35,7 +35,7 @@ FilesystemBrowser::FilesystemBrowser() {
     try {
         cwd = platform::realPath(platform::getProgramPath());
     } catch (...) {
-        cwd = platform::fsRoot();
+        cwd = platform::FS_ROOT;
     }
 }
 
@@ -45,18 +45,18 @@ void FilesystemBrowser::goUp() {
         if (validate(up)) {
             cwd = up;
         } else {
-            cwd = platform::fsRoot();
+            cwd = platform::FS_ROOT;
         }
     } catch (...) {
         // if going up fails, go to the filesystem root!
-        cwd = platform::fsRoot();
+        cwd = platform::FS_ROOT;
     }
 }
 
 void FilesystemBrowser::goDown(const std::string &sdir) {
     try {
         std::string down;
-        if (cwd != platform::fsRoot()) {
+        if (cwd != platform::FS_ROOT) {
             down = platform::realPath(cwd + "/" + sdir);
         } else {
             down = platform::realPath(cwd + sdir + "/");
@@ -85,8 +85,8 @@ void FilesystemBrowser::setFilter(const std::string &regex) {
 }
 
 std::string FilesystemBrowser::path(bool addSeparator) {
-    if (addSeparator && (cwd.back() != platform::fsSep())) {
-        return cwd + platform::fsSep();
+    if (addSeparator && (cwd.back() != platform::FS_SEP)) {
+        return cwd + platform::FS_SEP;
     }
     return cwd;
 }
@@ -102,7 +102,7 @@ std::vector<platform::DirEntry> FilesystemBrowser::entries(bool applyFilter, boo
     items.clear();
     try {
         items = platform::readDirectory(cwd);
-        if (applyFilter) { 
+        if (applyFilter) {
             filterEntries();
         }
         if (sort) {

--- a/src/avitab/apps/components/FilesysBrowser.cpp
+++ b/src/avitab/apps/components/FilesysBrowser.cpp
@@ -1,0 +1,153 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "FilesysBrowser.h"
+#include "src/Logger.h"
+
+namespace avitab {
+
+FilesystemBrowser::FilesystemBrowser(const std::string &path) {
+    try {
+        cwd = platform::realPath(path);
+        if (!validate(cwd)) {
+            cwd = platform::realPath(platform::getProgramPath());
+        }
+    } catch (...) {
+        cwd = platform::fsRoot();
+    }
+}
+
+FilesystemBrowser::FilesystemBrowser() {
+    try {
+        cwd = platform::realPath(platform::getProgramPath());
+    } catch (...) {
+        cwd = platform::fsRoot();
+    }
+}
+
+void FilesystemBrowser::goUp() {
+    try {
+        std::string up(platform::realPath(platform::parentPath(cwd)));
+        if (validate(up)) {
+            cwd = up;
+        } else {
+            cwd = platform::fsRoot();
+        }
+    } catch (...) {
+        // if going up fails, go to the filesystem root!
+        cwd = platform::fsRoot();
+    }
+}
+
+void FilesystemBrowser::goDown(const std::string &sdir) {
+    try {
+        std::string down;
+        if (cwd != platform::fsRoot()) {
+            down = platform::realPath(cwd + "/" + sdir);
+        } else {
+            down = platform::realPath(cwd + sdir + "/");
+        }
+        if (validate(down)) {
+            cwd = down;
+        }
+    } catch (...) {
+        // leave current directory unchanged
+    }
+}
+
+void FilesystemBrowser::goTo(const std::string &tdir) {
+    try {
+        std::string target(platform::realPath(tdir));
+        if (validate(target)) {
+            cwd = target;
+        }
+    } catch (...) {
+        // leave current directory unchanged
+    }
+}
+
+void FilesystemBrowser::setFilter(const std::string &regex) {
+    filterRegex = std::regex(regex, std::regex_constants::ECMAScript | std::regex_constants::icase);
+}
+
+std::string FilesystemBrowser::path(bool addSeparator) {
+    if (addSeparator && (cwd.back() != platform::fsSep())) {
+        return cwd + platform::fsSep();
+    }
+    return cwd;
+}
+
+std::string FilesystemBrowser::rtrimmed(const size_t max) {
+    if (cwd.size() <= max) {
+        return cwd;
+    }
+    return std::string("...") + cwd.substr(cwd.size() - (max - 3));
+}
+
+std::vector<platform::DirEntry> FilesystemBrowser::entries(bool applyFilter, bool sort) {
+    items.clear();
+    try {
+        items = platform::readDirectory(cwd);
+        if (applyFilter) { 
+            filterEntries();
+        }
+        if (sort) {
+            sortEntries();
+        }
+    } catch (const std::exception &e) {
+        logger::verbose("Couldn't read directory %s: %s", cwd.c_str(), e.what());
+    }
+
+    return items;
+}
+
+bool FilesystemBrowser::validate(const std::string &path) {
+    try {
+        return platform::fileExists(path);
+    } catch (const std::exception &e) {
+        logger::verbose("validate(%s) failed: %s", path.c_str(), e.what());
+    }
+    return false;
+}
+
+void FilesystemBrowser::filterEntries() {
+    auto iter = std::remove_if(std::begin(items), std::end(items), [this] (const auto &a) -> bool {
+        if (a.isDirectory) {
+            return false;
+        }
+        return !std::regex_search(a.utf8Name, filterRegex);
+    });
+    items.erase(iter, std::end(items));
+}
+
+void FilesystemBrowser::sortEntries() {
+    auto comparator = [] (const platform::DirEntry &a, const platform::DirEntry &b) -> bool {
+        if (a.isDirectory && !b.isDirectory) {
+            return true;
+        }
+
+        if (!a.isDirectory && b.isDirectory) {
+            return false;
+        }
+
+        return a.utf8Name < b.utf8Name;
+    };
+
+    std::sort(begin(items), end(items), comparator);
+}
+
+}

--- a/src/avitab/apps/components/FilesysBrowser.h
+++ b/src/avitab/apps/components/FilesysBrowser.h
@@ -1,0 +1,55 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_AVITAB_APPS_COMPONENTS_FILESYSBROWSER_H_
+#define SRC_AVITAB_APPS_COMPONENTS_FILESYSBROWSER_H_
+
+#include <vector>
+#include <string>
+#include <regex>
+#include "src/platform/Platform.h"
+
+namespace avitab {
+
+class FilesystemBrowser {
+public:
+    FilesystemBrowser(const std::string &path);
+    FilesystemBrowser();
+
+    void goUp();
+    void goDown(const std::string &sdir);
+    void goTo(const std::string &tdir);
+
+    void setFilter(const std::string &regex);
+
+    std::string path(bool addSeparator = true);
+    std::string rtrimmed(const size_t max);
+    std::vector<platform::DirEntry> entries(bool applyFilter = true, bool sort = true);
+
+private:
+    bool validate(const std::string &path);
+    void filterEntries();
+    void sortEntries();
+
+    std::string cwd;
+    std::regex filterRegex;
+    std::vector<platform::DirEntry> items;
+};
+
+} /* namespace avitab */
+
+#endif /* SRC_AVITAB_APPS_COMPONENTS_FILESYSBROWSER_H_ */

--- a/src/avitab/apps/components/PDFViewer.cpp
+++ b/src/avitab/apps/components/PDFViewer.cpp
@@ -51,21 +51,6 @@ void PDFViewer::showFile(const std::string& nameUtf8) {
     loadCurrentFile();
 }
 
-void PDFViewer::showDirectory(const std::string &dirPath, const std::vector<platform::DirEntry> &entries, size_t chosenIndex) {
-    fileNames.clear();
-
-    for (size_t i = 0; i < entries.size(); i++) {
-        if (i == chosenIndex) {
-            fileIndex = fileNames.size();
-        }
-        if (!entries[i].isDirectory) {
-            fileNames.push_back(dirPath + entries[i].utf8Name);
-        }
-    }
-
-    loadCurrentFile();
-}
-
 void PDFViewer::loadCurrentFile() {
     if (fileIndex >= fileNames.size()) {
         throw std::runtime_error("File index out of range");

--- a/src/avitab/apps/components/PDFViewer.h
+++ b/src/avitab/apps/components/PDFViewer.h
@@ -38,7 +38,6 @@ class PDFViewer: public App {
 public:
     PDFViewer(FuncsPtr appFuncs);
     void showFile(const std::string &nameUtf8);
-    void showDirectory(const std::string &dirPath, const std::vector<platform::DirEntry> &entries, size_t chosenIndex);
     void onMouseWheel(int dir, int x, int y) override;
 private:
     std::shared_ptr<maps::OverlayConfig> overlays;

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -148,7 +148,7 @@ std::vector<DirEntry> readDirectory(const std::string& utf8Path) {
 #ifdef _WIN32
     // this fragment deals with a notional filesystem root directory which allows
     // traversal to other drives
-    if (utf8Path.empty()) {
+    if (utf8Path == FS_ROOT) {
         auto ldbitmap = GetLogicalDrives();
         std::string drive("A:");
         while (ldbitmap) {
@@ -193,7 +193,7 @@ std::string parentPath(const std::string &utf8Path) {
     auto here_clean = fs::canonical(path).string();
 #ifdef _WIN32
     if (here_clean.back() == '\\') {    // drive root directory
-        return "";    // notional filesystem root containing all drives
+        return FS_ROOT;    // notional filesystem root containing all drives
     }
     auto parent = fs::u8path(here_clean + "\\..");
     return fs::canonical(parent).string() + "\\";

--- a/src/platform/Platform.h
+++ b/src/platform/Platform.h
@@ -86,20 +86,13 @@ int getElapsedMillis(std::chrono::time_point<std::chrono::steady_clock> startAt)
 constexpr size_t getMaxPathLen();
 std::string UTF8ToACP(const std::string &utf8);
 
-constexpr const char *fsRoot() {
 #ifdef _WIN32
-    return "";
+constexpr const char *FS_ROOT = "";
+constexpr const char FS_SEP = '\\';
 #else
-    return "/";
+constexpr const char *FS_ROOT = "/";
+constexpr const char FS_SEP = '/';
 #endif
-}
-constexpr const char fsSep() {
-#ifdef _WIN32
-    return '\\';
-#else
-    return '/';
-#endif
-}
 
 std::string getProgramPath();
 std::vector<DirEntry> readDirectory(const std::string &utf8Path);

--- a/src/platform/Platform.h
+++ b/src/platform/Platform.h
@@ -86,8 +86,24 @@ int getElapsedMillis(std::chrono::time_point<std::chrono::steady_clock> startAt)
 constexpr size_t getMaxPathLen();
 std::string UTF8ToACP(const std::string &utf8);
 
+constexpr const char *fsRoot() {
+#ifdef _WIN32
+    return "";
+#else
+    return "/";
+#endif
+}
+constexpr const char fsSep() {
+#ifdef _WIN32
+    return '\\';
+#else
+    return '/';
+#endif
+}
+
 std::string getProgramPath();
 std::vector<DirEntry> readDirectory(const std::string &utf8Path);
+std::string parentPath(const std::string &utf8Path);
 std::string realPath(const std::string &utf8Path);
 std::string getFileNameFromPath(const std::string &utf8Path);
 std::string getDirNameFromPath(const std::string &utf8Path);


### PR DESCRIPTION
New FilesysBrowser class to manage current path and navigation.
Replace App's self-managed navigation with FilesysBrowser class.
Add support for changing to other drives in Windows.
Add display of current path in file selector dialogs.

This is a better structured and more comprehensive version of the previous (cancelled) pull request. I have tested this on Windows only. There is some platform conditional code, but I have not been able to test the non-Windows variant.