### PR TITLE
Locale independent strtod

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -27,6 +27,7 @@
 #include "src/maps/sources/XPlaneSource.h"
 #include "src/maps/sources/EPSGSource.h"
 #include "src/maps/sources/NavigraphSource.h"
+#include "src/libxdata/parsers/strtod.h"
 
 namespace avitab {
 
@@ -582,7 +583,7 @@ double MapApp::getCoordinate(const std::string &input) {
 
     if (coordStr.find(" ") == std::string::npos) {
         // Parse decimal format
-        return std::stod(coordStr);
+        return xdata::locale_independent_strtod(coordStr.c_str(), NULL);
     } else {
         // Parse DMS format with space separator between D M and M S.
         // Also handles D M only with no seconds field.

--- a/src/libxdata/parsers/BaseParser.cpp
+++ b/src/libxdata/parsers/BaseParser.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <limits>
 #include "src/Logger.h"
+#include "strtod.h"
 
 namespace xdata {
 
@@ -138,7 +139,7 @@ double BaseParser::parseDouble() {
     lineStream >> doubleStr;
 
     try {
-        return std::stod(doubleStr);
+        return xdata::locale_independent_strtod(doubleStr.c_str(), NULL);
     } catch (...) {
         return std::numeric_limits<double>::quiet_NaN();
     }

--- a/src/libxdata/parsers/CMakeLists.txt
+++ b/src/libxdata/parsers/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/MetarParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/CustomSceneryParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/UserFixParser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/strtod.cpp
 )

--- a/src/libxdata/parsers/UserFixParser.cpp
+++ b/src/libxdata/parsers/UserFixParser.cpp
@@ -19,6 +19,7 @@
 #include "src/Logger.h"
 #include <iostream>
 #include <cmath>
+#include "strtod.h"
 
 namespace xdata {
 
@@ -69,9 +70,9 @@ void UserFixParser::parseLine() {
         }
 
         std::string latStr = parser.nextCSVValue();
-        userFix.latitude = std::stod(latStr);
+        userFix.latitude = xdata::locale_independent_strtod(latStr.c_str(), NULL);
         std::string lonStr = parser.nextCSVValue();
-        userFix.longitude = std::stod(lonStr);
+        userFix.longitude = xdata::locale_independent_strtod(lonStr.c_str(), NULL);
         if (std::isnan(userFix.latitude) || std::isnan(userFix.longitude)) {
             throw std::runtime_error("Bad values");
         }

--- a/src/libxdata/parsers/strtod.cpp
+++ b/src/libxdata/parsers/strtod.cpp
@@ -1,7 +1,7 @@
 /*
  * strtod.c --
  *
- *	Source code for the "strtod" library procedure.
+ *  Source code for the "strtod" library procedure.
  *
  * Copyright (c) 1988-1993 The Regents of the University of California.
  * Copyright (c) 1994 Sun Microsystems, Inc.
@@ -22,7 +22,10 @@
 #include <ctype.h>
 #include <errno.h>
 #include <locale.h>
+#include "strtod.h"
 extern  int     errno;
+namespace xdata {
+
 #ifndef __STDC__
 # ifdef __GNUC__
 #  define const __const__
@@ -37,14 +40,14 @@ extern  int     errno;
 #ifndef NULL
 #define NULL 0
 #endif
-static int maxExponent = 511;	/* Largest possible base 10 exponent.  Any
-				 * exponent larger than this will already
-				 * produce underflow or overflow, so there's
-				 * no need to worry about additional digits.
-				 */
-static double powersOf10[] = {	/* Table giving binary powers of 10.  Entry */
-    10.,			/* is 10^2^i.  Used to convert decimal */
-    100.,			/* exponents into floating-point numbers. */
+static int maxExponent = 511;   /* Largest possible base 10 exponent.  Any
+                 * exponent larger than this will already
+                 * produce underflow or overflow, so there's
+                 * no need to worry about additional digits.
+                 */
+static double powersOf10[] = {  /* Table giving binary powers of 10.  Entry */
+    10.,            /* is 10^2^i.  Used to convert decimal */
+    100.,           /* exponents into floating-point numbers. */
     1.0e4,
     1.0e8,
     1.0e16,
@@ -53,78 +56,78 @@ static double powersOf10[] = {	/* Table giving binary powers of 10.  Entry */
     1.0e128,
     1.0e256
 };
-
+
 /*
  *----------------------------------------------------------------------
  *
  * strtod --
  *
- *	This procedure converts a floating-point number from an ASCII
- *	decimal representation to internal double-precision format.
+ *  This procedure converts a floating-point number from an ASCII
+ *  decimal representation to internal double-precision format.
  *
  * Results:
- *	The return value is the double-precision floating-point
- *	representation of the characters in string.  If endPtr isn't
- *	NULL, then *endPtr is filled in with the address of the
- *	next character after the last one that was part of the
- *	floating-point number.
+ *  The return value is the double-precision floating-point
+ *  representation of the characters in string.  If endPtr isn't
+ *  NULL, then *endPtr is filled in with the address of the
+ *  next character after the last one that was part of the
+ *  floating-point number.
  *
  * Side effects:
- *	None.
+ *  None.
  *
  *----------------------------------------------------------------------
  */
 double
-strtod(string, endPtr)
-    const char *string;		/* A decimal ASCII floating-point number,
-				 * optionally preceded by white space.
-				 * Must have form "-I.FE-X", where I is the
-				 * integer part of the mantissa, F is the
-				 * fractional part of the mantissa, and X
-				 * is the exponent.  Either of the signs
-				 * may be "+", "-", or omitted.  Either I
-				 * or F may be omitted, or both.  The decimal
-				 * point isn't necessary unless F is present.
-				 * The "E" may actually be an "e".  E and X
-				 * may both be omitted (but not just one).
-				 */
-    char **endPtr;		/* If non-NULL, store terminating character's
-				 * address here. */
+locale_independent_strtod(const char *string, char **endPtr)
+    /* const char *string;  A decimal ASCII floating-point number,
+                 * optionally preceded by white space.
+                 * Must have form "-I.FE-X", where I is the
+                 * integer part of the mantissa, F is the
+                 * fractional part of the mantissa, and X
+                 * is the exponent.  Either of the signs
+                 * may be "+", "-", or omitted.  Either I
+                 * or F may be omitted, or both.  The decimal
+                 * point isn't necessary unless F is present.
+                 * The "E" may actually be an "e".  E and X
+                 * may both be omitted (but not just one).
+                 */
+    /* char **endPtr; If non-NULL, store terminating character's
+                 * address here. */
 {
     int sign, expSign = FALSE;
     double fraction, dblExp, *d;
-    register const char *p;
-    register int c;
-    int exp = 0;		/* Exponent read from "EX" field. */
-    int fracExp = 0;		/* Exponent that derives from the fractional
-				 * part.  Under normal circumstatnces, it is
-				 * the negative of the number of digits in F.
-				 * However, if I is very long, the last digits
-				 * of I get dropped (otherwise a long I with a
-				 * large negative exponent could cause an
-				 * unnecessary overflow on I alone).  In this
-				 * case, fracExp is incremented one for each
-				 * dropped digit. */
-    int mantSize;		/* Number of digits in mantissa. */
-    int decPt;			/* Number of mantissa digits BEFORE decimal
-				 * point. */
-    const char *pExp;		/* Temporarily holds location of exponent
-				 * in string. */
+    const char *p;
+    int c;
+    int exp = 0;        /* Exponent read from "EX" field. */
+    int fracExp = 0;        /* Exponent that derives from the fractional
+                 * part.  Under normal circumstatnces, it is
+                 * the negative of the number of digits in F.
+                 * However, if I is very long, the last digits
+                 * of I get dropped (otherwise a long I with a
+                 * large negative exponent could cause an
+                 * unnecessary overflow on I alone).  In this
+                 * case, fracExp is incremented one for each
+                 * dropped digit. */
+    int mantSize;       /* Number of digits in mantissa. */
+    int decPt;          /* Number of mantissa digits BEFORE decimal
+                 * point. */
+    const char *pExp;       /* Temporarily holds location of exponent
+                 * in string. */
     /*
      * Strip off leading blanks and check for a sign.
      */
     p = string;
     while (isspace(*p)) {
-	p += 1;
+    p += 1;
     }
     if (*p == '-') {
-	sign = TRUE;
-	p += 1;
+    sign = TRUE;
+    p += 1;
     } else {
-	if (*p == '+') {
-	    p += 1;
-	}
-	sign = FALSE;
+    if (*p == '+') {
+        p += 1;
+    }
+    sign = FALSE;
     }
     /*
      * Count the number of digits in the mantissa (including the decimal
@@ -133,14 +136,14 @@ strtod(string, endPtr)
     decPt = -1;
     for (mantSize = 0; ; mantSize += 1)
     {
-	c = *p;
-	if (!isdigit(c)) {
-	    if ((c != '.') || (decPt >= 0)) {
-		break;
-	    }
-	    decPt = mantSize;
-	}
-	p += 1;
+    c = *p;
+    if (!isdigit(c)) {
+        if ((c != '.') || (decPt >= 0)) {
+        break;
+        }
+        decPt = mantSize;
+    }
+    p += 1;
     }
     /*
      * Now suck up the digits in the mantissa.  Use two integers to
@@ -152,70 +155,70 @@ strtod(string, endPtr)
     pExp  = p;
     p -= mantSize;
     if (decPt < 0) {
-	decPt = mantSize;
+    decPt = mantSize;
     } else {
-	mantSize -= 1;			/* One of the digits was the point. */
+    mantSize -= 1;          /* One of the digits was the point. */
     }
     if (mantSize > 18) {
-	fracExp = decPt - 18;
-	mantSize = 18;
+    fracExp = decPt - 18;
+    mantSize = 18;
     } else {
-	fracExp = decPt - mantSize;
+    fracExp = decPt - mantSize;
     }
     if (mantSize == 0) {
-	fraction = 0.0;
-	p = string;
-	goto done;
+    fraction = 0.0;
+    p = string;
+    goto done;
     } else {
-	int frac1, frac2;
-	frac1 = 0;
-	for ( ; mantSize > 9; mantSize -= 1)
-	{
-	    c = *p;
-	    p += 1;
-	    if (c == '.') {
-		c = *p;
-		p += 1;
-	    }
-	    frac1 = 10*frac1 + (c - '0');
-	}
-	frac2 = 0;
-	for (; mantSize > 0; mantSize -= 1)
-	{
-	    c = *p;
-	    p += 1;
-	    if (c == '.') {
-		c = *p;
-		p += 1;
-	    }
-	    frac2 = 10*frac2 + (c - '0');
-	}
-	fraction = (1.0e9 * frac1) + frac2;
+    int frac1, frac2;
+    frac1 = 0;
+    for ( ; mantSize > 9; mantSize -= 1)
+    {
+        c = *p;
+        p += 1;
+        if (c == '.') {
+        c = *p;
+        p += 1;
+        }
+        frac1 = 10*frac1 + (c - '0');
+    }
+    frac2 = 0;
+    for (; mantSize > 0; mantSize -= 1)
+    {
+        c = *p;
+        p += 1;
+        if (c == '.') {
+        c = *p;
+        p += 1;
+        }
+        frac2 = 10*frac2 + (c - '0');
+    }
+    fraction = (1.0e9 * frac1) + frac2;
     }
     /*
      * Skim off the exponent.
      */
     p = pExp;
     if ((*p == 'E') || (*p == 'e')) {
-	p += 1;
-	if (*p == '-') {
-	    expSign = TRUE;
-	    p += 1;
-	} else {
-	    if (*p == '+') {
-		p += 1;
-	    }
-	    expSign = FALSE;
-	}
-	while (isdigit(*p)) {
-	    exp = exp * 10 + (*p - '0');
-	    p += 1;
-	}
+    p += 1;
+    if (*p == '-') {
+        expSign = TRUE;
+        p += 1;
+    } else {
+        if (*p == '+') {
+        p += 1;
+        }
+        expSign = FALSE;
+    }
+    while (isdigit(*p)) {
+        exp = exp * 10 + (*p - '0');
+        p += 1;
+    }
     }
     if (expSign) {
-	exp = fracExp - exp;
+    exp = fracExp - exp;
     } else {
-	exp = fracExp + exp;
+    exp = fracExp + exp;
     }
     /*
      * Generate a floating-point number that represents the exponent.
@@ -225,62 +228,34 @@ strtod(string, endPtr)
      */
     
     if (exp < 0) {
-	expSign = TRUE;
-	exp = -exp;
+    expSign = TRUE;
+    exp = -exp;
     } else {
-	expSign = FALSE;
+    expSign = FALSE;
     }
     if (exp > maxExponent) {
-	exp = maxExponent;
-	errno = ERANGE;
+    exp = maxExponent;
+    errno = ERANGE;
     }
     dblExp = 1.0;
     for (d = powersOf10; exp != 0; exp >>= 1, d += 1) {
-	if (exp & 01) {
-	    dblExp *= *d;
-	}
+    if (exp & 01) {
+        dblExp *= *d;
+    }
     }
     if (expSign) {
-	fraction /= dblExp;
+    fraction /= dblExp;
     } else {
-	fraction *= dblExp;
+    fraction *= dblExp;
     }
 done:
     if (endPtr != NULL) {
-	*endPtr = (char *) p;
+    *endPtr = (char *) p;
     }
     if (sign) {
-	return -fraction;
+    return -fraction;
     }
     return fraction;
 }
-/*
- * Implementations added for emscripten.
- */
-// XXX add real support for long double
-long double
-strtold(const char* nptr, char **endptr)
-{
-  return (long double) strtod(nptr, endptr);
-}
-// use stdtod to handle strtof
-float
-strtof(const char* nptr, char **endptr)
-{
-  return (float) strtof(nptr, endptr);
-}
-// XXX no locale support yet
-double
-strtod_l(const char* nptr, char **endptr, locale_t loc)
-{
-  return strtod(nptr, endptr);
-}
-long double
-strtold_l(const char* nptr, char **endptr, locale_t loc)
-{
-  return strtold(nptr, endptr);
-}
-double atof(const char* str)
-{
-  return strtod(str, (char **) NULL);
-}
+
+} /* namespace xdata */

--- a/src/libxdata/parsers/strtod.cpp
+++ b/src/libxdata/parsers/strtod.cpp
@@ -1,0 +1,286 @@
+/*
+ * strtod.c --
+ *
+ *	Source code for the "strtod" library procedure.
+ *
+ * Copyright (c) 1988-1993 The Regents of the University of California.
+ * Copyright (c) 1994 Sun Microsystems, Inc.
+ *
+ * Permission to use, copy, modify, and distribute this
+ * software and its documentation for any purpose and without
+ * fee is hereby granted, provided that the above copyright
+ * notice appear in all copies.  The University of California
+ * makes no representations about the suitability of this
+ * software for any purpose.  It is provided "as is" without
+ * express or implied warranty.
+ *
+ * RCS: @(#) $Id$
+ *
+ * Taken from http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8/missing/strtod.c
+ */
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+#include <locale.h>
+extern  int     errno;
+#ifndef __STDC__
+# ifdef __GNUC__
+#  define const __const__
+# else
+#  define const
+# endif
+#endif
+#ifndef TRUE
+#define TRUE 1
+#define FALSE 0
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+static int maxExponent = 511;	/* Largest possible base 10 exponent.  Any
+				 * exponent larger than this will already
+				 * produce underflow or overflow, so there's
+				 * no need to worry about additional digits.
+				 */
+static double powersOf10[] = {	/* Table giving binary powers of 10.  Entry */
+    10.,			/* is 10^2^i.  Used to convert decimal */
+    100.,			/* exponents into floating-point numbers. */
+    1.0e4,
+    1.0e8,
+    1.0e16,
+    1.0e32,
+    1.0e64,
+    1.0e128,
+    1.0e256
+};
+
+/*
+ *----------------------------------------------------------------------
+ *
+ * strtod --
+ *
+ *	This procedure converts a floating-point number from an ASCII
+ *	decimal representation to internal double-precision format.
+ *
+ * Results:
+ *	The return value is the double-precision floating-point
+ *	representation of the characters in string.  If endPtr isn't
+ *	NULL, then *endPtr is filled in with the address of the
+ *	next character after the last one that was part of the
+ *	floating-point number.
+ *
+ * Side effects:
+ *	None.
+ *
+ *----------------------------------------------------------------------
+ */
+double
+strtod(string, endPtr)
+    const char *string;		/* A decimal ASCII floating-point number,
+				 * optionally preceded by white space.
+				 * Must have form "-I.FE-X", where I is the
+				 * integer part of the mantissa, F is the
+				 * fractional part of the mantissa, and X
+				 * is the exponent.  Either of the signs
+				 * may be "+", "-", or omitted.  Either I
+				 * or F may be omitted, or both.  The decimal
+				 * point isn't necessary unless F is present.
+				 * The "E" may actually be an "e".  E and X
+				 * may both be omitted (but not just one).
+				 */
+    char **endPtr;		/* If non-NULL, store terminating character's
+				 * address here. */
+{
+    int sign, expSign = FALSE;
+    double fraction, dblExp, *d;
+    register const char *p;
+    register int c;
+    int exp = 0;		/* Exponent read from "EX" field. */
+    int fracExp = 0;		/* Exponent that derives from the fractional
+				 * part.  Under normal circumstatnces, it is
+				 * the negative of the number of digits in F.
+				 * However, if I is very long, the last digits
+				 * of I get dropped (otherwise a long I with a
+				 * large negative exponent could cause an
+				 * unnecessary overflow on I alone).  In this
+				 * case, fracExp is incremented one for each
+				 * dropped digit. */
+    int mantSize;		/* Number of digits in mantissa. */
+    int decPt;			/* Number of mantissa digits BEFORE decimal
+				 * point. */
+    const char *pExp;		/* Temporarily holds location of exponent
+				 * in string. */
+    /*
+     * Strip off leading blanks and check for a sign.
+     */
+    p = string;
+    while (isspace(*p)) {
+	p += 1;
+    }
+    if (*p == '-') {
+	sign = TRUE;
+	p += 1;
+    } else {
+	if (*p == '+') {
+	    p += 1;
+	}
+	sign = FALSE;
+    }
+    /*
+     * Count the number of digits in the mantissa (including the decimal
+     * point), and also locate the decimal point.
+     */
+    decPt = -1;
+    for (mantSize = 0; ; mantSize += 1)
+    {
+	c = *p;
+	if (!isdigit(c)) {
+	    if ((c != '.') || (decPt >= 0)) {
+		break;
+	    }
+	    decPt = mantSize;
+	}
+	p += 1;
+    }
+    /*
+     * Now suck up the digits in the mantissa.  Use two integers to
+     * collect 9 digits each (this is faster than using floating-point).
+     * If the mantissa has more than 18 digits, ignore the extras, since
+     * they can't affect the value anyway.
+     */
+    
+    pExp  = p;
+    p -= mantSize;
+    if (decPt < 0) {
+	decPt = mantSize;
+    } else {
+	mantSize -= 1;			/* One of the digits was the point. */
+    }
+    if (mantSize > 18) {
+	fracExp = decPt - 18;
+	mantSize = 18;
+    } else {
+	fracExp = decPt - mantSize;
+    }
+    if (mantSize == 0) {
+	fraction = 0.0;
+	p = string;
+	goto done;
+    } else {
+	int frac1, frac2;
+	frac1 = 0;
+	for ( ; mantSize > 9; mantSize -= 1)
+	{
+	    c = *p;
+	    p += 1;
+	    if (c == '.') {
+		c = *p;
+		p += 1;
+	    }
+	    frac1 = 10*frac1 + (c - '0');
+	}
+	frac2 = 0;
+	for (; mantSize > 0; mantSize -= 1)
+	{
+	    c = *p;
+	    p += 1;
+	    if (c == '.') {
+		c = *p;
+		p += 1;
+	    }
+	    frac2 = 10*frac2 + (c - '0');
+	}
+	fraction = (1.0e9 * frac1) + frac2;
+    }
+    /*
+     * Skim off the exponent.
+     */
+    p = pExp;
+    if ((*p == 'E') || (*p == 'e')) {
+	p += 1;
+	if (*p == '-') {
+	    expSign = TRUE;
+	    p += 1;
+	} else {
+	    if (*p == '+') {
+		p += 1;
+	    }
+	    expSign = FALSE;
+	}
+	while (isdigit(*p)) {
+	    exp = exp * 10 + (*p - '0');
+	    p += 1;
+	}
+    }
+    if (expSign) {
+	exp = fracExp - exp;
+    } else {
+	exp = fracExp + exp;
+    }
+    /*
+     * Generate a floating-point number that represents the exponent.
+     * Do this by processing the exponent one bit at a time to combine
+     * many powers of 2 of 10. Then combine the exponent with the
+     * fraction.
+     */
+    
+    if (exp < 0) {
+	expSign = TRUE;
+	exp = -exp;
+    } else {
+	expSign = FALSE;
+    }
+    if (exp > maxExponent) {
+	exp = maxExponent;
+	errno = ERANGE;
+    }
+    dblExp = 1.0;
+    for (d = powersOf10; exp != 0; exp >>= 1, d += 1) {
+	if (exp & 01) {
+	    dblExp *= *d;
+	}
+    }
+    if (expSign) {
+	fraction /= dblExp;
+    } else {
+	fraction *= dblExp;
+    }
+done:
+    if (endPtr != NULL) {
+	*endPtr = (char *) p;
+    }
+    if (sign) {
+	return -fraction;
+    }
+    return fraction;
+}
+/*
+ * Implementations added for emscripten.
+ */
+// XXX add real support for long double
+long double
+strtold(const char* nptr, char **endptr)
+{
+  return (long double) strtod(nptr, endptr);
+}
+// use stdtod to handle strtof
+float
+strtof(const char* nptr, char **endptr)
+{
+  return (float) strtof(nptr, endptr);
+}
+// XXX no locale support yet
+double
+strtod_l(const char* nptr, char **endptr, locale_t loc)
+{
+  return strtod(nptr, endptr);
+}
+long double
+strtold_l(const char* nptr, char **endptr, locale_t loc)
+{
+  return strtold(nptr, endptr);
+}
+double atof(const char* str)
+{
+  return strtod(str, (char **) NULL);
+}

--- a/src/libxdata/parsers/strtod.h
+++ b/src/libxdata/parsers/strtod.h
@@ -1,0 +1,27 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_LIBXDATA_PARSERS_STRTOD_H_
+#define SRC_LIBXDATA_PARSERS_STRTOD_H_
+
+namespace xdata {
+
+double locale_independent_strtod(const char *string, char** endPtr);
+
+} /* namespace xdata */
+
+#endif /* SRC_LIBXDATA_PARSERS_STRTOD_H_ */


### PR DESCRIPTION
Fix issue reported by drogeda2, where lat/long were being parsed in locale which expected comma decimal separator, so only integer part was being taken. Always expect dot decimal for XPlane data, user fixes and calibration lat/long entry
