### PR TITLE
Support mouse-wheel scrolling of pages in multi-page documentation

### DIFF
--- a/src/avitab/apps/ChartsApp.h
+++ b/src/avitab/apps/ChartsApp.h
@@ -28,6 +28,9 @@
 #include "src/gui_toolkit/widgets/Window.h"
 #include "src/gui_toolkit/widgets/List.h"
 #include "src/gui_toolkit/widgets/PixMap.h"
+#include "src/gui_toolkit/widgets/Checkbox.h"
+#include "src/gui_toolkit/widgets/Container.h"
+#include "src/gui_toolkit/widgets/Label.h"
 #include "src/gui_toolkit/Timer.h"
 #include "src/libimg/Image.h"
 #include "src/libimg/stitcher/Stitcher.h"
@@ -62,6 +65,7 @@ private:
     void sortEntries();
     void showCurrentEntries();
     void upOneDirectory();
+    void onSettingsToggle(bool forceClose = false);
     void onDown();
     void onUp();
     void onSelect(int data);
@@ -89,9 +93,18 @@ private:
     void onPrevPage();
     void onPlus();
     void onMinus();
+    void onScrollUp();
+    void onScrollDown();
     void onRotate();
     void onPan(int x, int y, bool start, bool end);
     bool onTimer();
+
+
+    Settings::PdfReadingConfig  settings;
+    std::shared_ptr<Container> settingsContainer;
+    std::shared_ptr<Label> settingsLabel;
+    std::shared_ptr<Checkbox> mouseWheelScrollsCheckbox;
+    void showAppSettings();
 };
 
 } /* namespace avitab */

--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -47,7 +47,7 @@ Settings::Settings(const std::string &settingsFile)
 Settings::~Settings()
 {
     try {
-        save();
+        saveAll();
     } catch (...) {
         // can't rescue the process at this point
     }
@@ -151,6 +151,14 @@ void Settings::saveOverlayConfig() {
     setSetting("/overlay/colors/other_aircraft/above", colorIntToString(overlayConfig->colorOtherAircraftAbove));
 }
 
+void Settings::loadPdfReadingConfig(const std::string appName, PdfReadingConfig &config) {
+    config.mouseWheelScrollsMultiPage = getSetting("/" + appName + "/pdfreading/mousewheelscroll", false);
+}
+
+void Settings::savePdfReadingConfig(const std::string appName, PdfReadingConfig &config) {
+    setSetting("/" + appName + "/pdfreading/mousewheelscroll", config.mouseWheelScrollsMultiPage);
+}
+
 void Settings::upgrade() {
     // handle older json databases which have subsequently been updated
 #if 0 // example idea for this code
@@ -164,7 +172,7 @@ void Settings::upgrade() {
 #endif
 }
 
-void Settings::save() {
+void Settings::saveAll() {
     try {
         saveOverlayConfig();
         fs::ofstream fout(fs::u8path(filePath));

--- a/src/environment/Settings.h
+++ b/src/environment/Settings.h
@@ -37,6 +37,14 @@ public:
 
     std::shared_ptr<maps::OverlayConfig> getOverlayConfig();
 
+    struct PdfReadingConfig {
+        bool mouseWheelScrollsMultiPage = false;
+    };
+    void loadPdfReadingConfig(const std::string appName, PdfReadingConfig &config);
+    void savePdfReadingConfig(const std::string appName, PdfReadingConfig &config);
+
+    void saveAll();
+
 private:
     void init();
     void upgrade();

--- a/src/gui_toolkit/widgets/TabGroup.cpp
+++ b/src/gui_toolkit/widgets/TabGroup.cpp
@@ -30,6 +30,18 @@ TabGroup::TabGroup(WidgetPtr parent):
     setObj(tabs);
 }
 
+void TabGroup::setCallback(TabChangeCallback cb) {
+    callbackFunc = cb;
+    lv_obj_set_user_data(obj(), this);
+
+    lv_obj_set_event_cb(obj(), [] (lv_obj_t *obj, lv_event_t ev) {
+        if (ev == LV_EVENT_VALUE_CHANGED) {
+            TabGroup *me = reinterpret_cast<TabGroup *>(lv_obj_get_user_data(obj));
+            me->callbackFunc();
+        }
+    });
+}
+
 std::shared_ptr<Page> TabGroup::addTab(WidgetPtr tabs, const std::string &title) {
     lv_obj_t *page = lv_tabview_add_tab(obj(), title.c_str());
 

--- a/src/gui_toolkit/widgets/TabGroup.h
+++ b/src/gui_toolkit/widgets/TabGroup.h
@@ -25,7 +25,9 @@ namespace avitab {
 
 class TabGroup: public Widget {
 public:
+    using TabChangeCallback = std::function<void()>;
     TabGroup(WidgetPtr parent);
+    void setCallback(TabChangeCallback cb);
     std::shared_ptr<Page> addTab(WidgetPtr tabs, const std::string &title);
     size_t getTabIndex(WidgetPtr tab);
     void showTab(WidgetPtr tab);
@@ -35,6 +37,7 @@ public:
     void removeTab(size_t i);
     void clear();
 private:
+    TabChangeCallback callbackFunc;
 };
 
 } /* namespace avitab */


### PR DESCRIPTION
Add a settings dialog to the Charts app and persistent setting saved
in the preferences file.
Modify the behaviour of the mouse wheel action if the setting is enabled.