### PR TITLE
Enhancement/fast page select

### DIFF
--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -321,10 +321,19 @@ bool ChartsApp::onTimer() {
 void ChartsApp::onMouseWheel(int dir, int x, int y) {
     auto tab = getActivePdfPage();
     if (tab) {
+        bool doScroll = settings.mouseWheelScrollsMultiPage && (tab->stitcher->getPageCount() > 1);
         if (dir > 0) {
-            if (settings.mouseWheelScrollsMultiPage) onScrollUp(); else onPlus();
+            if (doScroll) {
+                onScrollUp();
+            } else {
+                onPlus();
+            }
         } else if (dir < 0) {
-            if (settings.mouseWheelScrollsMultiPage) onScrollDown(); else onMinus();
+            if (doScroll) {
+                onScrollDown();
+             } else {
+                onMinus();
+             }
         }
     } else {  // on file select tab
         if (dir > 0) {

--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -321,19 +321,30 @@ bool ChartsApp::onTimer() {
 void ChartsApp::onMouseWheel(int dir, int x, int y) {
     auto tab = getActivePdfPage();
     if (tab) {
-        bool doScroll = settings.mouseWheelScrollsMultiPage && (tab->stitcher->getPageCount() > 1);
-        if (dir > 0) {
-            if (doScroll) {
-                onScrollUp();
-            } else {
-                onPlus();
+        int hx1, hy1, hx2, hy2;
+        tab->window->getHeaderArea(hx1, hy1, hx2, hy2);
+        bool inHeader = ((x >= hx1) && (x < hx2) && (y >= hy1) && (y < hy2));
+        if (inHeader) {
+            if (dir > 0) {
+                onPrevPage();
+            } else if (dir < 0) {
+                onNextPage();
             }
-        } else if (dir < 0) {
-            if (doScroll) {
-                onScrollDown();
-             } else {
-                onMinus();
-             }
+        } else {
+            bool doScroll = settings.mouseWheelScrollsMultiPage && (tab->stitcher->getPageCount() > 1);
+            if (dir > 0) {
+                if (doScroll) {
+                    onScrollUp();
+                } else {
+                    onPlus();
+                }
+            } else if (dir < 0) {
+                if (doScroll) {
+                    onScrollDown();
+                } else {
+                    onMinus();
+                }
+            }
         }
     } else {  // on file select tab
         if (dir > 0) {

--- a/src/gui_toolkit/widgets/Window.cpp
+++ b/src/gui_toolkit/widgets/Window.cpp
@@ -49,6 +49,16 @@ void Window::hideScrollbars() {
     lv_win_set_sb_mode(obj(), LV_SB_MODE_OFF);
 }
 
+void Window::getHeaderArea(int &x1, int &y1, int &x2, int &y2) {
+    auto area = obj()->coords;
+    x1 = area.x1;
+    y1 = area.y1;
+    x2 = area.x2;
+    lv_win_ext_t * ext = reinterpret_cast<lv_win_ext_t *>(lv_obj_get_ext_attr(obj()));
+    auto h = lv_obj_get_height(ext->header);
+    y2 = area.y1 + h;
+}
+
 int Window::getContentWidth() {
     return lv_win_get_width(obj()) - 5;
 }

--- a/src/gui_toolkit/widgets/Window.h
+++ b/src/gui_toolkit/widgets/Window.h
@@ -34,6 +34,7 @@ public:
     void setCaption(const std::string &title);
     void setOnClose(WindowCallback cb);
     void hideScrollbars();
+    void getHeaderArea(int &x1, int &y1, int &x2, int &y2);
     int getContentWidth();
     int getContentHeight();
     std::shared_ptr<Button> addSymbol(Symbol smb, WindowCallback cb);


### PR DESCRIPTION
In the Charts app when viewing multi-page documents next or previous pages can be selected by scrolling the mouse-wheel (or equivalent on the VR controller) when the pointer is over the window title (ie where the current page and total number of pages is displayed).
