### PR TITLE
Allow compiling on Apple Silicon hardware running macOS Ventura.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ but all of this is available right inside your VR cockpit.
 
 ![](screenshots/charts.jpg)
 ![](screenshots/map.jpg)
-![](screenshots/airports.jpg)m
+![](screenshots/airports.jpg)
 
 More screenshots here: [Screenshots](screenshots/)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ but all of this is available right inside your VR cockpit.
 
 ![](screenshots/charts.jpg)
 ![](screenshots/map.jpg)
-![](screenshots/airports.jpg)
+![](screenshots/airports.jpg)m
 
 More screenshots here: [Screenshots](screenshots/)
 
@@ -55,6 +55,7 @@ charts there, including subdirectories.
   download and setup your environment with the needed dependencies.
   * Windows, Linux, and macOS are supported with their respective dependency managers.  If you do not have the
     proper dependency manager installed, the script will prompt you to install it before proceeding.
+  * X-Plane 12, Make sure you have downloaded the latest [X-Plane 4 Beta SDK](https://developer.x-plane.com/sdk/plugin-sdk-downloads). (Needed for running the plugin on Apple Silicon hardware.)
 * There is another script called `teardown.sh` that will delete the folders where the dependencies were
   placed to compile AviTab.
 

--- a/setup.sh
+++ b/setup.sh
@@ -15,8 +15,8 @@ brewInstall() {
   brew install "$1"
 }
 
-standalone() {
-  # Move files from res/ to build/
+copyResources() {
+ # Move files from res/ to build/
   echo "Moving files..."
   if [ ! -f "$BUILD_FOLDER"/config.json ]; then
     cp -a "$(pwd)"/res/* "$BUILD_FOLDER"
@@ -29,13 +29,17 @@ standalone() {
   fi
 
   cd "$BUILD_FOLDER" || exit
+}
 
+standalone() {
   echo "Making AviTab-standalone..."
+  copyResources
   make AviTab-standalone
 }
 
 plugin() {
   echo "Making avitab_plugin..."
+  copyResources
   make avitab_plugin
 }
 

--- a/src/maps/sources/XPlaneSource.cpp
+++ b/src/maps/sources/XPlaneSource.cpp
@@ -107,7 +107,7 @@ std::unique_ptr<img::Image> XPlaneSource::loadTileImage(int page, int x, int y, 
     }
 
     char name[32];
-    int max_len = sizeof name;
+    size_t max_len = sizeof name;
     std::snprintf(name, max_len, "%+03d%+04d.dds", -y * 10 + 80, x * 10 - 180);
     std::string path = baseDir + name;
 

--- a/src/maps/sources/XPlaneSource.cpp
+++ b/src/maps/sources/XPlaneSource.cpp
@@ -107,7 +107,8 @@ std::unique_ptr<img::Image> XPlaneSource::loadTileImage(int page, int x, int y, 
     }
 
     char name[32];
-    std::sprintf(name, "%+03d%+04d.dds", -y * 10 + 80, x * 10 - 180);
+    int max_len = sizeof name;
+    std::snprintf(name, max_len, "%+03d%+04d.dds", -y * 10 + 80, x * 10 - 180);
     std::string path = baseDir + name;
 
     if (!platform::fileExists(path)) {

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -278,7 +278,7 @@ std::string getClipboardContent() {
 
 std::string formatStringArgs(const std::string format, va_list list) {
     char buf[2048];
-    int max_len = sizeof buf;
+    size_t max_len = sizeof buf;
     vsnprintf(buf, max_len, format.c_str(), list);
     return buf;
 }

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -278,7 +278,8 @@ std::string getClipboardContent() {
 
 std::string formatStringArgs(const std::string format, va_list list) {
     char buf[2048];
-    vsprintf(buf, format.c_str(), list);
+    int max_len = sizeof buf;
+    vsnprintf(buf, max_len, format.c_str(), list);
     return buf;
 }
 


### PR DESCRIPTION
Hello I hope  this pull request is either accepted or encourages changes to allow for building Avitab successfully on Apple Silicon hardware.

This pull request is requested to add minor changes needed for me to allow for compiling on Apple Silicon hardware running on the new publicly released version of macOS Ventura. 

Note, Xcode version 14.1, currently in beta, is needed to compile, at least for me. The changes to 'XPlaneSource.cpp' and 'Platform.cpp' replacing 'sprintf' with 'snprintf' and 'vsprintf' with 'vsnprintf' were needed to overcome associated compilation failures.