### PR TITLE
Calibrate Mercator charts which have North arbitrarily rotated

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -209,6 +209,9 @@ void MapApp::selectMercator() {
                 setTileSource(pdfSource);
                 fileChooser.reset();
                 chooserContainer->setVisible(false);
+                if (savedSettings->getGeneralSetting<bool>("show_calibration_msg_on_load")) {
+                    finalizeCalibration();
+                }
             } catch (const std::exception &e) {
                 logger::warn("Couldn't open Mercator %s: %s", selectedUTF8.c_str(), e.what());
             }
@@ -552,7 +555,7 @@ void MapApp::startCalibration() {
     });
     messageBox->centerInParent();
 
-    coordsField = std::make_shared<TextArea>(window, "1.234, -2 30 59.9");
+    coordsField = std::make_shared<TextArea>(window, "");
     coordsField->setDimensions(window->getContentWidth(), 40);
     coordsField->alignInTopLeft();
 
@@ -614,7 +617,16 @@ void MapApp::processCalibrationPoint(int step) {
 
     auto it = coords.find(',');
     if (it == std::string::npos) {
-        return;
+        if (step <= 2) {
+             LOG_INFO(1, "No ',' found, returning, step = %d", step);
+             return;
+        } else {
+             double angle = getCoordinate(coords);
+             LOG_INFO(1, "Found angle %f", angle);
+             map->setCalibrationAngle(angle);
+             finalizeCalibration();
+             return;
+        }
     }
 
     try {
@@ -626,19 +638,34 @@ void MapApp::processCalibrationPoint(int step) {
             LOG_ERROR("Out of bounds lat/lon in '%s'", coords.c_str());
             return;
         }
-        LOG_INFO(1, "From '%s', got %f, %f", coords.c_str(), lat, lon);
+        LOG_INFO(1, "From '%s', got %4.10f, %4.10f", coords.c_str(), lat, lon);
         if (step == 1) {
             map->setCalibrationPoint1(lat, lon);
             coordsField->setText("");
-        } else {
+        } else if (step == 2) {
             map->setCalibrationPoint2(lat, lon);
-            keyboard.reset();
-            coordsField.reset();
-            onTimer();
+            coordsField->setText("0");
+        } else {
+            map->setCalibrationPoint3(lat, lon);
+            finalizeCalibration();
         }
     } catch (const std::exception &e) {
         LOG_ERROR("Failed to parse '%s': %s", coords.c_str(), e.what());
     }
+    rotateButton->setVisible(false);
+}
+
+void MapApp::finalizeCalibration() {
+    keyboard.reset();
+    coordsField.reset();
+    messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), map->getCalibrationReport());
+    messageBox->addButton("Ok", [this] () {
+        api().executeLater([this] () {
+            messageBox.reset();
+        });
+    });
+    messageBox->centerInParent();
+    onTimer();
     rotateButton->setVisible(false);
 }
 
@@ -661,6 +688,8 @@ bool MapApp::handleNonNumericContent(std::string coords)  {
         auto airportLoc = airport->getLocation();
         ss << airportLoc.latitude << ", " << airportLoc.longitude;
         coordsField->setText(ss.str());
+        LOG_INFO(1, "Replace airport %s with %4.10f, %4.10f",
+                    coordsUpper.c_str(), airportLoc.latitude, airportLoc.longitude);
         return true;
     }
 
@@ -678,6 +707,8 @@ bool MapApp::handleNonNumericContent(std::string coords)  {
         auto fixLoc = fix->getLocation();
         ss << fixLoc.latitude << ", " << fixLoc.longitude;
         coordsField->setText(ss.str());
+        LOG_INFO(1, "Replace nav fix %s with %4.10f, %4.10f",
+                    coordsUpper.c_str(), fixLoc.latitude, fixLoc.longitude);
         return true;
     }
     return false;

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -64,6 +64,7 @@ MapApp::MapApp(FuncsPtr funcs):
     chooserContainer->setVisible(false);
 
     setMapSource(MapSource::OPEN_TOPO);
+    mercatorDir = api().getDataPath() + "/MapTiles/Mercator/";
 
     mapWidget->draw(*mapImage);
     onTimer();
@@ -200,7 +201,7 @@ void MapApp::selectGeoTIFF() {
 
 void MapApp::selectMercator() {
     fileChooser = std::make_unique<FileChooser>(&api(), "Mercator: ");
-    fileChooser->setBaseDirectory(api().getDataPath() + "/MapTiles/Mercator/");
+    fileChooser->setBaseDirectory(mercatorDir);
     fileChooser->setFilterRegex("\\.(pdf|png|jpg|jpeg|bmp)$");
     fileChooser->setSelectCallback([this] (const std::string &selectedUTF8) {
         api().executeLater([this, selectedUTF8] () {
@@ -212,6 +213,7 @@ void MapApp::selectMercator() {
                 if (savedSettings->getGeneralSetting<bool>("show_calibration_msg_on_load")) {
                     finalizeCalibration();
                 }
+                mercatorDir = platform::getDirNameFromPath(selectedUTF8);
             } catch (const std::exception &e) {
                 logger::warn("Couldn't open Mercator %s: %s", selectedUTF8.c_str(), e.what());
             }

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -90,6 +90,7 @@ private:
     bool suspended = true;
 
     int panPosX = 0, panPosY = 0;
+    std::string mercatorDir;
 
     void createSettingsLayout();
     void showOverlaySettings();

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -114,6 +114,7 @@ private:
     void startCalibration();
     double getCoordinate(const std::string &str);
     void processCalibrationPoint(int step);
+    void finalizeCalibration();
     bool handleNonNumericContent(std::string coords);
 };
 

--- a/src/charts/Crypto.cpp
+++ b/src/charts/Crypto.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <memory>
 #include "src/Logger.h"
+#include "src/platform/Platform.h"
 #include "Crypto.h"
 
 namespace apis {
@@ -201,7 +202,7 @@ std::string Crypto::aesDecrypt(const std::string& in, const std::string& key) {
 }
 
 std::string Crypto::getFileSha256(const std::string &utf8Path) {
-    std::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
+    fs::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
     if (!ifs.is_open()) {
         LOG_ERROR("Unable to open file '%s'", utf8Path.c_str());
         return "No file !";

--- a/src/charts/Crypto.cpp
+++ b/src/charts/Crypto.cpp
@@ -21,6 +21,9 @@
 #include <mbedtls/md.h>
 #include <mbedtls/rsa.h>
 #include <stdexcept>
+#include <iomanip>
+#include <fstream>
+#include <memory>
 #include "src/Logger.h"
 #include "Crypto.h"
 
@@ -62,6 +65,15 @@ std::vector<uint8_t> Crypto::sha256(const std::string& in) {
     mbedtls_md(info, (uint8_t *) in.data(), in.size(), hash.data());
 
     return hash;
+}
+
+std::string Crypto::sha256String(const std::string& in) {
+    auto hash = sha256(in);
+    std::ostringstream buffer;
+    buffer << std::hex << std::setfill('0');
+    for(int i : hash)
+        buffer << std::setw(2) << i;
+    return buffer.str();
 }
 
 std::string Crypto::urlEncode(const std::string& in) {
@@ -186,6 +198,23 @@ std::string Crypto::aesDecrypt(const std::string& in, const std::string& key) {
     plain.push_back('\0');
 
     return std::string((char *) plain.data());
+}
+
+std::string Crypto::getFileSha256(const std::string &utf8Path) {
+    std::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
+    if (!ifs.is_open()) {
+        LOG_ERROR("Unable to open file '%s'", utf8Path.c_str());
+        return "No file !";
+    }
+
+    std::streampos size = ifs.tellg();
+    auto fileBytes = std::unique_ptr<char[]>(new char[size]);
+    ifs.seekg (0, std::ios::beg);
+    ifs.read (fileBytes.get(), size);
+    ifs.close();
+
+    auto hash = sha256String(std::string(fileBytes.get(), size));
+    return hash;
 }
 
 Crypto::~Crypto() {

--- a/src/charts/Crypto.h
+++ b/src/charts/Crypto.h
@@ -32,6 +32,7 @@ class Crypto {
 public:
     Crypto();
     std::vector<uint8_t> sha256(const std::string &in);
+    std::string sha256String(const std::string& in);
     std::vector<uint8_t> generateRandom(size_t len);
     std::string urlEncode(const std::string &in);
     std::string base64URLEncode(const std::vector<uint8_t> &in);
@@ -40,6 +41,7 @@ public:
     bool RSASHA256(const std::string &base64in, const std::string &sig, const std::string &n, const std::string &e);
     std::string aesEncrypt(const std::string &in, const std::string &key);
     std::string aesDecrypt(const std::string &in, const std::string &key);
+    std::string getFileSha256(const std::string &utf8Path);
     virtual ~Crypto();
 private:
     mbedtls_aes_context aesCtx {};

--- a/src/charts/libnavigraph/NavigraphChart.cpp
+++ b/src/charts/libnavigraph/NavigraphChart.cpp
@@ -100,6 +100,7 @@ std::shared_ptr<img::TileSource> NavigraphChart::createTileSource(bool nightMode
             int h = img->getHeight();
             src->attachCalibration1(geoRef.x1 * w, geoRef.y1 * h, geoRef.lat1, geoRef.lon1, 0);
             src->attachCalibration2(geoRef.x2 * w, geoRef.y2 * h, geoRef.lat2, geoRef.lon2, 0);
+            src->attachCalibration3Angle(0);
         } catch (const std::exception &e) {
             logger::verbose("Invalid geo reference for chart: %s", e.what());
         }

--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -96,7 +96,10 @@ void Settings::setSetting(const std::string &id, const T value) {
 
 void Settings::init() {
     // full init not required, just defaults that aren't zero/false/empty
-    *database = { { "general", { { "prefs_version", 1 }, { "show_fps", true } } }, { "overlay", { { "my_aircraft", true } } } };
+    *database = { { "general", { { "prefs_version", 1 },
+                                 { "show_calibration_msg_on_load", true },
+                                 { "show_fps", true } } },
+                  { "overlay", { { "my_aircraft", true } } } };
 }
 
 void Settings::load() {

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -39,6 +39,8 @@ public:
     virtual Point<int> getTileDimensions(int zoom) = 0;
     virtual bool supportsWorldCoords() = 0;
     virtual img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) = 0;
+    virtual std::string getCalibrationReport() {return "No calibration"; };
+    virtual double getNorthOffsetAngle() { return 0.0; };
 
     // Control the underlying loader
     virtual void cancelPendingLoads() = 0;
@@ -56,6 +58,8 @@ public:
     virtual Point<double> xyToWorld(double x, double y, int zoom) = 0;
     virtual void attachCalibration1(double x, double y, double lat, double lon, int zoom) {}
     virtual void attachCalibration2(double x, double y, double lat, double lon, int zoom) {}
+    virtual void attachCalibration3Point(double x, double y, double lat, double lon, int zoom) {}
+    virtual void attachCalibration3Angle(double angle) {}
     virtual void rotate() {}
 
     virtual std::string getCopyrightInfo() { return ""; }

--- a/src/maps/OverlayHelper.h
+++ b/src/maps/OverlayHelper.h
@@ -39,6 +39,7 @@ public:
     virtual void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const = 0;
     virtual int getZoomLevel() const = 0;
     virtual int getMaxZoomLevel() const = 0;
+    virtual double getNorthOffset() const = 0;
 
     virtual ~IOverlayHelper() = default;
 };

--- a/src/maps/OverlayedAirport.cpp
+++ b/src/maps/OverlayedAirport.cpp
@@ -109,9 +109,16 @@ bool OverlayedAirport::isVisible(OverlayHelper helper, const xdata::Airport *air
     if (!locUpLeft.isValid() || !locDownRight.isValid()) {
         return true; // Not sure, assume visible, let later stages figure it out
     }
-    int xmin, ymin, xmax, ymax;
-    helper->positionToPixel(locUpLeft.latitude, locUpLeft.longitude, xmin, ymin);
-    helper->positionToPixel(locDownRight.latitude, locDownRight.longitude, xmax, ymax);
+    // Chart may be rotated, so xUpleft is not not necessarily xmin, ymin
+    int xUpLeft, yUpLeft, xUpRight, yUpRight, xDownLeft, yDownLeft, xDownRight, yDownRight;
+    helper->positionToPixel(locUpLeft.latitude, locUpLeft.longitude, xUpLeft, yUpLeft);
+    helper->positionToPixel(locUpLeft.latitude, locDownRight.longitude, xUpRight, yUpRight);
+    helper->positionToPixel(locDownRight.latitude, locDownRight.longitude, xDownRight, yDownRight);
+    helper->positionToPixel(locDownRight.latitude, locUpLeft.longitude, xDownLeft, yDownLeft);
+    int xmin = std::min(std::min(xUpLeft, xUpRight), std::min(xDownRight, xDownLeft));
+    int xmax = std::max(std::max(xUpLeft, xUpRight), std::max(xDownRight, xDownLeft));
+    int ymin = std::min(std::min(yUpLeft, yUpRight), std::min(yDownRight, yDownLeft));
+    int ymax = std::max(std::max(yUpLeft, yUpRight), std::max(yDownRight, yDownLeft));
     int margin = 100; // Enough for text to spread out
     return helper->isAreaVisible(xmin - margin, ymin - margin, xmax + margin, ymax + margin);
 }

--- a/src/maps/OverlayedILSLocalizer.cpp
+++ b/src/maps/OverlayedILSLocalizer.cpp
@@ -111,6 +111,7 @@ void OverlayedILSLocalizer::getTailCoords(OverlayHelper helper, const xdata::Fix
         return;
     }
     double ilsHeading = std::fmod(ils->getRunwayHeading() + 180.0, 360);
+    ilsHeading += helper->getNorthOffset();
     double rangePixels = 0.0;
     if (helper->getMapWidthNM() != 0) {
         auto mapImage = helper->getMapImage();

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -176,7 +176,7 @@ void OverlayedMap::drawAircraftOverlay() {
     px -= planeIcon.getWidth() / 2;
     py -= planeIcon.getHeight() / 2;
 
-    mapImage->blendImage(planeIcon, px, py, planeLocations[0].heading);
+    mapImage->blendImage(planeIcon, px, py, planeLocations[0].heading + getNorthOffset());
 }
 
 void OverlayedMap::drawOtherAircraftOverlay() {
@@ -196,9 +196,9 @@ void OverlayedMap::drawOtherAircraftOverlay() {
         mapImage->drawCircle(px, py, 6, color);
         mapImage->drawCircle(px, py, 7, color);
         double ax, ay, tx, ty, rx, ry;
-        fastPolarToCartesian(12.0, static_cast<int>(planeLocations[i].heading), ax, ay);
-        fastPolarToCartesian(3.0, static_cast<int>(planeLocations[i].heading), tx, ty);
-        fastPolarToCartesian(2.0, static_cast<int>(planeLocations[i].heading) + 90, rx, ry);
+        fastPolarToCartesian(12.0, static_cast<int>(planeLocations[i].heading + getNorthOffset()), ax, ay);
+        fastPolarToCartesian(3.0, static_cast<int>(planeLocations[i].heading + getNorthOffset()), tx, ty);
+        fastPolarToCartesian(2.0, static_cast<int>(planeLocations[i].heading + getNorthOffset()) + 90, rx, ry);
         mapImage->drawLineAA(px + tx + rx, py + ty + ry, px + ax, py + ay, color);
         mapImage->drawLineAA(px + tx - rx, py + ty - ry, px + ax, py + ay, color);
         unsigned int flightLevel = static_cast<unsigned int>(planeLocations[i].elevation * xdata::M_TO_FT + 50.0) / 100.0;
@@ -225,6 +225,8 @@ void OverlayedMap::drawCalibrationOverlay() {
         color = img::COLOR_LIGHT_RED;
     } else if (calibrationStep == 2) {
         color = img::COLOR_BLUE;
+    } else {
+        color = img::COLOR_DARK_GREEN;
     }
     int centerX = mapImage->getWidth() / 2;
     int centerY = mapImage->getHeight() / 2;
@@ -282,7 +284,8 @@ void OverlayedMap::drawDataOverlays() {
 
     // Don't overlay anything if zoomed out to world view. Too much to draw.
     // And haversine formula used by distanceTo misbehaves in world views.
-    if ((deltaLon > 180) || (deltaLon < 0)) {
+    // We also don't handle things properly if the antimeridian is in area
+    if ((deltaLon > 180) || ((leftLon > 0) && (rightLon < 0))) {
         return;
     }
 
@@ -377,6 +380,10 @@ void OverlayedMap::drawDataOverlays() {
         stitcher->getZoomLevel(), deltaLon, nmPerPixel, mapWidthNM);
 
     drawScale(nmPerPixel);
+
+    if (std::abs(std::round(getNorthOffset())) > 0.5) {
+        drawCompass();
+    }
 }
 
 double OverlayedMap::getMapWidthNM() const {
@@ -415,6 +422,19 @@ void OverlayedMap::drawScale(double nmPerPixel) {
     std::string text = std::to_string(int(rangeToShow)) + units;
     int xtext = x + lineLength + 2;
     mapImage->drawText(text, 12, xtext, y, img::COLOR_BLACK, img::COLOR_TRANSPARENT_WHITE, img::Align::LEFT);
+}
+
+void OverlayedMap::drawCompass() {
+    int cx = stitcher->getTargetImage()->getWidth() - 30;
+    int cy = 210;
+    mapImage->drawCircle(cx, cy, 20, img::COLOR_RED);
+    double xt, yt, xm, ym, xp, yp;
+    fastPolarToCartesian(20, getNorthOffset(), xt, yt);
+    fastPolarToCartesian(5, getNorthOffset() + 90, xm, ym);
+    fastPolarToCartesian(5, getNorthOffset() - 90, xp, yp);
+    mapImage->drawLineAA(cx - xt, cy - yt, cx + xt, cy + yt, img::COLOR_RED);
+    mapImage->drawLineAA(cx + xt, cy + yt, cx + xp, cy + yp, img::COLOR_RED);
+    mapImage->drawLineAA(cx + xt, cy + yt, cx + xm, cy + ym, img::COLOR_RED);
 }
 
 void OverlayedMap::positionToPixel(double lat, double lon, int& px, int& py) const {
@@ -502,8 +522,16 @@ int OverlayedMap::getMaxZoomLevel() const {
     return tileSource->getMaxZoomLevel();
 }
 
-bool OverlayedMap::isCalibrated() {
+double OverlayedMap::getNorthOffset() const {
+    return tileSource->getNorthOffsetAngle();
+}
+
+bool OverlayedMap::isCalibrated() const {
     return tileSource->supportsWorldCoords();
+}
+
+std::string OverlayedMap::getCalibrationReport() const {
+    return tileSource->getCalibrationReport();
 }
 
 void OverlayedMap::beginCalibration() {
@@ -523,6 +551,19 @@ void OverlayedMap::setCalibrationPoint2(double lat, double lon) {
     auto center = stitcher->getCenter();
     tileSource->attachCalibration2(center.x, center.y, lat, lon, stitcher->getZoomLevel());
 
+    calibrationStep = 3;
+    updateImage();
+}
+
+void OverlayedMap::setCalibrationPoint3(double lat, double lon) {
+    auto center = stitcher->getCenter();
+    tileSource->attachCalibration3Point(center.x, center.y, lat, lon, stitcher->getZoomLevel());
+    calibrationStep = 0;
+    updateImage();
+}
+
+void OverlayedMap::setCalibrationAngle(double angle) {
+    tileSource->attachCalibration3Angle(angle);
     calibrationStep = 0;
     updateImage();
 }

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -159,6 +159,9 @@ void OverlayedMap::drawOverlays() {
     }
     if (tileSource->supportsWorldCoords()) {
         drawDataOverlays();
+        if (std::abs(std::round(getNorthOffset())) > 0.5) {
+            drawCompass();
+        }
         drawOtherAircraftOverlay();
         drawAircraftOverlay();
     }
@@ -380,10 +383,6 @@ void OverlayedMap::drawDataOverlays() {
         stitcher->getZoomLevel(), deltaLon, nmPerPixel, mapWidthNM);
 
     drawScale(nmPerPixel);
-
-    if (std::abs(std::round(getNorthOffset())) > 0.5) {
-        drawCompass();
-    }
 }
 
 double OverlayedMap::getMapWidthNM() const {

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -50,11 +50,14 @@ public:
     void zoomIn();
     void zoomOut();
 
-    bool isCalibrated();
+    bool isCalibrated() const;
     void beginCalibration();
     void setCalibrationPoint1(double lat, double lon);
     void setCalibrationPoint2(double lat, double lon);
+    void setCalibrationPoint3(double lat, double lon);
+    void setCalibrationAngle(double angle);
     int getCalibrationStep() const;
+    std::string getCalibrationReport() const;
 
     // Call periodically to refresh tiles that were pending
     void doWork();
@@ -72,6 +75,7 @@ public:
     void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const override;
     int getZoomLevel() const override;
     int getMaxZoomLevel() const override;
+    double getNorthOffset() const override;
 
 private:
     // Data
@@ -111,6 +115,7 @@ private:
     void drawDataOverlays();
     void drawCalibrationOverlay();
     void drawScale(double nmPerPixel);
+    void drawCompass();
 
     void pixelToPosition(int px, int py, double &lat, double &lon) const;
     float cosDegrees(int angleDegrees) const;

--- a/src/maps/OverlayedVOR.cpp
+++ b/src/maps/OverlayedVOR.cpp
@@ -67,6 +67,7 @@ void OverlayedVOR::drawGraphics() {
         const float BIG_TICK_SCALE = 0.84;
         const float SMALL_TICK_SCALE = 0.92;
         int bearing = (int)vor->getBearing();
+        bearing += overlayHelper->getNorthOffset();
         for (int deg = 0; deg <= 360; deg += 10) {
             double inner_x, inner_y, outer_x, outer_y;
             float tickScale = (deg%30 == 0) ? BIG_TICK_SCALE : SMALL_TICK_SCALE;

--- a/src/maps/sources/CMakeLists.txt
+++ b/src/maps/sources/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(avitab_common PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/NavigraphSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ImageSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Calibration.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/LinearEquation.cpp
 )

--- a/src/maps/sources/Calibration.cpp
+++ b/src/maps/sources/Calibration.cpp
@@ -24,6 +24,7 @@
 namespace maps {
 
 void Calibration::setPoint1(double x, double y, double lat, double lon) {
+    LOG_INFO(1,"%4.10f,%4.10f -> %4.10f,%4.10f", x, y, lat, lon);
     regX1 = x;
     regY1 = y;
     regLat1 = lat;
@@ -31,14 +32,38 @@ void Calibration::setPoint1(double x, double y, double lat, double lon) {
 }
 
 void Calibration::setPoint2(double x, double y, double lat, double lon) {
-    if (lat == regLat1 && lon == regLon1) {
+    if ((lat == regLat1 && lon == regLon1) || (x == regX1 && y == regY1)) {
         throw std::runtime_error("Must be two different points");
     }
-
+    LOG_INFO(1,"%4.10f,%4.10f -> %4.10f,%4.10f", x, y, lat, lon);
     regX2 = x;
     regY2 = y;
     regLat2 = lat;
     regLon2 = lon;
+}
+
+void Calibration::setPoint3(double x, double y, double lat, double lon) {
+    if (((lat == regLat1 && lon == regLon1) || (x == regX1 && y == regY1)) ||
+        ((lat == regLat2 && lon == regLon2) || (x == regX2 && y == regY2))) {
+        throw std::runtime_error("Must be two different points");
+    }
+    LOG_INFO(1,"%4.10f,%4.10f -> %4.10f,%4.10f", x, y, lat, lon);
+    regX3 = x;
+    regY3 = y;
+    regLat3 = lat;
+    regLon3 = lon;
+    northOffsetAngle = NAN;
+    
+    calculateCalibration();
+}
+
+void Calibration::setAngle(double angle) {
+    LOG_INFO(1, "%4.10f", angle);
+    northOffsetAngle = angle;
+    regX3 = NAN;
+    regY3 = NAN;
+    regLat3 = NAN;
+    regLon3 = NAN;
 
     calculateCalibration();
 }
@@ -47,10 +72,11 @@ void Calibration::setPreRotate(int angle) {
     preRotate = angle;
 }
 
-std::string Calibration::toString() {
+std::string Calibration::toString() const {
     nlohmann::json json;
 
-    json["calibration"] =
+    if (offsetAngleDefined) {
+        json["calibration"] =
                     {
                         {"prerotate", preRotate},
 
@@ -63,12 +89,34 @@ std::string Calibration::toString() {
                         {"y2", regY2},
                         {"longitude2", regLon2},
                         {"latitude2", regLat2},
-                    };
 
+                        {"northOffsetAngle", northOffsetAngle},
+                    };
+    } else {
+        json["calibration"] =
+                    {
+                        {"prerotate", preRotate},
+
+                        {"x1", regX1},
+                        {"y1", regY1},
+                        {"longitude1", regLon1},
+                        {"latitude1", regLat1},
+
+                        {"x2", regX2},
+                        {"y2", regY2},
+                        {"longitude2", regLon2},
+                        {"latitude2", regLat2},
+
+                        {"x3", regX3},
+                        {"y3", regY3},
+                        {"longitude3", regLon3},
+                        {"latitude3", regLat3},
+                    };
+    }
     return json.dump(2);
 }
 
-void Calibration::fromString(const std::string& s) {
+void Calibration::fromJsonString(const std::string& s) {
     nlohmann::json json = nlohmann::json::parse(s);
 
     using j = nlohmann::json;
@@ -85,44 +133,330 @@ void Calibration::fromString(const std::string& s) {
     regX2 = json[j::json_pointer("/calibration/x2")];
     regY2 = json[j::json_pointer("/calibration/y2")];
 
+    regLon3 = json.value("/calibration/longitude3"_json_pointer, NAN);
+    regLat3 = json.value("/calibration/latitude3"_json_pointer, NAN);
+    regX3 = json.value("/calibration/x3"_json_pointer, NAN);
+    regY3 = json.value("/calibration/y3"_json_pointer, NAN);
+
+    northOffsetAngle = json.value("/calibration/northOffsetAngle"_json_pointer, NAN);
+
     calculateCalibration();
+}
+
+std::string Calibration::getKmlTagData(const std::string kml, const std::string tag) const {
+    std::size_t start = kml.find("<" + tag + ">") + tag.length() + 2;
+    std::size_t end = kml.find("</" + tag + ">");
+    if ((start == std::string::npos) || (end == std::string::npos)) {
+        return "0.0"; // Should then fail to calibrate. Send suspect KML to devs
+    } else {
+        std::string data = kml.substr(start, end - start);
+        return data;
+    }
+}
+
+std::pair<double, double> Calibration::rotate(double x, double y, double angleDegrees) const {
+    double a = angleDegrees * M_PI / 180.0;
+    double xr = x * std::cos(a) - y * sin(a);
+    double yr = x * std::sin(a) + y * cos(a);
+    return std::make_pair(xr, yr);
+}
+
+void Calibration::fromKmlString(const std::string& s) {
+    double north = stof(getKmlTagData(s, "north"));
+    double south = stof(getKmlTagData(s, "south"));
+    double east = stof(getKmlTagData(s, "east"));
+    double west = stof(getKmlTagData(s, "west"));
+    double rotation = (getKmlTagData(s, "rotation") == "") ? 0 : stof(getKmlTagData(s, "rotation"));
+    LOG_INFO(dbg, "N %4.6f, S %4.6f, E %4.6f, W %4.6f,  R %4.6f", north, south, east, west, rotation);
+
+    // Convert from mercator to equirectangular
+    auto nw = mercator(north, west); // For nw, y is 1st, x is 2nd
+    auto ne = mercator(north, east);
+    auto se = mercator(south, east);
+
+    // Rotate about the centre and invMercator
+    auto cx = (nw.second + se.second) / 2; // Calculate centre (cx,cy)
+    auto cy = (nw.first + se.first) / 2;
+    auto nw0 = std::make_pair(nw.second - cx, nw.first - cy); // Translate so centre is (0,0)
+    auto ne0 = std::make_pair(ne.second - cx, ne.first - cy); // For these new pairs, x is 1st, y is 2nd
+    auto se0 = std::make_pair(se.second - cx, se.first - cy);
+    auto nwr = rotate(nw0.first, nw0.second, rotation); // Rotate about centre (0,0)
+    auto ner = rotate(ne0.first, ne0.second, rotation);
+    auto ser = rotate(se0.first, se0.second, rotation);
+    auto nwRef = std::make_pair(nwr.first + cx, invMercator(nwr.second + cy)); // Translate back from centre of (0,0)
+    auto neRef = std::make_pair(ner.first + cx, invMercator(ner.second + cy));
+    auto seRef = std::make_pair(ser.first + cx, invMercator(ser.second + cy));
+
+    LOG_INFO(dbg, "NW  %4.6f, %4.6f", nwRef.first, nwRef.second); // nwRef x/lon 1st, y/lat 2nd
+    LOG_INFO(dbg, "NE  %4.6f, %4.6f", neRef.first, neRef.second);
+    LOG_INFO(dbg, "SE  %4.6f, %4.6f", seRef.first, seRef.second);
+
+    setPoint1(0, 0, nwRef.second, nwRef.first);
+    setPoint2(1, 0, neRef.second, neRef.first);
+    setPoint3(1, 1, seRef.second, seRef.first);
 }
 
 bool Calibration::hasCalibration() const {
     return isCalibrated;
 }
 
+std::string Calibration::getReport() const {
+    return report;
+}
+
 void Calibration::calculateCalibration() {
+    report = "Not calibrated";
+
     auto xy1 = mercator(regLat1, regLon1);
     auto xy2 = mercator(regLat2, regLon2);
 
-    double deltaLon = xy1.second - xy2.second;
-    double deltaLat = xy1.first - xy2.first;
+    LOG_INFO(dbg, "ref1 %4.6f, %4.6f => %4.6f, %4.6f", regX1, regY1, regLat1, regLon1);
+    LOG_INFO(dbg, "ref1 after mercator        %4.6f, %4.6f", xy1.first, xy1.second);
+    LOG_INFO(dbg, "ref2 %4.6f, %4.6f => %4.6f, %4.6f", regX2, regY1, regLat2, regLon1);
+    LOG_INFO(dbg, "ref2 after mercator        %4.6f, %4.6f", xy2.first, xy2.second);
 
-    double deltaX = regX1 - regX2;
-    double deltaY = regY1 - regY2;
+    // Handle legacy calibration .json files with angle implicitly = 0
+    if (std::isnan(northOffsetAngle) && std::isnan(regX3)) {
+        northOffsetAngle = 0.0;
+    }
 
-    if (deltaX == 0 || deltaY == 0) {
+    if (!std::isnan(northOffsetAngle) && std::isnan(regX3)) {
+        offsetAngleDefined = true;
+        logger::info("North offset angle defined as %4.4f", northOffsetAngle);
+        LOG_INFO(dbg, "PixelsToWorld ...");
+        lePixelsToWorld.initialiseFrom2PointsAndAngleP2W(xy1.second, xy1.first, regX1, regY1,
+                                                         xy2.second, xy2.first, regX2, regY2,
+                                                         northOffsetAngle);
+        LOG_INFO(dbg, "WorldToPixels ...");
+        leWorldToPixels.initialiseFrom2PointsAndAngleW2P(regX1, regY1, xy1.second, xy1.first,
+                                                         regX2, regY2, xy2.second, xy2.first,
+                                                         northOffsetAngle);
+        define2PAThirdVertex();
+
+    } else if (!std::isnan(regX3) && std::isnan(northOffsetAngle)) {
+        offsetAngleDefined = false;
+        LOG_INFO(1, "point3 defined");
+        auto xy3 = mercator(regLat3, regLon3);
+        LOG_INFO(dbg, "ref3 %4.6f, %4.6f => %4.6f, %4.6f", regX3, regY3, regLat3, regLon3);
+        LOG_INFO(dbg, "ref3 after mercator        %4.6f, %4.6f", xy3.first, xy3.second);
+
+        LOG_INFO(dbg, "WorldToPixels ...");
+        leWorldToPixels.initialiseFrom3PointsW2P(regX1, regY1, xy1.second, xy1.first,
+                                                 regX2, regY2, xy2.second, xy2.first,
+                                                 regX3, regY3, xy3.second, xy3.first);
+        LOG_INFO(dbg, "PixelsToWorld ...");
+        lePixelsToWorld.initialiseFrom3PointsP2W(xy1.second, xy1.first, regX1, regY1,
+                                                 xy2.second, xy2.first, regX2, regY2,
+                                                 xy3.second, xy3.first, regX3, regY3);
+
+        northOffsetAngle = leWorldToPixels.getAngleDegrees();
+        LOG_INFO(1, "Calculated northOffsetAngle = %4.10f", northOffsetAngle);
+
+    } else {
+        LOG_ERROR("ERROR - Both northOffsetAngle and point3 are defined");
         return;
     }
 
-    coverLon = deltaLon / deltaX; // total longitudes covered
-    coverLat = deltaLat / deltaY;
-
-    // increase accuracy by choosing the right-most point for the left longitude
-    if (regX1 > regX2) {
-        leftLongitude = xy1.second - coverLon * regX1;
-    } else {
-        leftLongitude = xy2.second - coverLon * regX2;
+    if (dbg) {
+        logDebugInfo();
     }
 
-    if (regY1 > regY2) {
-        topLatitude = xy1.first - coverLat * regY1;
-    } else {
-        topLatitude = xy2.first - coverLat * regY2;
+    if (checkNoNanCoefficients() && checkRefRecalculation() && 
+        checkCornerRoundTrip() && checkTriangle()) {
+        isCalibrated = true;
+        if (std::abs(std::round(northOffsetAngle)) > 0.5) {
+            report += ".\nNorth offset angle = " + std::to_string(int(std::round(northOffsetAngle)));
+        }
     }
 
-    isCalibrated = true;
+    logger::info("Calibration report : \n%s", report.c_str());
+}
+
+void Calibration::logDebugInfo() const {
+    // Log reversed coefficients for equivalence check during development/debug/refactoring
+    double ax, bx, cx,  ay, by, cy, axr, bxr, cxr, ayr, byr, cyr;
+    LinearEquation leReversed;
+
+    leReversed.calculateReverseCoeffs(lePixelsToWorld);
+    leWorldToPixels.getCoeffs(ax, bx, cx, ay, by, cy);
+    leReversed.getCoeffs(axr, bxr, cxr, ayr, byr, cyr);
+    LOG_INFO(dbg, "leW2P          %+4.10f, %+4.10f, %+4.10f,  %+4.10f, %+4.10f, %+4.10f",
+            ax, bx, cx,  ay, by, cy);
+    LOG_INFO(dbg, "leP2W reversed %+4.10f, %+4.10f, %+4.10f,  %+4.10f, %+4.10f, %+4.10f",
+            axr, bxr, cxr,  ayr, byr, cyr);
+
+    leReversed.calculateReverseCoeffs(leWorldToPixels);
+    lePixelsToWorld.getCoeffs(ax, bx, cx, ay, by, cy);
+    leReversed.getCoeffs(axr, bxr, cxr, ayr, byr, cyr);
+    LOG_INFO(dbg, "leW2P          %+4.10f, %+4.10f, %+4.10f,  %+4.10f, %+4.10f, %+4.10f",
+            ax, bx, cx,  ay, by, cy);
+    LOG_INFO(dbg, "leP2W reversed %+4.10f, %+4.10f, %+4.10f,  %+4.10f, %+4.10f, %+4.10f",
+            axr, bxr, cxr,  ayr, byr, cyr);
+
+    // Recalculate reference points
+    img::Point<double> p, w;
+    w = pixelsToWorld(regX1, regY1);
+    LOG_INFO(dbg, "reference 1 P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX1, regY1, regLon1, regLat1);
+    LOG_INFO(dbg, "computed    P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX1, regY1, w.x, w.y);
+    p = worldToPixels(regLon1, regLat1);
+    LOG_INFO(dbg, "reference 1 W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon1, regLat1, regX1, regY1);
+    LOG_INFO(dbg, "computed    W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon1, regLat1, p.x, p.y);
+
+    w = pixelsToWorld(regX2, regY2);
+    LOG_INFO(dbg, "reference 2 P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX2, regY2, regLon2, regLat2);
+    LOG_INFO(dbg, "computed    P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX2, regY2, w.x, w.y);
+    p = worldToPixels(regLon2, regLat2);
+    LOG_INFO(dbg, "reference 2 W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon2, regLat2, regX2, regY2);
+    LOG_INFO(dbg, "computed    W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon2, regLat2, p.x, p.y);
+
+    if (!offsetAngleDefined) {
+        w = pixelsToWorld(regX3, regY3);
+        LOG_INFO(dbg, "reference 3 P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX3, regY3, regLon3, regLat3);
+        LOG_INFO(dbg, "computed    P2W  %4.6f, %4.6f - > %4.6f, %4.6f", regX3, regY3, w.x, w.y);
+        p = worldToPixels(regLon3, regLat3);
+        LOG_INFO(dbg, "reference 3 W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon3, regLat3, regX3, regY3);
+        LOG_INFO(dbg, "computed    W2P  %4.6f, %4.6f - > %4.6f, %4.6f", regLon3, regLat3, p.x, p.y);
+    }
+}
+
+bool Calibration::checkNoNanCoefficients() {
+    // Check no NaN in any calibration coefficients
+    if (lePixelsToWorld.hasNanCoeff() || leWorldToPixels.hasNanCoeff()) {
+        LOG_ERROR("Unable to calibrate - linear equations have NaN coefficient");
+        LOG_ERROR("Maybe similar reference points ?");
+        report = "Calibration failed. See Avitab.log for further details";
+        return false;
+    } else {
+        return true;
+    }
+}
+
+bool Calibration::checkRefRecalculation() {
+    // Check recalculation of reference points from world -> pixels
+    // Useful during development/refactoring as a sanity check, but should pass during normal use.
+    // If this goes wrong, it's more likely a programming/development/refactoring issue
+    // (Checking pixels -> world is difficult to reliably automate, but verbose log shows info)
+    img::Point<double> p;
+    double ex1, ey1, ex2, ey2, ex3, ey3;
+    p = worldToPixels(regLon1, regLat1);
+    ex1 = std::abs(p.x - regX1);
+    ey1 = std::abs(p.y - regY1);
+    p = worldToPixels(regLon2, regLat2);
+    ex2 = std::abs(p.x - regX2);
+    ey2 = std::abs(p.y - regY2);
+    if (!offsetAngleDefined) {
+        p = worldToPixels(regLon3, regLat3);
+        ex3 = std::abs(p.x - regX3);
+        ey3 = std::abs(p.y - regY3);
+    } else {
+        ex3 = 0;
+        ey3 = 0;
+    }
+    static const double ERR = 0.0001;
+    if ((ex1 > ERR) || (ey1 > ERR) || (ex2 > ERR) || (ey2 > ERR) || (ex3 > ERR) || (ey3 > ERR)) {
+        LOG_ERROR("Recalculation of reference World -> Pixels bad, submit Avitab.log and chart to devs");
+        report = "Calibration failed. See Avitab.log for further details";
+        return false;
+    } else {
+        return true;
+    }
+}
+
+bool Calibration::checkCornerRoundTrip() {
+    // Sanity check round trip of corners :  pixels -> world -> pixels is OK
+    // Useful during development/refactoring as a sanity check, but should pass during normal use.
+    // If this goes wrong, it's more likely a programming/development/refactoring issue
+    for (int x = 0; x <=1; x++) {
+        for (int y = 0; y <=1; y++) {
+            auto w = pixelsToWorld(x, y);
+            auto p = worldToPixels(w.x, w.y);
+            if ((std::abs(p.x - x) > 0.1) || (std::abs(p.y - y) > 0.1)) {
+                LOG_ERROR("%d,%d -> %f,%f -> %f,%f", x, y, w.x, w.y, p.x, p.y);
+                LOG_ERROR("Pixels -> World -> Pixels roundtrip is bad, submit Avitab.log and chart to devs");
+                report = "Calibration failed. See Avitab.log for further details";
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void Calibration::define2PAThirdVertex() {
+    // If 2 points and angle, there's a 3rd undefined vertex, at a right angle,
+    // that defines the calibration triangle. Rotate the 2 points first then
+    // other 2 sides are horizontal and vertical to join 3rd vertex. There are 2 solutions
+    // to this, but for our purposes, it doesn't matter which we use.
+    auto p1r = rotate(regX1, regY1, northOffsetAngle);
+    auto p2r = rotate(regX2, regY2, northOffsetAngle);
+    auto p3r = rotate(p1r.first, p2r.second, -northOffsetAngle);
+    regX3 = p3r.first;
+    regY3 = p3r.second;
+    LOG_INFO(dbg, "x, y = %4.8f, %4.8f", regX3, regY3);
+}
+
+double Calibration::getTriangleInnerAngleA(double a, double b, double c) const {
+    // Given lengths of 3 sides of a triangle, what is the inner angle opposite length a
+    return std::acos((std::pow(b, 2) + std::pow(c, 2) - std::pow(a, 2)) / (2 * b * c)) * 180 / M_PI;
+}
+
+double Calibration::getTriangleSmallestInnerAngle() const {
+    // We want a fat triangle to get good calibration, best is equilateral with inner angles 60,60,60
+    // Very thin triangles are bad, so what's the smallest inner angle in our calibration triangle
+    double s1 = std::sqrt(std::pow((regX2 - regX3), 2) + std::pow((regY2 - regY3), 2));
+    double s2 = std::sqrt(std::pow((regX1 - regX3), 2) + std::pow((regY1 - regY3), 2));
+    double s3 = std::sqrt(std::pow((regX1 - regX2), 2) + std::pow((regY1 - regY2), 2));
+    double a1 = getTriangleInnerAngleA(s1, s2, s3);
+    double a2 = getTriangleInnerAngleA(s2, s1, s3);
+    double a3 = getTriangleInnerAngleA(s3, s1, s2);
+    double smallestAngle = std::min(a1, std::min(a2, a3));
+    LOG_INFO(1, "sides = %f %f %f, angles %f %f %f, smallest %f", s1, s2, s3, a1, a2, a3, smallestAngle);
+    return smallestAngle;
+}
+
+double Calibration::getTriangleArea() const {
+    double area = std::abs(regX1 * (regY2 - regY3) + regX2 * (regY3 - regY1) + regX3 * (regY1 - regY2)) / 2;
+    LOG_INFO(1, "area = %f", area);
+    return area;
+}
+
+bool Calibration::checkTriangle() {
+    // Check the fatness and area of the triangle formed by the 3 provided reference points
+    // For 2 points + angle, a rotation is first performed to align north. A vertical and a horizontal
+    // line then form a right angle triangle from the 2 provided reference points.
+    report = "Calibration successful";
+    double angle = getTriangleSmallestInnerAngle();
+    double area = getTriangleArea();
+
+    if (angle < RECOMMENDED_SMALLEST_ANGLE) {
+        LOG_ERROR("Smallest inner angle in the calibration triangle is only %f",  angle);
+        LOG_ERROR("Minimum value is %f", MINIMUM_SMALLEST_ANGLE);
+        LOG_ERROR("Recommended value is at least %f", RECOMMENDED_SMALLEST_ANGLE);
+        LOG_ERROR("Best value is %f, for equilateral triangle", BEST_SMALLEST_ANGLE);
+        if (offsetAngleDefined) {
+        	LOG_ERROR("Note that with 2 points and an angle, the triangle is defined after chart rotation to align north");
+        }
+        if (angle < MINIMUM_SMALLEST_ANGLE) {
+            report = "Calibration failed. Triangle formed by reference points is too thin. See Avitab.log for further details";
+            return false;
+        } else {
+            report = "Calibration may be inaccurate. Triangle formed by reference points may be too thin. See Avitab.log for further details";
+        }
+    }
+
+    if (area < RECOMMENDED_AREA) {
+        LOG_ERROR("Area of the calibration triangle is only %f", area);
+        LOG_ERROR("Minimum value is %f", MINIMUM_AREA);
+        LOG_ERROR("Recommended value is at least %f", RECOMMENDED_AREA);
+        LOG_ERROR("Best value is %f, for corners of chart", BEST_AREA);
+        if (area < MINIMUM_AREA) {
+            report = "Calibration failed. Triangle formed by reference points is too small. See Avitab.log for further details";
+            return false;
+        } else {
+            report = "Calibration may be inaccurate. Triangle formed by reference points may be too small. See Avitab.log for further details";
+        }
+    }
+
+    return true;
 }
 
 std::pair<double, double> Calibration::mercator(double lat, double lon) const {
@@ -137,25 +471,39 @@ double Calibration::invMercator(double lat) const {
 }
 
 img::Point<double> Calibration::worldToPixels(double lon, double lat) const {
+    LOG_INFO(0, "lat,lon = %4.10f,%4.10f", lat, lon);
+
     auto xy = mercator(lat, lon);
+    LOG_INFO(0, "x,y =     %4.10f,%4.10f", xy.first, xy.second);
 
-    double normX = (xy.second - leftLongitude) / coverLon;
-    double normY = (xy.first - topLatitude) / coverLat;
+    auto r = leWorldToPixels.getResult(xy.second, xy.first);
+    double x = r.first;
+    double y = r.second;
 
-    return img::Point<double>{normX, normY};
+    LOG_INFO(0, "x,y =     %4.10f,%4.10f", x, y);
+    return img::Point<double>{x, y};
 }
 
 img::Point<double> Calibration::pixelsToWorld(double x, double y) const {
-    double lat = topLatitude + y * coverLat;
-    double lon = leftLongitude + x * coverLon;
+    LOG_INFO(0, "x,y =     %4.10f,%4.10f", x, y);
+
+    auto r = lePixelsToWorld.getResult(x, y);
+    double lat = r.second;
+    double lon = r.first;
+    LOG_INFO(0, "lat,lon = %4.10f,%4.10f", lat, lon);
 
     lat = invMercator(lat);
 
+    LOG_INFO(0, "lat,lon = %4.10f,%4.10f", lat, lon);
     return img::Point<double>{lon, lat};
 }
 
-int Calibration::getPreRotate() {
+int Calibration::getPreRotate() const {
     return preRotate;
+}
+
+double Calibration::getNorthOffset() const {
+    return northOffsetAngle;
 }
 
 } /* namespace maps */

--- a/src/maps/sources/Calibration.cpp
+++ b/src/maps/sources/Calibration.cpp
@@ -23,6 +23,10 @@
 
 namespace maps {
 
+void Calibration::setHash(const std::string &s) {
+    regHash = s;
+}
+
 void Calibration::setPoint1(double x, double y, double lat, double lon) {
     LOG_INFO(1,"%4.10f,%4.10f -> %4.10f,%4.10f", x, y, lat, lon);
     regX1 = x;
@@ -78,6 +82,7 @@ std::string Calibration::toString() const {
     if (offsetAngleDefined) {
         json["calibration"] =
                     {
+                        {"hash", regHash},
                         {"prerotate", preRotate},
 
                         {"x1", regX1},
@@ -95,6 +100,7 @@ std::string Calibration::toString() const {
     } else {
         json["calibration"] =
                     {
+                        {"hash", regHash},
                         {"prerotate", preRotate},
 
                         {"x1", regX1},
@@ -433,7 +439,7 @@ bool Calibration::checkTriangle() {
         LOG_ERROR("Recommended value is at least %f", RECOMMENDED_SMALLEST_ANGLE);
         LOG_ERROR("Best value is %f, for equilateral triangle", BEST_SMALLEST_ANGLE);
         if (offsetAngleDefined) {
-        	LOG_ERROR("Note that with 2 points and an angle, the triangle is defined after chart rotation to align north");
+            LOG_ERROR("Note that with 2 points and an angle, the triangle is defined after chart rotation to align north");
         }
         if (angle < MINIMUM_SMALLEST_ANGLE) {
             report = "Calibration failed. Triangle formed by reference points is too thin. See Avitab.log for further details";

--- a/src/maps/sources/Calibration.h
+++ b/src/maps/sources/Calibration.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <string>
 #include "src/libimg/stitcher/TileSource.h"
+#include "LinearEquation.h"
 
 namespace maps {
 
@@ -28,28 +29,60 @@ class Calibration {
 public:
     void setPoint1(double x, double y, double lat, double lon);
     void setPoint2(double x, double y, double lat, double lon);
+    void setPoint3(double x, double y, double lat, double lon);
+    void setAngle(double angle);
     void setPreRotate(int angle);
 
-    std::string toString();
-    void fromString(const std::string &s);
+    std::string toString()const;
+    void fromJsonString(const std::string &s);
+    void fromKmlString(const std::string &s);
 
     bool hasCalibration() const;
 
     img::Point<double> worldToPixels(double lon, double lat) const;
     img::Point<double> pixelsToWorld(double x, double y) const;
-    int getPreRotate();
+    int getPreRotate() const;
+    double getNorthOffset() const;
+    std::string getReport() const;
 
 private:
     int preRotate{};
     double regX1{}, regY1{}, regLat1{}, regLon1{};
     double regX2{}, regY2{}, regLat2{}, regLon2{};
-    double leftLongitude{}, coverLon{};
-    double topLatitude{}, coverLat{};
+    double regX3{}, regY3{}, regLat3{}, regLon3{};
+    double northOffsetAngle{};
     bool isCalibrated = false;
+    bool offsetAngleDefined = false;
+    std::string report{"No calibration"};
+    bool dbg = false;
+
+    LinearEquation leWorldToPixels;
+    LinearEquation lePixelsToWorld;
 
     void calculateCalibration();
+    std::pair<double, double> rotate(double x, double y, double angleDegrees) const;
+    std::string getKmlTagData(const std::string kml, const std::string tag) const;
     std::pair<double, double> mercator(double lat, double lon) const;
     double invMercator(double lat) const;
+    void define2PAThirdVertex();
+    double getTriangleInnerAngleA(double a, double b, double c) const;
+    double getTriangleSmallestInnerAngle() const;
+    double getTriangleArea() const;
+    void logDebugInfo() const;
+    bool checkNoNanCoefficients();
+    bool checkRefRecalculation();
+    bool checkCornerRoundTrip();
+    bool checkTriangle();
+
+    static constexpr double MAXIMUM_REF_RECALCULATION_ERROR = 0.01;
+    static constexpr double RECOMMENDED_REF_RECALCULATION_ERROR = 0.001;
+    static constexpr double BEST_REF_RECALCULATION_ERROR = 0.0;
+    static constexpr double MINIMUM_SMALLEST_ANGLE = 0.1;
+    static constexpr double RECOMMENDED_SMALLEST_ANGLE = 1;
+    static constexpr double BEST_SMALLEST_ANGLE = 60;
+    static constexpr double MINIMUM_AREA = 0.0002;
+    static constexpr double RECOMMENDED_AREA = 0.002;
+    static constexpr double BEST_AREA = 0.5;
 };
 
 } /* namespace maps */

--- a/src/maps/sources/Calibration.h
+++ b/src/maps/sources/Calibration.h
@@ -32,6 +32,7 @@ public:
     void setPoint3(double x, double y, double lat, double lon);
     void setAngle(double angle);
     void setPreRotate(int angle);
+    void setHash(const std::string &s);
 
     std::string toString()const;
     void fromJsonString(const std::string &s);
@@ -50,6 +51,7 @@ private:
     double regX1{}, regY1{}, regLat1{}, regLon1{};
     double regX2{}, regY2{}, regLat2{}, regLon2{};
     double regX3{}, regY3{}, regLat3{}, regLon3{};
+    std::string regHash{};
     double northOffsetAngle{};
     bool isCalibrated = false;
     bool offsetAngleDefined = false;

--- a/src/maps/sources/ImageSource.cpp
+++ b/src/maps/sources/ImageSource.cpp
@@ -82,6 +82,10 @@ void ImageSource::attachCalibration2(double x, double y, double lat, double lon,
     calibration.setPoint2(normX, normY, lat, lon);
 }
 
+void ImageSource::attachCalibration3Angle(double angle) {
+    calibration.setAngle(0);
+}
+
 img::Point<int> ImageSource::getTileDimensions(int zoom) {
     return img::Point<int>{TILE_SIZE, TILE_SIZE};
 }

--- a/src/maps/sources/ImageSource.h
+++ b/src/maps/sources/ImageSource.h
@@ -49,6 +49,7 @@ public:
     bool supportsWorldCoords() override;
     void attachCalibration1(double x, double y, double lat, double lon, int zoom) override;
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
+    void attachCalibration3Angle(double angle) override;
     img::Point<double> worldToXY(double lon, double lat, int zoom) override;
     img::Point<double> xyToWorld(double x, double y, int zoom) override;
 

--- a/src/maps/sources/LinearEquation.cpp
+++ b/src/maps/sources/LinearEquation.cpp
@@ -1,0 +1,204 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <cmath>
+#include "LinearEquation.h"
+#include "src/Logger.h"
+#include <algorithm>
+#include <cfloat>
+#include <algorithm>
+
+namespace maps {
+
+void LinearEquation::initialiseFrom3PointsW2P(double px1, double py1, double wx1, double wy1,
+                                              double px2, double py2, double wx2, double wy2,
+                                              double px3, double py3, double wx3, double wy3) {
+    calculateCoeffsFrom3Points(px1, py1, wx1, wy1,  px2, py2, wx2, wy2,  px3, py3, wx3, wy3);
+    /* For World2Pixels, the linear equations are mapped to 3x3 2D Matrix multiplication for Rotate -> Translate -> Scale
+     * px = Sx.cos(A).wx - Sx.sin(A).wy + cx
+     * py = Sy.sin(A).wx + Sy.cos(A).wy + cy
+     * where bx = -Sx.sin(A) & ax = Sx.cos(A)
+     * so -bx/ax = sin(A)/cos(A) = tan(A)
+     */
+    double angleRadians = std::atan2(-bx, ax); // angleRadians = trig maths convention : -CW, +CCW
+    angle = -angleRadians * 180.0 / M_PI; // angle = compass/kml convention : -CCW, +CW
+    LOG_INFO(dbg, "    ax = %4.10f, bx = %4.10f, cx = %4.10f, angle = %4.10f", ax, bx, cx, angle);
+    LOG_INFO(dbg, "    ay = %4.10f, by = %4.10f, cy = %4.10f", ay, by, cy);
+}
+
+void LinearEquation::initialiseFrom3PointsP2W(double wx1, double wy1, double px1, double py1,
+                                              double wx2, double wy2, double px2, double py2,
+                                              double wx3, double wy3, double px3, double py3) {
+    calculateCoeffsFrom3Points(wx1, wy1, px1, py1,  wx2, wy2, px2, py2,  wx3, wy3, px3, py3);
+    
+    /* For PixelsToWorld, the linear equations are mapped to 3x3 2D Matrix multiplication for Scale -> Translate -> Rotate
+     * wx = Sx.cos(A).px - Sy.sin(A).py + cx
+     * wy = Sx.sin(A).px + Sy.cos(A).py + cy
+     * where ay = Sx.sin(A) & ax = Sx.cos(A)
+     * so ay/ax = sin(A)/cos(A) = tan(A)
+     */
+    double angleRadians = std::atan2(ay, ax); // angleRadians = trig maths convention : -CW, +CCW
+    angle = -angleRadians * 180.0 / M_PI; // angle = compass/kml convention : -CCW, +CW
+    LOG_INFO(dbg, "    ax = %4.10f, bx = %4.10f, cx = %4.10f, angle = %4.10f", ax, bx, cx, angle);
+    LOG_INFO(dbg, "    ay = %4.10f, by = %4.10f, cy = %4.10f", ay, by, cy);
+}
+
+void LinearEquation::calculateCoeffsFrom3Points(double rx1, double ry1, double x1, double y1,
+                                                double rx2, double ry2, double x2, double y2,
+                                                double rx3, double ry3, double x3, double y3) {
+    // Given 3 input points and 3 output points, then there's a 2D linear equation that represents the transformation
+    // x' = ax.x + bx.y + cx
+    // y' = ay.x + by.y + cy
+    // Solve the linear equations to determine the ax, bx, cx, ay, by, cy coefficients
+    // This is the same whether we're doing PixelsToWorld or WorldToPixels
+    ax = ((rx3 - rx1) * (y2 - y1) - (rx2 - rx1) * (y3 - y1)) / ((x3 - x1) * (y2 - y1) - (x2 - x1) * (y3 - y1));
+    bx = ((rx3 - rx1) * (x2 - x1) - (rx2 - rx1) * (x3 - x1)) / ((y3 - y1) * (x2 - x1) - (y2 - y1) * (x3 - x1));
+    cx = rx1 - ax * x1 - bx * y1;
+    ay = ((ry3 - ry1) * (y2 - y1) - (ry2 - ry1) * (y3 - y1)) / ((x3 - x1) * (y2 - y1) - (x2 - x1) * (y3 - y1));
+    by = ((ry3 - ry1) * (x2 - x1) - (ry2 - ry1) * (x3 - x1)) / ((y3 - y1) * (x2 - x1) - (y2 - y1) * (x3 - x1));
+    cy = ry1 - ay * x1 - by * y1;
+}
+
+void LinearEquation::initialiseFrom2PointsAndAngleP2W(double wx1, double wy1, double px1, double py1,
+                                                      double wx2, double wy2, double px2, double py2,
+                                                      double northOffsetAngleDegrees) {
+    // Incoming angle = compass/kml convention : -CCW, +CW
+
+    /*
+     * wx = ax.px + bx.py + cx
+     * wy = ay.px + by.py + cy
+     * which is mapped to 3x3 2D Matrix multiplication for Scale -> Translate -> Rotate
+     * wx = Sx.cos(A).px - Sy.sin(A).py + cx
+     * wy = Sx.sin(A).px + Sy.cos(A).py + cy
+     */
+
+    // To work out scaling, first apply rotation to the world coordinates to align north with chart
+    // The world coordinate system has Y axis pointing north/up for increasing values
+    // The pixel coordinate system has Y axis pointing down for increasing values
+    // So sign of rotation to align with chart is inverse of incoming northOffsetAngle
+    angle = -northOffsetAngleDegrees * M_PI / 180.0; // angle = maths convention (-CW, +CCW)
+    double wx1r = (wx1 * std::cos(angle)) - (wy1 * std::sin(angle));
+    double wx2r = (wx2 * std::cos(angle)) - (wy2 * std::sin(angle));
+    double wy1r = (wx1 * std::sin(angle)) + (wy1 * std::cos(angle));
+    double wy2r = (wx2 * std::sin(angle)) + (wy2 * std::cos(angle));
+
+    // Work out X & Y scaling factors
+    double Sx = (wx2r - wx1r) / (px2 - px1);
+    double Sy = (wy2r - wy1r) / (py2 - py1);
+
+    // Compute coefficients. Actual rotation transformation uses an angle with
+    // same sign as the incoming northOffsetAngle, but has maths convention (-CW, +CCW)
+    ax =  Sx * std::cos(-angle);
+    bx = -Sy * std::sin(-angle);
+    cx = wx1 - ax * px1 - bx * py1;
+    ay = Sx * std::sin(-angle);
+    by = Sy * std::cos(-angle);
+    cy = wy1 - ay * px1 - by * py1;
+
+    LOG_INFO(dbg, "ax = %4.10f, bx = %4.10f, cx = %4.10f, Sx = %4.10f", ax, bx, cx, Sx);
+    LOG_INFO(dbg, "ay = %4.10f, by = %4.10f, cy = %4.10f, Sy = %4.10f", ay, by, cy, Sy);
+    LOG_INFO(dbg, "X1, Y1       = %4.6f, %4.6f", wx1, wy1);
+    LOG_INFO(dbg, "recalculated = %4.6f, %4.6f", getResult(px1, py1).first, getResult(px1, py1).second);
+    LOG_INFO(dbg, "X2, Y2       = %4.6f, %4.6f", wx2, wy2);
+    LOG_INFO(dbg, "recalculated = %4.6f, %4.6f", getResult(px2, py2).first, getResult(px2, py2).second);
+}
+
+void LinearEquation::initialiseFrom2PointsAndAngleW2P(double px1, double py1, double wx1, double wy1,
+                                                      double px2, double py2, double wx2, double wy2,
+                                                      double northOffsetAngleDegrees) {
+    // Incoming angle = compass/kml convention : -CCW, +CW
+
+    /*
+     * px = ax.wx + bx.wy + cx
+     * py = ay.wx + by.wy + cy
+     * which is mapped to 3x3 2D Matrix multiplication for Rotate -> Translate -> Scale
+     * px = Sx.cos(A).wx - Sx.sin(A).wy + cx
+     * py = Sy.sin(A).wx + Sy.cos(A).wy + cy
+     */
+
+    // Apply rotation to the world coordinates to align north with chart
+    // The world coordinate system has Y axis pointing north/up for increasing values
+    // The pixel coordinate system has Y axis pointing down for increasing values
+    // So sign of rotation to align with chart is inverse of incoming northOffsetAngle
+    angle = -northOffsetAngleDegrees * M_PI / 180.0; // angle = Maths convention : -CW, +CCW
+    double wx1r = (wx1 * std::cos(angle)) - (wy1 * std::sin(angle));
+    double wx2r = (wx2 * std::cos(angle)) - (wy2 * std::sin(angle));
+    double wy1r = (wx1 * std::sin(angle)) + (wy1 * std::cos(angle));
+    double wy2r = (wx2 * std::sin(angle)) + (wy2 * std::cos(angle));
+
+    // Work out X & Y scaling factors
+    double Sx = (px2 - px1) / (wx2r - wx1r);
+    double Sy = (py2 - py1) / (wy2r - wy1r); // Sy will be -ve, which models the Y axis flip
+
+    // Compute coefficients using mapping above
+    ax =  Sx * std::cos(angle);
+    bx = -Sx * std::sin(angle);
+    cx = px1 - ax * wx1 - bx * wy1;
+    ay = Sy * std::sin(angle);
+    by = Sy * std::cos(angle);
+    cy = py1 - ay * wx1 - by * wy1;
+
+    LOG_INFO(dbg, "ax = %4.10f, bx = %4.10f, cx = %4.10f, Sx = %4.10f", ax, bx, cx, Sx);
+    LOG_INFO(dbg, "ay = %4.10f, by = %4.10f, cy = %4.10f, Sy = %4.10f", ay, by, cy, Sy);
+    LOG_INFO(dbg, "px1, py1     = %4.6f, %4.6f", px1, py1);
+    LOG_INFO(dbg, "recalculated = %4.6f, %4.6f", getResult(wx1, wy1).first, getResult(wx1, wy1).second);
+    LOG_INFO(dbg, "px2, py2     = %4.6f, %4.6f", px2, py2);
+    LOG_INFO(dbg, "recalculated = %4.6f, %4.6f", getResult(wx2, wy2).first, getResult(wx2, wy2).second);
+}
+
+void LinearEquation::calculateReverseCoeffs(const LinearEquation & le) {
+    double divx = le.ax * le.by - le.ay * le.bx;
+    ax =  le.by / divx;
+    bx = -le.bx / divx;
+    cx = (le.bx * le.cy - le.cx * le.by) / divx;
+
+    double divy = le.by * le.ax - le.ay * le.bx;
+    ay = -le.ay / divy;
+    by =  le.ax / divy;
+    cy = (le.ay * le.cx - le.cy * le.ax) / divy;
+
+    LOG_INFO(0, "  ax = %4.10f, bx = %4.10f, cx = %4.10f, divx = %4.10f, ", ax, bx, cx, divx);
+    LOG_INFO(0, "  ay = %4.10f, by = %4.10f, cy = %4.10f, divy = %4.10f, ", ay, by, cy, divy);
+}
+
+std::pair<double,double> LinearEquation::getResult(double x, double y) const {
+    double rx = ax * x + bx * y + cx;
+    double ry = ay * x + by * y + cy;
+    return std::make_pair(rx, ry);
+}
+
+void LinearEquation::getCoeffs(double &_ax, double &_bx, double &_cx,
+                               double &_ay, double &_by, double &_cy) const {
+    _ax = ay;
+    _bx = by;
+    _cx = cy;
+    _ay = ay;
+    _by = by;
+    _cy = cy;
+}
+
+bool LinearEquation::hasNanCoeff() const {
+    // We hope not !
+    return std::isnan(ax) || std::isnan(bx) || std::isnan(cx) ||
+           std::isnan(ay) || std::isnan(by) || std::isnan(cy);
+}
+
+double LinearEquation::getAngleDegrees() const {
+    return angle;
+}
+
+} /* namespace maps */

--- a/src/maps/sources/LinearEquation.h
+++ b/src/maps/sources/LinearEquation.h
@@ -1,0 +1,69 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_MAPS_SOURCES_LINEAREQUATION_H_
+#define SRC_MAPS_SOURCES_LINEAREQUATION_H_
+
+#include <utility>
+namespace maps {
+
+class LinearEquation {
+public:
+
+    void   initialiseFrom3PointsW2P(double px1, double py1, double wx1, double wy1,
+                                    double px2, double py2, double wx2, double wy2,
+                                    double px3, double py3, double wx3, double wy3);
+
+    void   initialiseFrom3PointsP2W(double wx1, double wy1, double px1, double py1,
+                                    double wx2, double wy2, double px2, double py2,
+                                    double wx3, double wy3, double px3, double py3);
+
+    void   initialiseFrom2PointsAndAngleP2W(double wx1, double wy1, double px1, double py1,
+                                            double wx2, double wy2, double px2, double py2,
+                                            double northOffsetAngleDegrees);
+
+    void   initialiseFrom2PointsAndAngleW2P(double px1, double py1, double wx1, double wy1,
+                                            double px2, double py2, double wx2, double wy2,
+                                            double northOffsetAngleDegrees);
+
+    void   calculateReverseCoeffs(const LinearEquation & l);
+
+    std::pair<double, double> getResult(double x, double y) const;
+    double getAngleDegrees() const;
+    void   getCoeffs(double &_ax, double &_bx, double &_cx,
+                     double &_ay, double &_by, double &_cy) const;
+    bool hasNanCoeff() const;
+
+private:
+
+    void   calculateCoeffsFrom3Points(double rx1, double ry1, double x1, double y1,
+                                      double rx2, double ry2, double x2, double y2,
+                                      double rx3, double ry3, double x3, double y3);
+    double ax{};
+    double bx{};
+    double cx{};
+    double ay{};
+    double by{};
+    double cy{};
+    double angle{};
+
+    bool dbg = false;
+};
+
+} /* namespace maps */
+
+#endif /* SRC_MAPS_SOURCES_LINEAREQUATION_H_ */

--- a/src/maps/sources/PDFSource.cpp
+++ b/src/maps/sources/PDFSource.cpp
@@ -213,7 +213,7 @@ void PDFSource::loadCalibration() {
     if (jsonFile.fail()) {
         // Try reading a Google Earth KML file for calibration
         std::string kmlFileName = utf8FileName + ".kml";
-        std::ifstream kmlFile(fs::u8path(kmlFileName));
+        fs::ifstream kmlFile(fs::u8path(kmlFileName));
         if (kmlFile.fail()) {
             logger::warn("No json or kml calibration file for %s", utf8FileName.c_str());
             return;

--- a/src/maps/sources/PDFSource.cpp
+++ b/src/maps/sources/PDFSource.cpp
@@ -197,6 +197,7 @@ void PDFSource::storeCalibration() {
         return;
     }
     try {
+        calibration.setHash(platform::getFileSha256(utf8FileName));
         std::string calFileName = utf8FileName + ".json";
         fs::ofstream jsonFile(fs::u8path(calFileName));
         jsonFile << calibration.toString();

--- a/src/maps/sources/PDFSource.cpp
+++ b/src/maps/sources/PDFSource.cpp
@@ -197,7 +197,7 @@ void PDFSource::storeCalibration() {
         return;
     }
     try {
-        calibration.setHash(platform::getFileSha256(utf8FileName));
+        calibration.setHash(crypto.getFileSha256(utf8FileName));
         std::string calFileName = utf8FileName + ".json";
         fs::ofstream jsonFile(fs::u8path(calFileName));
         jsonFile << calibration.toString();

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -48,14 +48,18 @@ public:
     void resumeLoading() override;
 
     bool supportsWorldCoords() override;
+    std::string getCalibrationReport() override;
     img::Point<double> worldToXY(double lon, double lat, int zoom) override;
     img::Point<double> xyToWorld(double x, double y, int zoom) override;
 
     void attachCalibration1(double x, double y, double lat, double lon, int zoom) override;
     void attachCalibration2(double x, double y, double lat, double lon, int zoom) override;
+    void attachCalibration3Point(double x, double y, double lat, double lon, int zoom) override;
+    void attachCalibration3Angle(double angle) override;
 
     void setNightMode(bool night);
     void rotate() override;
+    double getNorthOffsetAngle() override;
 
 private:
     std::string utf8FileName;

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -24,6 +24,7 @@
 #include "Calibration.h"
 #include "src/libimg/stitcher/TileSource.h"
 #include "src/libimg/Rasterizer.h"
+#include "src/charts/Crypto.h"
 
 namespace maps {
 
@@ -67,6 +68,7 @@ private:
     Calibration calibration;
     bool nightMode = false;
     int rotateAngle = 0;
+    apis::Crypto crypto;
 
     void storeCalibration();
     void loadCalibration();

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -36,7 +36,6 @@
 #include <regex>
 #include <fstream>
 #include <algorithm>
-#include <mbedtls/rsa.h>
 #include "Platform.h"
 #include "src/Logger.h"
 
@@ -221,41 +220,6 @@ std::string getDirNameFromPath(const std::string& utf8Path) {
 bool fileExists(const std::string& utf8Path) {
     auto path = fs::u8path(utf8Path);
     return fs::exists(path);
-}
-
-std::string getFileSha256(const std::string &utf8Path) {
-    std::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
-    if (!ifs.is_open()) {
-        LOG_ERROR("Unable to open file '%s'", utf8Path.c_str());
-        return "No file !";
-    }
-
-    std::streampos size = ifs.tellg();
-    auto fileBytes = std::unique_ptr<char[]>(new char[size]);
-    ifs.seekg (0, std::ios::beg);
-    ifs.read (fileBytes.get(), size);
-    ifs.close();
-
-    return getSha256(fileBytes.get(), size);
-}
-
-std::string getSha256(const char * bytes, const int size) {
-    static const int DIGEST_SIZE = 32;
-    unsigned char digest[DIGEST_SIZE];
-    mbedtls_md_context_t ctx;
-    mbedtls_md_init(&ctx);
-    mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 0);
-    mbedtls_md_starts(&ctx);
-    mbedtls_md_update(&ctx, (const unsigned char *) bytes, size);
-    mbedtls_md_finish(&ctx, digest);
-    mbedtls_md_free(&ctx);
-
-    char digest_str[DIGEST_SIZE * 2 + 1];
-    for(int i = 0; i < DIGEST_SIZE; i++) {
-        sprintf(digest_str + i * 2, "%02x", digest[i]);
-    }
-
-    return std::string(digest_str);
 }
 
 void mkdir(const std::string& utf8Path) {

--- a/src/platform/Platform.cpp
+++ b/src/platform/Platform.cpp
@@ -36,6 +36,7 @@
 #include <regex>
 #include <fstream>
 #include <algorithm>
+#include <mbedtls/rsa.h>
 #include "Platform.h"
 #include "src/Logger.h"
 
@@ -220,6 +221,41 @@ std::string getDirNameFromPath(const std::string& utf8Path) {
 bool fileExists(const std::string& utf8Path) {
     auto path = fs::u8path(utf8Path);
     return fs::exists(path);
+}
+
+std::string getFileSha256(const std::string &utf8Path) {
+    std::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
+    if (!ifs.is_open()) {
+        LOG_ERROR("Unable to open file '%s'", utf8Path.c_str());
+        return "No file !";
+    }
+
+    std::streampos size = ifs.tellg();
+    auto fileBytes = std::unique_ptr<char[]>(new char[size]);
+    ifs.seekg (0, std::ios::beg);
+    ifs.read (fileBytes.get(), size);
+    ifs.close();
+
+    return getSha256(fileBytes.get(), size);
+}
+
+std::string getSha256(const char * bytes, const int size) {
+    static const int DIGEST_SIZE = 32;
+    unsigned char digest[DIGEST_SIZE];
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 0);
+    mbedtls_md_starts(&ctx);
+    mbedtls_md_update(&ctx, (const unsigned char *) bytes, size);
+    mbedtls_md_finish(&ctx, digest);
+    mbedtls_md_free(&ctx);
+
+    char digest_str[DIGEST_SIZE * 2 + 1];
+    for(int i = 0; i < DIGEST_SIZE; i++) {
+        sprintf(digest_str + i * 2, "%02x", digest[i]);
+    }
+
+    return std::string(digest_str);
 }
 
 void mkdir(const std::string& utf8Path) {

--- a/src/platform/Platform.h
+++ b/src/platform/Platform.h
@@ -101,8 +101,6 @@ std::string realPath(const std::string &utf8Path);
 std::string getFileNameFromPath(const std::string &utf8Path);
 std::string getDirNameFromPath(const std::string &utf8Path);
 bool fileExists(const std::string &utf8Path);
-std::string getFileSha256(const std::string &utf8Path);
-std::string getSha256(const char *bytes, const int size);
 void mkdir(const std::string &utf8Path);
 void mkpath(const std::string &utf8Path);
 void removeFile(const std::string &utf8Path);

--- a/src/platform/Platform.h
+++ b/src/platform/Platform.h
@@ -101,6 +101,8 @@ std::string realPath(const std::string &utf8Path);
 std::string getFileNameFromPath(const std::string &utf8Path);
 std::string getDirNameFromPath(const std::string &utf8Path);
 bool fileExists(const std::string &utf8Path);
+std::string getFileSha256(const std::string &utf8Path);
+std::string getSha256(const char *bytes, const int size);
 void mkdir(const std::string &utf8Path);
 void mkpath(const std::string &utf8Path);
 void removeFile(const std::string &utf8Path);


### PR DESCRIPTION
Calibration now requires the user enter 3 datapoints. The first 2 datapoints are lat/lon as normal.
The 3rd datapoint can be either another lat/lon, or an angle, representing the offset from North on the chart. The 3rd datapoint text field is prefilled with '0', as a default angle for typical North up charts.

Avitab can also now get calibration metadata from a .kml file, saved from Google Earth after a chart has been georeferenced via Image Overlay.

A more complex set of 2D linear equations have been implemented to represent the 2D matrix operations for the Rotate/Translate/Scale transformations between pixel and world coordinates. Added more logging and reporting of calibration success/failure.

I've added some code to hopefully ensure this still works with Navigraph, but am unable to test.