### PR TITLE
Georeference Chartfox with hash-matching json

### DIFF
--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -383,8 +383,11 @@ void AirportApp::onChartLoaded(std::shared_ptr<Page> page) {
     TabPage &tab = findPage(page);
 
     tab.label->setVisible(false);
-    tab.overlays = std::make_shared<maps::OverlayConfig>();
-
+    if (api().getSettings()->getGeneralSetting<bool>("show_overlays_in_airport_app")) {
+        tab.overlays = api().getSettings()->getOverlayConfig();
+    } else {
+        tab.overlays = std::make_shared<maps::OverlayConfig>();
+    }
     tab.window->addSymbol(Widget::Symbol::MINUS, [this, page] {
         TabPage &tab = findPage(page);
         tab.map->zoomOut();

--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -440,6 +440,16 @@ void AirportApp::onChartLoaded(std::shared_ptr<Page> page) {
         });
     }
 
+    if (tab.mapSource->supportsWorldCoords()) {
+        messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), "Chart is georeferenced");
+        messageBox->addButton("Ok", [this] () {
+            api().executeLater([this] () {
+                messageBox.reset();
+            });
+        });
+        messageBox->centerInParent();
+    }
+
     onTimer();
 }
 

--- a/src/avitab/apps/AirportApp.h
+++ b/src/avitab/apps/AirportApp.h
@@ -31,6 +31,7 @@
 #include "src/gui_toolkit/widgets/DropDownList.h"
 #include "src/gui_toolkit/widgets/List.h"
 #include "src/gui_toolkit/widgets/Window.h"
+#include "src/gui_toolkit/widgets/MessageBox.h"
 #include "src/gui_toolkit/Timer.h"
 #include "src/libimg/stitcher/TileSource.h"
 #include "src/maps/OverlayedMap.h"
@@ -76,6 +77,7 @@ private:
     std::shared_ptr<DropDownList> resultList;
     std::shared_ptr<Button> nextButton;
     std::shared_ptr<Keyboard> keys;
+    std::unique_ptr<MessageBox> messageBox;
 
     void removeTab(std::shared_ptr<Page> page);
     void resetLayout();

--- a/src/avitab/apps/DocumentsApp.cpp
+++ b/src/avitab/apps/DocumentsApp.cpp
@@ -196,7 +196,8 @@ void DocumentsApp::setupCallbacks(PageInfo tab) {
 }
 
 void DocumentsApp::loadFile(PageInfo tab, const std::string &pdfPath) {
-    tab->source = std::make_shared<maps::PDFSource>(pdfPath);
+    std::string cm = api().getChartService()->getCalibrationMetadataForFile(pdfPath);
+    tab->source = std::make_shared<maps::PDFSource>(pdfPath, cm);
     tab->stitcher = std::make_shared<img::Stitcher>(tab->rasterImage, tab->source);
     tab->stitcher->setCacheDirectory(api().getDataPath() + "MapTiles/");
 
@@ -213,6 +214,16 @@ void DocumentsApp::loadFile(PageInfo tab, const std::string &pdfPath) {
         positionPage(tab, VerticalPosition::Top, HorizontalPosition::Middle, ZoomAdjust::Width);
     } else {
         positionPage(tab, VerticalPosition::Centre, HorizontalPosition::Middle, ZoomAdjust::All);
+    }
+
+    if (tab->source->supportsWorldCoords()) {
+        messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), "Chart is georeferenced");
+        messageBox->addButton("Ok", [this] () {
+            api().executeLater([this] () {
+                messageBox.reset();
+            });
+        });
+        messageBox->centerInParent();
     }
 }
 

--- a/src/avitab/apps/DocumentsApp.cpp
+++ b/src/avitab/apps/DocumentsApp.cpp
@@ -215,16 +215,6 @@ void DocumentsApp::loadFile(PageInfo tab, const std::string &pdfPath) {
     } else {
         positionPage(tab, VerticalPosition::Centre, HorizontalPosition::Middle, ZoomAdjust::All);
     }
-
-    if (tab->source->supportsWorldCoords()) {
-        messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), "Chart is georeferenced");
-        messageBox->addButton("Ok", [this] () {
-            api().executeLater([this] () {
-                messageBox.reset();
-            });
-        });
-        messageBox->centerInParent();
-    }
 }
 
 void DocumentsApp::setTitle(PageInfo tab) {

--- a/src/avitab/apps/DocumentsApp.h
+++ b/src/avitab/apps/DocumentsApp.h
@@ -30,7 +30,6 @@
 #include "src/gui_toolkit/widgets/Checkbox.h"
 #include "src/gui_toolkit/widgets/Container.h"
 #include "src/gui_toolkit/widgets/Label.h"
-#include "src/gui_toolkit/widgets/MessageBox.h"
 #include "src/gui_toolkit/Timer.h"
 #include "src/libimg/Image.h"
 #include "src/libimg/stitcher/Stitcher.h"
@@ -108,7 +107,6 @@ private:
     std::shared_ptr<Container> settingsContainer;
     std::shared_ptr<Label> settingsLabel;
     std::shared_ptr<Checkbox> mouseWheelScrollsCheckbox;
-    std::unique_ptr<MessageBox> messageBox;
     void showAppSettings();
 
     enum class VerticalPosition { Top, Centre, Bottom };

--- a/src/avitab/apps/DocumentsApp.h
+++ b/src/avitab/apps/DocumentsApp.h
@@ -30,6 +30,7 @@
 #include "src/gui_toolkit/widgets/Checkbox.h"
 #include "src/gui_toolkit/widgets/Container.h"
 #include "src/gui_toolkit/widgets/Label.h"
+#include "src/gui_toolkit/widgets/MessageBox.h"
 #include "src/gui_toolkit/Timer.h"
 #include "src/libimg/Image.h"
 #include "src/libimg/stitcher/Stitcher.h"
@@ -107,6 +108,7 @@ private:
     std::shared_ptr<Container> settingsContainer;
     std::shared_ptr<Label> settingsLabel;
     std::shared_ptr<Checkbox> mouseWheelScrollsCheckbox;
+    std::unique_ptr<MessageBox> messageBox;
     void showAppSettings();
 
     enum class VerticalPosition { Top, Centre, Bottom };

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -211,7 +211,9 @@ void MapApp::selectMercator() {
                 fileChooser.reset();
                 chooserContainer->setVisible(false);
                 if (savedSettings->getGeneralSetting<bool>("show_calibration_msg_on_load")) {
-                    finalizeCalibration();
+                    finalizeCalibration(map->getCalibrationReport());
+                } else if (map->isCalibrated()) {
+                    finalizeCalibration("Chart is georeferenced");
                 }
                 mercatorDir = platform::getDirNameFromPath(selectedUTF8);
             } catch (const std::exception &e) {
@@ -626,7 +628,7 @@ void MapApp::processCalibrationPoint(int step) {
              double angle = getCoordinate(coords);
              LOG_INFO(1, "Found angle %f", angle);
              map->setCalibrationAngle(angle);
-             finalizeCalibration();
+             finalizeCalibration(map->getCalibrationReport());
              return;
         }
     }
@@ -649,7 +651,7 @@ void MapApp::processCalibrationPoint(int step) {
             coordsField->setText("0");
         } else {
             map->setCalibrationPoint3(lat, lon);
-            finalizeCalibration();
+            finalizeCalibration(map->getCalibrationReport());
         }
     } catch (const std::exception &e) {
         LOG_ERROR("Failed to parse '%s': %s", coords.c_str(), e.what());
@@ -657,10 +659,10 @@ void MapApp::processCalibrationPoint(int step) {
     rotateButton->setVisible(false);
 }
 
-void MapApp::finalizeCalibration() {
+void MapApp::finalizeCalibration(std::string msg) {
     keyboard.reset();
     coordsField.reset();
-    messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), map->getCalibrationReport());
+    messageBox = std::make_unique<avitab::MessageBox>(getUIContainer(), msg);
     messageBox->addButton("Ok", [this] () {
         api().executeLater([this] () {
             messageBox.reset();

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -115,7 +115,7 @@ private:
     void startCalibration();
     double getCoordinate(const std::string &str);
     void processCalibrationPoint(int step);
-    void finalizeCalibration();
+    void finalizeCalibration(std::string msg);
     bool handleNonNumericContent(std::string coords);
 };
 

--- a/src/charts/Chart.h
+++ b/src/charts/Chart.h
@@ -43,6 +43,7 @@ public:
     virtual bool isLoaded() const = 0;
     virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) = 0;
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) = 0;
+    virtual void setCalibrationMetadata(std::string metadata) = 0;
 };
 
 } /* namespace navigraph */

--- a/src/charts/ChartService.h
+++ b/src/charts/ChartService.h
@@ -52,7 +52,8 @@ public:
     std::shared_ptr<navigraph::NavigraphAPI> getNavigraph();
     void submitCall(std::shared_ptr<BaseCall> call);
 
-    std::string getHashMappedJson(std::string utf8ChartFileName) const;
+    std::string getCalibrationMetadataForFile(std::string utf8ChartFileName) const;
+    std::string getCalibrationMetadataForHash(std::string hash) const;
 
 private:
     std::shared_ptr<navigraph::NavigraphAPI> navigraph;

--- a/src/charts/libchartfox/ChartFoxChart.cpp
+++ b/src/charts/libchartfox/ChartFoxChart.cpp
@@ -111,12 +111,20 @@ void ChartFoxChart::attachPDF(const std::vector<uint8_t> &data) {
     pdfData = data;
 }
 
+std::vector<uint8_t> ChartFoxChart::getPdfData() {
+    return pdfData;
+}
+
+void ChartFoxChart::setCalibrationMetadata(std::string metadata) {
+    calibrationMetadata = metadata;
+}
+
 std::shared_ptr<img::TileSource> ChartFoxChart::createTileSource(bool nightMode) {
     if (!isLoaded()) {
         throw std::runtime_error("Chart not loaded");
     }
 
-    auto pdfSrc = std::make_shared<maps::PDFSource>(pdfData);
+    auto pdfSrc = std::make_shared<maps::PDFSource>(pdfData, calibrationMetadata);
     pdfSrc->setNightMode(nightMode);
     return pdfSrc;
 }

--- a/src/charts/libchartfox/ChartFoxChart.h
+++ b/src/charts/libchartfox/ChartFoxChart.h
@@ -38,9 +38,12 @@ public:
     virtual bool isLoaded() const override;
     virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) override;
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
+    virtual void setCalibrationMetadata(std::string metadata);
 
     std::string getURL() const;
     void attachPDF(const std::vector<uint8_t> &data);
+    std::vector<uint8_t> getPdfData();
+
 private:
     std::string icao;
     size_t index;
@@ -48,6 +51,7 @@ private:
     std::string identifier;
     std::string url;
     std::vector<uint8_t> pdfData;
+    std::string calibrationMetadata = "";
 };
 
 } // namespace chartfox

--- a/src/charts/liblocalfile/LocalFileChart.cpp
+++ b/src/charts/liblocalfile/LocalFileChart.cpp
@@ -63,6 +63,10 @@ bool LocalFileChart::isLoaded() const {
     return true;
 }
 
+void LocalFileChart::setCalibrationMetadata(std::string metadata) {
+    calibrationMetadata = metadata;
+}
+
 std::string LocalFileChart::getPath() const {
     return path;
 }
@@ -71,7 +75,7 @@ void LocalFileChart::attachData(const std::vector<uint8_t> &data) {
 }
 
 std::shared_ptr<img::TileSource> LocalFileChart::createTileSource(bool nightMode) {
-    auto pdfSrc = std::make_shared<maps::PDFSource>(path);
+    auto pdfSrc = std::make_shared<maps::PDFSource>(path, calibrationMetadata);
     pdfSrc->setNightMode(nightMode);
     return pdfSrc;
 }

--- a/src/charts/liblocalfile/LocalFileChart.h
+++ b/src/charts/liblocalfile/LocalFileChart.h
@@ -37,6 +37,7 @@ public:
     virtual bool isLoaded() const override;
     virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) override;
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
+    virtual void setCalibrationMetadata(std::string metadata);
 
     std::string getPath() const;
     void attachData(const std::vector<uint8_t> &data);
@@ -46,6 +47,7 @@ private:
     apis::ChartCategory category;
     std::string identifier;
     std::string path;
+    std::string calibrationMetadata = "";
 };
 
 } // namespace localfile

--- a/src/charts/libnavigraph/NavigraphChart.h
+++ b/src/charts/libnavigraph/NavigraphChart.h
@@ -45,6 +45,7 @@ public:
     virtual bool isLoaded() const override;
     virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) override;
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
+    virtual void setCalibrationMetadata(std::string metadata) {}; // Ignore
 
     std::string getFileDay() const;
     std::string getFileNight() const;

--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -98,6 +98,7 @@ void Settings::init() {
     // full init not required, just defaults that aren't zero/false/empty
     *database = { { "general", { { "prefs_version", 1 },
                                  { "show_calibration_msg_on_load", true },
+                                 { "show_overlays_in_airport_app", true },
                                  { "show_fps", true } } },
                   { "overlay", { { "my_aircraft", true } } } };
 }

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -41,6 +41,7 @@ public:
     virtual img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) = 0;
     virtual std::string getCalibrationReport() {return "No calibration"; };
     virtual double getNorthOffsetAngle() { return 0.0; };
+    virtual bool isPDFSource() { return false; };
 
     // Control the underlying loader
     virtual void cancelPendingLoads() = 0;

--- a/src/maps/sources/PDFSource.h
+++ b/src/maps/sources/PDFSource.h
@@ -32,7 +32,8 @@ namespace maps {
 class PDFSource: public img::TileSource {
 public:
     PDFSource(const std::string& file, std::shared_ptr<apis::ChartService> chartService = NULL);
-    PDFSource(const std::vector<uint8_t> &pdfData);
+    PDFSource(const std::string& file, std::string calibrationMetadata);
+    PDFSource(const std::vector<uint8_t> &pdfData, std::string calibrationMetadata);
 
     int getMinZoomLevel() override;
     int getMaxZoomLevel() override;
@@ -62,6 +63,7 @@ public:
     void setNightMode(bool night);
     void rotate() override;
     double getNorthOffsetAngle() override;
+    bool isPDFSource() override { return true; };
 
 private:
     std::string utf8FileName;
@@ -71,8 +73,10 @@ private:
     int rotateAngle = 0;
     apis::Crypto crypto;
     std::shared_ptr<apis::ChartService> chartService;
+
+    void loadProvidedCalibrationMetadata(std::string calibrationMetadata);
     void storeCalibration();
-    void loadCalibration();
+    void findAndLoadCalibration();
 };
 
 } /* namespace maps */


### PR DESCRIPTION
Also georeference local charts in AirportApp and ChartsApp via hash-matched json.
Show "Chart is georeferenced" msg box on load if so.
Always show compass top right if chart is a georeferenced PDFSource.
