### PR TITLE
Load calibration from remote hash-mapped json file

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -206,7 +206,7 @@ void MapApp::selectMercator() {
     fileChooser->setSelectCallback([this] (const std::string &selectedUTF8) {
         api().executeLater([this, selectedUTF8] () {
             try {
-                auto pdfSource = std::make_shared<maps::PDFSource>(selectedUTF8);
+                auto pdfSource = std::make_shared<maps::PDFSource>(selectedUTF8, api().getChartService());
                 setTileSource(pdfSource);
                 fileChooser.reset();
                 chooserContainer->setVisible(false);

--- a/src/charts/ChartService.h
+++ b/src/charts/ChartService.h
@@ -26,6 +26,7 @@
 #include "src/charts/libchartfox/ChartFoxAPI.h"
 #include "src/charts/liblocalfile/LocalFileAPI.h"
 #include "src/charts/libnavigraph/NavigraphAPI.h"
+#include "src/charts/Crypto.h"
 
 namespace apis {
 
@@ -51,6 +52,8 @@ public:
     std::shared_ptr<navigraph::NavigraphAPI> getNavigraph();
     void submitCall(std::shared_ptr<BaseCall> call);
 
+    std::string getHashMappedJson(std::string utf8ChartFileName) const;
+
 private:
     std::shared_ptr<navigraph::NavigraphAPI> navigraph;
     std::shared_ptr<chartfox::ChartFoxAPI> chartfox;
@@ -65,6 +68,11 @@ private:
     std::atomic_bool keepAlive { false };
     std::unique_ptr<std::thread> apiThread;
     std::vector<std::shared_ptr<BaseCall>> pendingCalls;
+
+    Crypto crypto;
+    std::map<std::string, std::string> jsonFileHashes;
+
+    void scanJsonFiles(std::string dir);
 
     bool hasWork();
     void workLoop();

--- a/src/charts/Crypto.cpp
+++ b/src/charts/Crypto.cpp
@@ -54,7 +54,7 @@ std::vector<uint8_t> Crypto::generateRandom(size_t len) {
     return res;
 }
 
-std::vector<uint8_t> Crypto::sha256(const std::string& in) {
+std::vector<uint8_t> Crypto::sha256(const std::string& in) const {
     const mbedtls_md_info_t *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     if (!info) {
         throw std::runtime_error("Couldn't find SHA256");
@@ -68,7 +68,7 @@ std::vector<uint8_t> Crypto::sha256(const std::string& in) {
     return hash;
 }
 
-std::string Crypto::sha256String(const std::string& in) {
+std::string Crypto::sha256String(const std::string& in) const {
     auto hash = sha256(in);
     std::ostringstream buffer;
     buffer << std::hex << std::setfill('0');
@@ -201,7 +201,7 @@ std::string Crypto::aesDecrypt(const std::string& in, const std::string& key) {
     return std::string((char *) plain.data());
 }
 
-std::string Crypto::getFileSha256(const std::string &utf8Path) {
+std::string Crypto::getFileSha256(const std::string &utf8Path) const {
     fs::ifstream ifs (utf8Path, std::ios::in|std::ios::binary|std::ios::ate);
     if (!ifs.is_open()) {
         LOG_ERROR("Unable to open file '%s'", utf8Path.c_str());

--- a/src/charts/Crypto.h
+++ b/src/charts/Crypto.h
@@ -31,8 +31,8 @@ namespace apis {
 class Crypto {
 public:
     Crypto();
-    std::vector<uint8_t> sha256(const std::string &in);
-    std::string sha256String(const std::string& in);
+    std::vector<uint8_t> sha256(const std::string &in) const;
+    std::string sha256String(const std::string& in) const;
     std::vector<uint8_t> generateRandom(size_t len);
     std::string urlEncode(const std::string &in);
     std::string base64URLEncode(const std::vector<uint8_t> &in);
@@ -41,7 +41,7 @@ public:
     bool RSASHA256(const std::string &base64in, const std::string &sig, const std::string &n, const std::string &e);
     std::string aesEncrypt(const std::string &in, const std::string &key);
     std::string aesDecrypt(const std::string &in, const std::string &key);
-    std::string getFileSha256(const std::string &utf8Path);
+    std::string getFileSha256(const std::string &utf8Path) const;
     virtual ~Crypto();
 private:
     mbedtls_aes_context aesCtx {};

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -25,12 +25,13 @@
 #include "src/libimg/stitcher/TileSource.h"
 #include "src/libimg/Rasterizer.h"
 #include "src/charts/Crypto.h"
+#include "src/charts/ChartService.h"
 
 namespace maps {
 
 class PDFSource: public img::TileSource {
 public:
-    PDFSource(const std::string &file);
+    PDFSource(const std::string& file, std::shared_ptr<apis::ChartService> chartService = NULL);
     PDFSource(const std::vector<uint8_t> &pdfData);
 
     int getMinZoomLevel() override;
@@ -69,7 +70,7 @@ private:
     bool nightMode = false;
     int rotateAngle = 0;
     apis::Crypto crypto;
-
+    std::shared_ptr<apis::ChartService> chartService;
     void storeCalibration();
     void loadCalibration();
 };


### PR DESCRIPTION
Json calibration files can now optionally be kept in MapTiles/Mercator/Calibration, decoupled from charts. This directory is scanned at startup by ChartService and a std::Map created of sha256 hash -> json file. During load of calibration for a chart in PDFSource, if a name-matched co-located json or kml file is not found, then a hash-matched json file is used.