### PR TITLE
Add set(CMAKE_EXPORT_COMPILE_COMMANDS ON) to the CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ configure_file(
 
 add_definitions("-include ${PROJECT_BINARY_DIR}/config.h")
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
 include(lib/CMakeLists.txt)


### PR DESCRIPTION
The CMAKE_EXPORT_COMPILE_COMMANDS will export a `compile_commands.json` file that can be used in IDEs for code navigation and auto-completion.

https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html