### PR TITLE
Support Chartfox even if Navigraph is not enabled (or allowed).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(AviTab VERSION 0.6.2 DESCRIPTION "AviTab X-Plane plugin")
 
 if (NOT "$ENV{NAVIGRAPH_SECRET}" STREQUAL "")
     set(NAVIGRAPH_SECRET "$ENV{NAVIGRAPH_SECRET}" CACHE INTERNAL "Copied from environment variable")
+endif()
+if (NOT "$ENV{CHARTFOX_SECRET}" STREQUAL "")
     set(CHARTFOX_SECRET "$ENV{CHARTFOX_SECRET}" CACHE INTERNAL "Copied from environment variable")
 endif()
 

--- a/src/avitab/apps/AppLauncher.cpp
+++ b/src/avitab/apps/AppLauncher.cpp
@@ -43,7 +43,7 @@ AppLauncher::AppLauncher(FuncsPtr appFuncs):
     addEntry<PlaneManualApp>("Aircraft", root + "if_ilustracoes_04-11_1519786.png", AppId::PLANE_MANUAL);
     addEntry<NotesApp>("Notes", root + "if_txt2_3783.png", AppId::NOTES);
 
-    if (api().getChartService()->getNavigraph()->isSupported()) {
+    if (api().getChartService()->getNavigraph()->isSupported() || api().getChartService()->getChartfox()->isSupported()) {
         addEntry<ProvidersApp>("Providers", root + "if_Airport_22906.png", AppId::NAVIGRAPH);
     }
 

--- a/src/avitab/apps/ProvidersApp.cpp
+++ b/src/avitab/apps/ProvidersApp.cpp
@@ -27,20 +27,24 @@ ProvidersApp::ProvidersApp(FuncsPtr appFuncs):
     tabs = std::make_shared<TabGroup>(getUIContainer());
     tabs->centerInParent();
 
-    navigraphPage = tabs->addTab(tabs, "Navigraph");
-    windowNavigraph = std::make_shared<Window>(navigraphPage, "Navigraph");
-    windowNavigraph->setOnClose([this] () { exit(); });
-    resetNavigraphLayout();
+    if (api().getChartService()->getNavigraph()->isSupported()) {
+        navigraphPage = tabs->addTab(tabs, "Navigraph");
+        windowNavigraph = std::make_shared<Window>(navigraphPage, "Navigraph");
+        windowNavigraph->setOnClose([this] () { exit(); });
+        resetNavigraphLayout();
 
-    auto navigraph = api().getChartService()->getNavigraph();
-    if (navigraph->hasLoggedInBefore()) {
-        onNavigraphLogin();
+        auto navigraph = api().getChartService()->getNavigraph();
+        if (navigraph->hasLoggedInBefore()) {
+            onNavigraphLogin();
+        }
     }
 
-    chartFoxPage = tabs->addTab(tabs, "ChartFox");
-    windowChartFox = std::make_shared<Window>(chartFoxPage, "ChartFox");
-    windowChartFox->setOnClose([this] () { exit(); });
-    resetChartFoxLayout();
+    if (api().getChartService()->getChartfox()->isSupported()) {
+        chartFoxPage = tabs->addTab(tabs, "ChartFox");
+        windowChartFox = std::make_shared<Window>(chartFoxPage, "ChartFox");
+        windowChartFox->setOnClose([this] () { exit(); });
+        resetChartFoxLayout();
+    }
 }
 
 void ProvidersApp::resetNavigraphLayout() {

--- a/src/charts/ChartService.cpp
+++ b/src/charts/ChartService.cpp
@@ -53,6 +53,10 @@ std::shared_ptr<navigraph::NavigraphAPI> ChartService::getNavigraph() {
     return navigraph;
 }
 
+std::shared_ptr<chartfox::ChartFoxAPI> ChartService::getChartfox() {
+    return chartfox;
+}
+
 std::shared_ptr<APICall<bool>> ChartService::loginNavigraph() {
     auto call = std::make_shared<APICall<bool>>([this] {
         if (useNavigraph) {

--- a/src/charts/ChartService.h
+++ b/src/charts/ChartService.h
@@ -50,6 +50,7 @@ public:
 
     // state
     std::shared_ptr<navigraph::NavigraphAPI> getNavigraph();
+    std::shared_ptr<chartfox::ChartFoxAPI> getChartfox();
     void submitCall(std::shared_ptr<BaseCall> call);
 
     std::string getCalibrationMetadataForFile(std::string utf8ChartFileName) const;


### PR DESCRIPTION
This removes the dependency between Chartfox and Navigraph so that Avitab can be built with neither, either, or both.