### PR TITLE
Enhance Charts app PDF viewing when moving between pages or rotating.

### DIFF
--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -174,6 +174,13 @@ void ChartsApp::createPdfTab(const std::string &pdfPath) {
 
     pages.push_back(tab);
     tabs->showTab(page);
+
+    if (tab.stitcher->getPageCount() > 1) {
+        positionPage(tab, ALIGN_TOP, ALIGN_MIDDLE, FIT_WIDTH);
+    } else {
+        positionPage(tab, ALIGN_CENTRE, ALIGN_MIDDLE, FIT_ALL);
+    }
+
 }
 
 void ChartsApp::removeTab(std::shared_ptr<Page> page) {
@@ -248,16 +255,24 @@ void ChartsApp::onPan(int x, int y, bool start, bool end) {
 void ChartsApp::onNextPage() {
     PdfPage *tab = getActivePdfPage();
     if (tab && tab->source) {
-        tab->stitcher->nextPage();
-        setTitle(*tab);
+        if (tab->stitcher->nextPage()) {
+            setTitle(*tab);
+            positionPage(*tab, ALIGN_TOP, ALIGN_MIDDLE);
+        } else {
+            positionPage(*tab, ALIGN_BOTTOM, ALIGN_MIDDLE);
+        }
     }
 }
 
 void ChartsApp::onPrevPage() {
     PdfPage *tab = getActivePdfPage();
     if (tab && tab->source) {
-        tab->stitcher->prevPage();
-        setTitle(*tab);
+        if (tab->stitcher->prevPage()) {
+            setTitle(*tab);
+            positionPage(*tab, ALIGN_BOTTOM, ALIGN_MIDDLE);
+        } else {
+            positionPage(*tab, ALIGN_TOP, ALIGN_MIDDLE);
+        }
     }
 }
 
@@ -279,6 +294,11 @@ void ChartsApp::onRotate() {
     PdfPage *tab = getActivePdfPage();
     if (tab && tab->stitcher) {
         tab->stitcher->rotateRight();
+        if (tab->stitcher->getPageCount() > 1) {
+            positionPage(*tab, ALIGN_TOP, ALIGN_MIDDLE);
+        } else {
+            positionPage(*tab, ALIGN_CENTRE, ALIGN_MIDDLE, FIT_ALL);
+        }
     }
 }
 
@@ -305,6 +325,50 @@ void ChartsApp::onMouseWheel(int dir, int x, int y) {
             onDown();
         }
     }
+}
+
+void ChartsApp::positionPage(PdfPage &tab, VerticalPosition vp, HorizontalPosition hp, ZoomAdjust za) {
+    auto doc = std::dynamic_pointer_cast<img::ChartTileSource>(tab.stitcher->getTileSource());
+    if (!doc) return;
+
+    img::Point<int> aperturexy{tab.pixMap->getWidth(), tab.pixMap->getHeight()};
+    auto angle = tab.stitcher->getRotation();
+
+    // set the required zoom
+    if (za != NO_CHANGE) {
+        // start with maximal zoom, and then zoom out until all criteria are met
+        int z  = doc->getMaxZoomLevel();
+        while (z > doc->getMinZoomLevel()) {
+            // iterative loop could be optimised to binary search
+            auto pagexy = doc->getPageDimensions(tab.stitcher->getCurrentPage(), z);
+            if ((angle == 90) || (angle == 270)) std::swap(pagexy.x, pagexy.y);
+            bool fitsWidth = (za == FIT_HEIGHT) ? true : (pagexy.x <= aperturexy.x);
+            bool fitsHeight = (za == FIT_WIDTH) ? true : (pagexy.y <= aperturexy.y);
+            if (fitsWidth && fitsHeight) break;
+            --z;
+        }
+        tab.stitcher->setZoomLevel(z);
+    }
+
+    // now adjust the tile centre to align as requested
+    auto zoomNow = tab.map->getZoomLevel();
+    auto tilexy = tab.stitcher->getTileSource()->getTileDimensions(zoomNow);
+    auto pagexy = doc->getPageDimensions(tab.stitcher->getCurrentPage(), zoomNow);
+    float cx = 0.0, cy = 0.0;
+    if (angle == 0) {
+        cx = (hp == ALIGN_LEFT) ? (aperturexy.x / 2) : ((hp == ALIGN_RIGHT) ? (pagexy.x - (aperturexy.x / 2)) : (pagexy.x / 2));
+        cy = (vp == ALIGN_TOP) ? (aperturexy.y / 2) : ((vp == ALIGN_BOTTOM) ? (pagexy.y - (aperturexy.y / 2)) : (pagexy.y / 2));
+    } else if (angle == 90) {
+        cx = (vp == ALIGN_TOP) ? (aperturexy.y / 2) : ((vp == ALIGN_BOTTOM) ? (pagexy.x - (aperturexy.y / 2)) : (pagexy.x / 2));
+        cy = (hp == ALIGN_LEFT) ? (pagexy.y - (aperturexy.x / 2)) : ((hp == ALIGN_RIGHT) ? (aperturexy.x / 2) : (pagexy.y / 2));
+    } else if (angle == 180) {
+        cx = (hp == ALIGN_LEFT) ? (pagexy.x - (aperturexy.x / 2)) : ((hp == ALIGN_RIGHT) ? (aperturexy.x / 2) : (pagexy.x / 2));
+        cy = (vp == ALIGN_TOP) ? (pagexy.y - (aperturexy.y / 2)) : ((vp == ALIGN_BOTTOM) ? (aperturexy.y / 2) : (pagexy.y / 2));
+    } else if (angle == 270) {
+        cx = (vp == ALIGN_TOP) ? (pagexy.x - (aperturexy.y / 2)) : ((vp == ALIGN_BOTTOM) ? (aperturexy.y / 2) : (pagexy.x / 2));
+        cy = (hp == ALIGN_LEFT) ? (aperturexy.x / 2) : ((hp == ALIGN_RIGHT) ? (pagexy.y - (aperturexy.x / 2)) : (pagexy.y / 2));
+    }
+    tab.stitcher->setCenter((float)cx / tilexy.x, (float)cy / tilexy.y);
 }
 
 } /* namespace avitab */

--- a/src/avitab/apps/ChartsApp.h
+++ b/src/avitab/apps/ChartsApp.h
@@ -93,10 +93,10 @@ private:
     void onPan(int x, int y, bool start, bool end);
     bool onTimer();
 
-    enum VerticalPosition { ALIGN_TOP, ALIGN_CENTRE, ALIGN_BOTTOM };
-    enum HorizontalPosition { ALIGN_LEFT, ALIGN_MIDDLE, ALIGN_RIGHT };
-    enum ZoomAdjust { NO_CHANGE, FIT_HEIGHT, FIT_WIDTH, FIT_ALL };
-    void positionPage(PdfPage &tab, VerticalPosition vp, HorizontalPosition hp, ZoomAdjust za = NO_CHANGE);
+    enum class VerticalPosition { Top, Centre, Bottom };
+    enum class HorizontalPosition { Left, Middle, Right };
+    enum class ZoomAdjust { None, Height, Width, All };
+    void positionPage(PdfPage &tab, VerticalPosition vp, HorizontalPosition hp, ZoomAdjust za = ZoomAdjust::None);
 };
 
 } /* namespace avitab */

--- a/src/avitab/apps/ChartsApp.h
+++ b/src/avitab/apps/ChartsApp.h
@@ -92,6 +92,11 @@ private:
     void onRotate();
     void onPan(int x, int y, bool start, bool end);
     bool onTimer();
+
+    enum VerticalPosition { ALIGN_TOP, ALIGN_CENTRE, ALIGN_BOTTOM };
+    enum HorizontalPosition { ALIGN_LEFT, ALIGN_MIDDLE, ALIGN_RIGHT };
+    enum ZoomAdjust { NO_CHANGE, FIT_HEIGHT, FIT_WIDTH, FIT_ALL };
+    void positionPage(PdfPage &tab, VerticalPosition vp, HorizontalPosition hp, ZoomAdjust za = NO_CHANGE);
 };
 
 } /* namespace avitab */

--- a/src/libimg/stitcher/Stitcher.cpp
+++ b/src/libimg/stitcher/Stitcher.cpp
@@ -59,20 +59,24 @@ img::Point<double> Stitcher::getCenter() const {
     return img::Point<double>{centerX, centerY};
 }
 
-void Stitcher::nextPage() {
+bool Stitcher::nextPage() {
     if (page + 1 < tileSource->getPageCount()) {
         page++;
         tileCache.cancelPendingRequests();
         updateImage();
+        return true;
     }
+    return false;
 }
 
-void Stitcher::prevPage() {
+bool Stitcher::prevPage() {
     if (page > 0) {
         page--;
         tileCache.cancelPendingRequests();
         updateImage();
+        return true;
     }
+    return false;
 }
 
 int Stitcher::getPageCount() const {
@@ -146,6 +150,10 @@ void Stitcher::convertSourceImageToRenderedCoords(int &x, int &y) {
     int offsetY = unrotatedCentreY - dstCentreY;
     x += offsetX;
     y += offsetY;
+}
+
+int Stitcher::getRotation() const {
+    return rotAngle;
 }
 
 void Stitcher::rotateRight() {

--- a/src/libimg/stitcher/Stitcher.h
+++ b/src/libimg/stitcher/Stitcher.h
@@ -41,8 +41,8 @@ public:
 
     int getCurrentPage() const;
     int getPageCount() const;
-    void nextPage();
-    void prevPage();
+    bool nextPage();
+    bool prevPage();
 
     void pan(int dx, int dy);
     void setZoomLevel(int level);
@@ -52,6 +52,7 @@ public:
     void updateImage();
     void doWork();
 
+    int getRotation() const;
     void rotateRight();
 
     std::shared_ptr<Image> getPreRotatedImage();

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -46,6 +46,7 @@ public:
 
     // Query and load tile information
     virtual int getPageCount() = 0;
+    virtual Point<int> getPageDimensions(int page, int zoom) = 0;
     virtual bool isTileValid(int page, int x, int y, int zoom) = 0;
     virtual std::string getUniqueTileName(int page, int x, int y, int zoom) = 0;
     virtual std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) = 0;
@@ -60,12 +61,6 @@ public:
     virtual std::string getCopyrightInfo() { return ""; }
 
     virtual ~TileSource() = default;
-};
-
-class ChartTileSource : public TileSource {
-public:
-    virtual Point<int> getPageDimensions(int page, int zoom) = 0;
-
 };
 
 }

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -62,6 +62,12 @@ public:
     virtual ~TileSource() = default;
 };
 
+class ChartTileSource : public TileSource {
+public:
+    virtual Point<int> getPageDimensions(int page, int zoom) = 0;
+
+};
+
 }
 
 #endif /* SRC_LIBIMG_STITCHER_TILESOURCE_H_ */

--- a/src/maps/sources/EPSGSource.cpp
+++ b/src/maps/sources/EPSGSource.cpp
@@ -90,6 +90,10 @@ int EPSGSource::getPageCount() {
     return 1;
 }
 
+img::Point<int> EPSGSource::getPageDimensions(int page, int zoom) {
+    return img::Point<int>{0, 0};
+}
+
 bool EPSGSource::isTileValid(int page, int x, int y, int zoom) {
     if (page != 0) {
         return false;

--- a/src/maps/sources/EPSGSource.h
+++ b/src/maps/sources/EPSGSource.h
@@ -43,6 +43,7 @@ public:
 
     // Query and load tile information
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;

--- a/src/maps/sources/GeoTIFFSource.cpp
+++ b/src/maps/sources/GeoTIFFSource.cpp
@@ -90,6 +90,11 @@ int GeoTIFFSource::getPageCount() {
     return 1;
 }
 
+img::Point<int> GeoTIFFSource::getPageDimensions(int page, int zoom) {
+    auto scale = zoomToScale(zoom);
+    return img::Point<int>{(int)(scale * tiff.getFullWidth()), (int)(scale * tiff.getFullHeight())};
+}
+
 bool GeoTIFFSource::isTileValid(int page, int x, int y, int zoom) {
     if (page != 0) {
         return false;

--- a/src/maps/sources/GeoTIFFSource.h
+++ b/src/maps/sources/GeoTIFFSource.h
@@ -40,6 +40,7 @@ public:
     img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) override;
 
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;

--- a/src/maps/sources/ImageSource.cpp
+++ b/src/maps/sources/ImageSource.cpp
@@ -168,4 +168,9 @@ img::Point<double> ImageSource::xyToWorld(double x, double y, int zoom) {
     return calibration.pixelsToWorld(normX, normY);
 }
 
+img::Point<int> ImageSource::getPageDimensions(int page, int zoom) {
+    auto scale = zoomToScale(zoom);
+    return img::Point<int>{(int)(scale * image->getWidth()), (int)(scale * image->getHeight())};
+}
+
 } /* namespace maps */

--- a/src/maps/sources/ImageSource.h
+++ b/src/maps/sources/ImageSource.h
@@ -26,7 +26,7 @@
 
 namespace maps {
 
-class ImageSource: public img::ChartTileSource {
+class ImageSource: public img::TileSource {
 public:
     ImageSource(std::shared_ptr<img::Image> image);
 
@@ -39,6 +39,7 @@ public:
     img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) override;
 
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;
@@ -51,7 +52,6 @@ public:
     img::Point<double> worldToXY(double lon, double lat, int zoom) override;
     img::Point<double> xyToWorld(double x, double y, int zoom) override;
 
-    img::Point<int> getPageDimensions(int page, int zoom) override;
 private:
     static constexpr const int TILE_SIZE = 256;
     std::shared_ptr<img::Image> image;

--- a/src/maps/sources/ImageSource.h
+++ b/src/maps/sources/ImageSource.h
@@ -26,7 +26,7 @@
 
 namespace maps {
 
-class ImageSource: public img::TileSource {
+class ImageSource: public img::ChartTileSource {
 public:
     ImageSource(std::shared_ptr<img::Image> image);
 
@@ -50,6 +50,8 @@ public:
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
     img::Point<double> worldToXY(double lon, double lat, int zoom) override;
     img::Point<double> xyToWorld(double x, double y, int zoom) override;
+
+    img::Point<int> getPageDimensions(int page, int zoom) override;
 private:
     static constexpr const int TILE_SIZE = 256;
     std::shared_ptr<img::Image> image;

--- a/src/maps/sources/NavigraphSource.cpp
+++ b/src/maps/sources/NavigraphSource.cpp
@@ -99,6 +99,10 @@ int NavigraphSource::getPageCount() {
     return 1;
 }
 
+img::Point<int> NavigraphSource::getPageDimensions(int page, int zoom) {
+    return img::Point<int>{0, 0};
+}
+
 bool NavigraphSource::isTileValid(int page, int x, int y, int zoom) {
     if (page != 0) {
         return false;

--- a/src/maps/sources/NavigraphSource.h
+++ b/src/maps/sources/NavigraphSource.h
@@ -43,6 +43,7 @@ public:
 
     // Query and load tile information
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;

--- a/src/maps/sources/OpenTopoSource.cpp
+++ b/src/maps/sources/OpenTopoSource.cpp
@@ -95,6 +95,10 @@ int OpenTopoSource::getPageCount() {
     return 1;
 }
 
+img::Point<int> OpenTopoSource::getPageDimensions(int page, int zoom) {
+    return img::Point<int>{0, 0};
+}
+
 bool OpenTopoSource::isTileValid(int page, int x, int y, int zoom) {
     if (page != 0) {
         return false;

--- a/src/maps/sources/OpenTopoSource.h
+++ b/src/maps/sources/OpenTopoSource.h
@@ -42,6 +42,7 @@ public:
 
     // Query and load tile information
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getTileURL(bool randomHost, int x, int y, int zoom);
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;

--- a/src/maps/sources/PDFSource.cpp
+++ b/src/maps/sources/PDFSource.cpp
@@ -138,6 +138,10 @@ void PDFSource::attachCalibration2(double x, double y, double lat, double lon, i
     }
 }
 
+img::Point<int> PDFSource::getPageDimensions(int page, int zoom) {
+    return img::Point<int>{rasterizer.getPageWidth(page, zoom), rasterizer.getPageHeight(page, zoom)};
+}
+
 img::Point<double> PDFSource::worldToXY(double lon, double lat, int zoom) {
     int tileSize = rasterizer.getTileSize();
 

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -27,7 +27,7 @@
 
 namespace maps {
 
-class PDFSource: public img::TileSource {
+class PDFSource: public img::ChartTileSource {
 public:
     PDFSource(const std::string &file);
     PDFSource(const std::vector<uint8_t> &pdfData);
@@ -52,6 +52,8 @@ public:
 
     void attachCalibration1(double x, double y, double lat, double lon, int zoom) override;
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
+
+    img::Point<int> getPageDimensions(int page, int zoom) override;
 
     void setNightMode(bool night);
     void rotate();

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -27,7 +27,7 @@
 
 namespace maps {
 
-class PDFSource: public img::ChartTileSource {
+class PDFSource: public img::TileSource {
 public:
     PDFSource(const std::string &file);
     PDFSource(const std::vector<uint8_t> &pdfData);
@@ -40,6 +40,7 @@ public:
     img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) override;
 
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;
@@ -52,8 +53,6 @@ public:
 
     void attachCalibration1(double x, double y, double lat, double lon, int zoom) override;
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
-
-    img::Point<int> getPageDimensions(int page, int zoom) override;
 
     void setNightMode(bool night);
     void rotate();

--- a/src/maps/sources/XPlaneSource.cpp
+++ b/src/maps/sources/XPlaneSource.cpp
@@ -70,6 +70,10 @@ int XPlaneSource::getPageCount() {
     return 1;
 }
 
+img::Point<int> XPlaneSource::getPageDimensions(int page, int zoom) {
+    return img::Point<int>{0, 0};
+}
+
 bool XPlaneSource::isTileValid(int page, int x, int y, int zoom) {
     if (page != 0) {
         return false;

--- a/src/maps/sources/XPlaneSource.h
+++ b/src/maps/sources/XPlaneSource.h
@@ -35,6 +35,7 @@ public:
     img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) override;
 
     int getPageCount() override;
+    img::Point<int> getPageDimensions(int page, int zoom) override;
     bool isTileValid(int page, int x, int y, int zoom) override;
     std::string getUniqueTileName(int page, int x, int y, int zoom) override;
     std::unique_ptr<img::Image> loadTileImage(int page, int x, int y, int zoom) override;


### PR DESCRIPTION
When opening single page PDFs and images these will be zoomed to fit and
aligned centrally.
Multiple page docs will be zoomed to fit width of first page and aligned
at the top (in the middle).
When moving to the next page this will be aligned at the top to assist
continuity if reading. Similarly, when moving to the previous page this
will be aligned at the bottom.
After rotation the page will be aligned centrally for single page documents,
or at the top for multiple page docs.