### PR TITLE
Tidy up aircraft tracking in Airport App

### DIFF
--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -415,11 +415,11 @@ void AirportApp::onChartLoaded(std::shared_ptr<Page> page) {
         }
     });
     tab.nightModeButton->setToggleState(nightMode);
-    tab.aircraftButton = tab.window->addSymbol(Widget::Symbol::GPS, [this, page] {
+    tab.trackButton = tab.window->addSymbol(Widget::Symbol::GPS, [this, page] {
         TabPage &tab = findPage(page);
         if (tab.map) {
-            tab.overlays->drawMyAircraft = !tab.overlays->drawMyAircraft;
-            tab.aircraftButton->setToggleState(tab.overlays->drawMyAircraft);
+            tab.trackPlane = !tab.trackPlane;
+            tab.trackButton->setToggleState(tab.trackPlane);
         }
     });
 
@@ -439,7 +439,7 @@ void AirportApp::onChartLoaded(std::shared_ptr<Page> page) {
         tab.map->setRedrawCallback([this, page] () { redrawPage(page); });
         tab.map->setNavWorld(api().getNavWorld());
 
-        tab.aircraftButton->setToggleState(tab.map->getOverlayConfig().drawMyAircraft);
+        tab.trackButton->setToggleState(tab.trackPlane);
 
         if (tab.mapSource->getPageCount() > 1) {
             tab.window->addSymbol(Widget::Symbol::RIGHT, [this, page] {
@@ -465,7 +465,10 @@ void AirportApp::onMapPan(std::shared_ptr<Page> page, int x, int y, bool start, 
     TabPage &tab = findPage(page);
 
     if (start) {
-        // trackPlane = false;
+        if (tab.trackPlane) {
+            tab.trackPlane = false;
+            tab.trackButton->setToggleState(tab.trackPlane);
+        }
     } else if (!end) {
         int panVecX = tab.panPosX - x;
         int panVecY = tab.panPosY - y;
@@ -516,6 +519,9 @@ bool AirportApp::onTimer() {
             std::vector<avitab::Location> loc;
             loc.push_back(api().getAircraftLocation(0));
             tab.map->setPlaneLocations(loc);
+            if (tab.trackPlane) {
+                tab.map->centerOnPlane();
+            }
             tab.map->doWork();
         }
     }

--- a/src/avitab/apps/AirportApp.h
+++ b/src/avitab/apps/AirportApp.h
@@ -48,7 +48,7 @@ private:
         std::shared_ptr<Page> page;
         std::shared_ptr<Window> window;
         std::shared_ptr<Label> label;
-        std::shared_ptr<Button> aircraftButton, nightModeButton;
+        std::shared_ptr<Button> trackButton, nightModeButton;
         std::shared_ptr<xdata::Airport> airport;
 
         apis::ChartCategory requestedList = apis::ChartCategory::ROOT;
@@ -64,6 +64,7 @@ private:
         std::shared_ptr<maps::OverlayConfig> overlays;
 
         int panPosX = 0, panPosY = 0;
+        bool trackPlane = true;
     };
     std::vector<TabPage> pages;
     bool nightMode = false;

--- a/src/charts/ChartService.cpp
+++ b/src/charts/ChartService.cpp
@@ -36,6 +36,10 @@ ChartService::ChartService(const std::string &programPath) {
     std::string calibrationPath = programPath + "/MapTiles/Mercator/Calibration";
     if (platform::fileExists(calibrationPath)) {
         scanJsonFiles(calibrationPath);
+        logger::info(" Found %d calibration files", jsonFileHashes.size());
+    } else {
+        logger::info("Calibration folder does not exist at:");
+        logger::info(" %s", calibrationPath.c_str());
     }
 
     setUseNavigraph(true);


### PR DESCRIPTION
Track icon in Airport App is used to enable/disable centering of map on aircraft, consistent with Map App. Hide/show of aircraft on map is configured in overlay config drop-down in Map App, consistent with other overlays. Stop tracking aircraft on pan

Also add a little debug to calibration file load.