### PR TITLE
Fix for incorrectly included 'version' file during Avitab build.

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -117,7 +117,9 @@ if [ ! -f $OUTDIR/lib/libgeotiff.a ]; then echo "Failed"; exit; fi
 echo "Building QuickJS..."
 if [ ! -f $OUTDIR/lib/libquickjs.a ]; then
     cd QuickJS
+    if [ -f VERSION-QuickJS ]; then mv VERSION-QuickJS VERSION ; fi
     make CC="gcc -fPIC" -j10 libquickjs.a
+    if [ -f VERSION ]; then mv VERSION VERSION-QuickJS ; fi
     cp libquickjs.a $OUTDIR/lib
     cd ..
 fi


### PR DESCRIPTION
A further update to rename the QuickJS 'VERSION' file after build so that it does not get incorrectly included instead of the C++ library <version> file when building Avitab on Mac.