### PR TITLE
Bug fix: mouse wheel scrolling should only apply to multi-paged documents

### DIFF
--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -321,10 +321,19 @@ bool ChartsApp::onTimer() {
 void ChartsApp::onMouseWheel(int dir, int x, int y) {
     auto tab = getActivePdfPage();
     if (tab) {
+        bool doScroll = settings.mouseWheelScrollsMultiPage && (tab->stitcher->getPageCount() > 1);
         if (dir > 0) {
-            if (settings.mouseWheelScrollsMultiPage) onScrollUp(); else onPlus();
+            if (doScroll) {
+                onScrollUp();
+            } else {
+                onPlus();
+            }
         } else if (dir < 0) {
-            if (settings.mouseWheelScrollsMultiPage) onScrollDown(); else onMinus();
+            if (doScroll) {
+                onScrollDown();
+             } else {
+                onMinus();
+             }
         }
     } else {  // on file select tab
         if (dir > 0) {


### PR DESCRIPTION
This was specified in discussions but missed from the implementation.
The code has been restructured slightly in anticipation of a further mouse-wheel related update.