### PR TITLE
Add abstract interface for world::World, implemented by xdata::XWorld

### DIFF
--- a/src/libxdata/CMakeLists.txt
+++ b/src/libxdata/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(xdata STATIC
     "${CMAKE_CURRENT_LIST_DIR}/XData.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/XWorld.cpp"
 )
 
 target_link_libraries(xdata PUBLIC world)

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -32,7 +32,7 @@ namespace xdata {
 
 XData::XData(const std::string& dataRootPath):
     xplaneRoot(dataRootPath),
-    world(std::make_shared<world::World>())
+    xworld(std::make_shared<xdata::XWorld>())
 {
     navDataPath = determineNavDataPath();
 }
@@ -74,7 +74,7 @@ void XData::setUserFixesFilename(std::string filename) {
 }
 
 std::shared_ptr<world::World> XData::getWorld() {
-    return world;
+    return xworld;
 }
 
 void XData::load() {
@@ -97,16 +97,16 @@ void XData::load() {
     loadMetar();
 
     logger::verbose("Build node network...");
-    world->registerNavNodes();
+    xworld->registerNavNodes();
     logger::info("Loaded nav data in %.2f seconds", millis / 1000.0f);
 }
 
 void XData::cancelLoading() {
-    world->cancelLoading();
+    xworld->cancelLoading();
 }
 
 void XData::loadAirports() {
-    const AirportLoader loader(world);
+    const AirportLoader loader(xworld);
 
     loadCustomScenery(loader);
 
@@ -136,29 +136,29 @@ void XData::loadCustomScenery(const AirportLoader& loader) {
 }
 
 void XData::loadFixes() {
-    FixLoader loader(world);
+    FixLoader loader(xworld);
     loader.load(navDataPath + "earth_fix.dat");
 }
 
 void XData::loadNavaids() {
-    NavaidLoader loader(world);
+    NavaidLoader loader(xworld);
     loader.load(navDataPath + "earth_nav.dat");
 }
 
 void XData::loadAirways() {
-    AirwayLoader loader(world);
+    AirwayLoader loader(xworld);
     loader.load(navDataPath + "earth_awy.dat");
 }
 
 void XData::loadProcedures() {
-    CIFPLoader loader(world);
-    world->forEachAirport([this, &loader] (std::shared_ptr<world::Airport> ap) {
+    CIFPLoader loader(xworld);
+    xworld->forEachAirport([this, &loader] (std::shared_ptr<world::Airport> ap) {
         try {
             loader.load(ap, navDataPath + "CIFP/" + ap->getID() + ".dat");
         } catch (const std::exception &e) {
             // many airports do not have CIFP data, so ignore silently
         }
-        if (world->shouldCancelLoading()) {
+        if (xworld->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });
@@ -170,7 +170,7 @@ void XData::loadMetar() {
     logger::verbose("Loading METAR...");
 
     try {
-        MetarLoader loader(world);
+        MetarLoader loader(xworld);
         loader.load(xplaneRoot + "METAR.rwx");
     } catch (const std::exception &e) {
         // metar is optional, so only log
@@ -189,10 +189,10 @@ void XData::loadUserFixes() {
 
 void XData::loadUserFixes(std::string userFixesFilename) {
     try {
-        UserFixLoader loader(world);
+        UserFixLoader loader(xworld);
         loader.load(userFixesFilename);
         // Re-register all nodes, but shouldn't affect existing items, just adds new
-        world->registerNavNodes();
+        xworld->registerNavNodes();
         logger::info("Loaded %s", userFixesFilename.c_str());
 
     } catch (const std::exception &e) {

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <vector>
 #include "src/world/Manager.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 #include "src/libxdata/loaders/AirportLoader.h"
 
 namespace xdata {
@@ -41,7 +41,7 @@ public:
 private:
     std::string xplaneRoot;
     std::string navDataPath;
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<xdata::XWorld> xworld;
     std::vector<std::string> customSceneries;
     std::string userFixesFilename;
 

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -19,25 +19,25 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
-#include "World.h"
+#include "XWorld.h"
 #include "src/Logger.h"
 #include "src/platform/Platform.h"
 
-namespace world {
+namespace xdata {
 
-World::World()
+XWorld::XWorld()
 {
 }
 
-void World::cancelLoading() {
+void XWorld::cancelLoading() {
     loadCancelled = true;
 }
 
-bool World::shouldCancelLoading() const {
+bool XWorld::shouldCancelLoading() const {
     return loadCancelled;
 }
 
-std::shared_ptr<Airport> World::findAirportByID(const std::string& id) const {
+std::shared_ptr<world::Airport> XWorld::findAirportByID(const std::string& id) const {
     std::string cleanId = platform::upper(id);
     cleanId.erase(std::remove(cleanId.begin(), cleanId.end(), ' '), cleanId.end());
 
@@ -49,8 +49,8 @@ std::shared_ptr<Airport> World::findAirportByID(const std::string& id) const {
     }
 }
 
-std::vector<std::shared_ptr<Airport>> World::findAirport(const std::string& keyWord) const {
-    std::vector<std::shared_ptr<Airport>> res;
+std::vector<std::shared_ptr<world::Airport>> XWorld::findAirport(const std::string& keyWord) const {
+    std::vector<std::shared_ptr<world::Airport>> res;
 
     std::string key = platform::lower(keyWord);
 
@@ -71,7 +71,7 @@ std::vector<std::shared_ptr<Airport>> World::findAirport(const std::string& keyW
     return res;
 }
 
-std::shared_ptr<Fix> World::findFixByRegionAndID(const std::string& region, const std::string& id) const {
+std::shared_ptr<world::Fix> XWorld::findFixByRegionAndID(const std::string& region, const std::string& id) const {
     auto range = fixes.equal_range(id);
 
     for (auto it = range.first; it != range.second; ++it) {
@@ -83,33 +83,33 @@ std::shared_ptr<Fix> World::findFixByRegionAndID(const std::string& region, cons
     return nullptr;
 }
 
-void World::forEachAirport(std::function<void(std::shared_ptr<Airport>)> f) {
+void XWorld::forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f) {
     for (auto it: airports) {
         f(it.second);
     }
 }
 
-std::shared_ptr<Region> World::findOrCreateRegion(const std::string& id) {
+std::shared_ptr<world::Region> XWorld::findOrCreateRegion(const std::string& id) {
     auto iter = regions.find(id);
     if (iter == regions.end()) {
-        auto ptr = std::make_shared<Region>(id);
+        auto ptr = std::make_shared<world::Region>(id);
         regions.insert(std::make_pair(id, ptr));
         return ptr;
     }
     return iter->second;
 }
 
-std::shared_ptr<Airport> World::findOrCreateAirport(const std::string& id) {
+std::shared_ptr<world::Airport> XWorld::findOrCreateAirport(const std::string& id) {
     auto iter = airports.find(id);
     if (iter == airports.end()) {
-        auto ptr = std::make_shared<Airport>(id);
+        auto ptr = std::make_shared<world::Airport>(id);
         airports.insert(std::make_pair(id, ptr));
         return ptr;
     }
     return iter->second;
 }
 
-std::shared_ptr<Airway> World::findOrCreateAirway(const std::string& name, world::AirwayLevel lvl) {
+std::shared_ptr<world::Airway> XWorld::findOrCreateAirway(const std::string& name, world::AirwayLevel lvl) {
     auto range = airways.equal_range(name);
 
     for (auto it = range.first; it != range.second; ++it) {
@@ -119,17 +119,17 @@ std::shared_ptr<Airway> World::findOrCreateAirway(const std::string& name, world
     }
 
     // not found -> insert
-    auto awy = std::make_shared<Airway>(name, lvl);
+    auto awy = std::make_shared<world::Airway>(name, lvl);
     airways.insert(std::make_pair(name, awy));
     return awy;
 }
 
-void World::addFix(std::shared_ptr<Fix> fix) {
+void XWorld::addFix(std::shared_ptr<world::Fix> fix) {
     fix->setGlobal(true);
     fixes.insert(std::make_pair(fix->getID(), fix));
 }
 
-void World::registerNavNodes() {
+void XWorld::registerNavNodes() {
     for (auto it: airports) {
         auto node = it.second;
         auto &loc = node->getLocation();
@@ -149,7 +149,7 @@ void World::registerNavNodes() {
     }
 }
 
-void World::visitNodes(const world::Location& upLeft, const world::Location& lowRight, NodeAcceptor f) {
+void XWorld::visitNodes(const world::Location& upLeft, const world::Location& lowRight, NodeAcceptor f) {
     int lat1 = (int) std::ceil(std::min(90.0, upLeft.latitude));
     int lat2 = (int) std::floor(std::max(-90.0, lowRight.latitude));
     int lon1 = (int) std::floor(std::max(-180.0, upLeft.longitude));
@@ -168,4 +168,4 @@ void World::visitNodes(const world::Location& upLeft, const world::Location& low
     }
 }
 
-} /* namespace world */
+} /* namespace xdata */

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -1,0 +1,70 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018-2023 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_XDATA_XWORLD_H_
+#define SRC_XDATA_XWORLD_H_
+
+#include <map>
+#include <string>
+#include <memory>
+#include <functional>
+#include <atomic>
+#include "src/world/World.h"
+
+namespace xdata {
+
+class XWorld : public world::World {
+public:
+    XWorld();
+
+    std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;
+    std::shared_ptr<world::Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const override;
+    std::vector<std::shared_ptr<world::Airport>> findAirport(const std::string &keyWord) const override;
+
+    void forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f);
+    void addFix(std::shared_ptr<world::Fix> fix);
+    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id) override;
+    std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id) override;
+    std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl) override;
+
+    void cancelLoading();
+    bool shouldCancelLoading() const;
+
+    void registerNavNodes();
+    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f);
+
+private:
+    std::atomic_bool loadCancelled { false };
+
+    // Unique IDs
+    std::map<std::string, std::shared_ptr<world::Region>> regions;
+    std::map<std::string, std::shared_ptr<world::Airport>> airports;
+
+    // Unique only within region
+    std::multimap<std::string, std::shared_ptr<world::Fix>> fixes;
+
+    // Unique within airway level
+    std::multimap<std::string, std::shared_ptr<world::Airway>> airways;
+
+    // To search by location
+    std::map<std::pair<int, int>, std::vector<std::shared_ptr<world::NavNode>>> allNodes;
+};
+
+
+} /* namespace xdata */
+
+#endif /* SRC_XDATA_XWORLD_H_ */

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -22,7 +22,7 @@
 
 namespace xdata {
 
-AirportLoader::AirportLoader(std::shared_ptr<world::World> worldPtr):
+AirportLoader::AirportLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/AirportLoader.h
+++ b/src/libxdata/loaders/AirportLoader.h
@@ -21,16 +21,16 @@
 #include <memory>
 #include "src/libxdata/parsers/objects/AirportData.h"
 #include "src/libxdata/parsers/AirportParser.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class AirportLoader {
 public:
-    AirportLoader(std::shared_ptr<world::World> worldPtr);
+    AirportLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file) const;
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onAirportLoaded(const AirportData &port) const;
 

--- a/src/libxdata/loaders/AirwayLoader.cpp
+++ b/src/libxdata/loaders/AirwayLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-AirwayLoader::AirwayLoader(std::shared_ptr<world::World> worldPtr):
+AirwayLoader::AirwayLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/AirwayLoader.h
+++ b/src/libxdata/loaders/AirwayLoader.h
@@ -21,16 +21,16 @@
 #include <memory>
 #include "src/libxdata/parsers/objects/AirwayData.h"
 #include "src/libxdata/parsers/AirwayParser.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class AirwayLoader {
 public:
-    AirwayLoader(std::shared_ptr<world::World> worldPtr);
+    AirwayLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onAirwayLoaded(const AirwayData &airway);
 };

--- a/src/libxdata/loaders/CIFPLoader.cpp
+++ b/src/libxdata/loaders/CIFPLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-CIFPLoader::CIFPLoader(std::shared_ptr<world::World> worldPtr):
+CIFPLoader::CIFPLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/CIFPLoader.h
+++ b/src/libxdata/loaders/CIFPLoader.h
@@ -21,16 +21,16 @@
 #include <memory>
 #include "src/libxdata/parsers/objects/CIFPData.h"
 #include "src/world/models/airport/Airport.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class CIFPLoader {
 public:
-    CIFPLoader(std::shared_ptr<world::World> worldPtr);
+    CIFPLoader(std::shared_ptr<XWorld> worldPtr);
     void load(std::shared_ptr<world::Airport> airport, const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onProcedureLoaded(std::shared_ptr<world::Airport> airport, const CIFPData &procedure);
 

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-FixLoader::FixLoader(std::shared_ptr<world::World> worldPtr):
+FixLoader::FixLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/FixLoader.h
+++ b/src/libxdata/loaders/FixLoader.h
@@ -20,16 +20,16 @@
 
 #include <memory>
 #include "src/libxdata/parsers/FixParser.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class FixLoader {
 public:
-    FixLoader(std::shared_ptr<world::World> worldPtr);
+    FixLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onFixLoaded(const FixData &fix);
     void loadEnrouteFix(const FixData &fix);

--- a/src/libxdata/loaders/MetarLoader.cpp
+++ b/src/libxdata/loaders/MetarLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-MetarLoader::MetarLoader(std::shared_ptr<world::World> worldPtr):
+MetarLoader::MetarLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/MetarLoader.h
+++ b/src/libxdata/loaders/MetarLoader.h
@@ -20,16 +20,16 @@
 
 #include <memory>
 #include "src/libxdata/parsers/objects/MetarData.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class MetarLoader {
 public:
-    MetarLoader(std::shared_ptr<world::World> worldPtr);
+    MetarLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onMetarLoaded(const MetarData &metar);
 };

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -22,7 +22,7 @@
 
 namespace xdata {
 
-NavaidLoader::NavaidLoader(std::shared_ptr<world::World> worldPtr):
+NavaidLoader::NavaidLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/NavaidLoader.h
+++ b/src/libxdata/loaders/NavaidLoader.h
@@ -20,16 +20,16 @@
 
 #include <memory>
 #include "src/libxdata/parsers/NavaidParser.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class NavaidLoader {
 public:
-    NavaidLoader(std::shared_ptr<world::World> worldPtr);
+    NavaidLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onNavaidLoaded(const NavaidData &navaid);
 };

--- a/src/libxdata/loaders/UserFixLoader.cpp
+++ b/src/libxdata/loaders/UserFixLoader.cpp
@@ -22,7 +22,7 @@
 
 namespace xdata {
 
-UserFixLoader::UserFixLoader(std::shared_ptr<world::World> worldPtr):
+UserFixLoader::UserFixLoader(std::shared_ptr<XWorld> worldPtr):
     world(worldPtr)
 {
 }

--- a/src/libxdata/loaders/UserFixLoader.h
+++ b/src/libxdata/loaders/UserFixLoader.h
@@ -20,16 +20,16 @@
 
 #include <memory>
 #include "src/libxdata/parsers/UserFixParser.h"
-#include "src/world/World.h"
+#include "src/libxdata/XWorld.h"
 
 namespace xdata {
 
 class UserFixLoader {
 public:
-    UserFixLoader(std::shared_ptr<world::World> worldPtr);
+    UserFixLoader(std::shared_ptr<XWorld> worldPtr);
     void load(const std::string &file);
 private:
-    std::shared_ptr<world::World> world;
+    std::shared_ptr<XWorld> world;
 
     void onUserFixLoaded(const UserFixData &navaid);
 };

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_library(world STATIC
-    "${CMAKE_CURRENT_LIST_DIR}/World.cpp"
-)
+add_library(world STATIC)
 
 include(${CMAKE_CURRENT_LIST_DIR}/graph/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/models/CMakeLists.txt)

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -23,10 +23,10 @@
 #include <memory>
 #include <functional>
 #include <atomic>
-#include "src/world/models/airport/Airport.h"
-#include "src/world/models/navaids/Fix.h"
-#include "src/world/models/Region.h"
-#include "src/world/models/Airway.h"
+#include "models/airport/Airport.h"
+#include "models/navaids/Fix.h"
+#include "models/Region.h"
+#include "models/Airway.h"
 
 namespace world {
 
@@ -38,39 +38,16 @@ public:
     static constexpr const int MAX_SEARCH_RESULTS = 10;
     using NodeAcceptor = std::function<void(const world::NavNode &node)>;
 
-    World();
+    virtual std::shared_ptr<Airport> findAirportByID(const std::string &id) const = 0;
+    virtual std::shared_ptr<Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const = 0;
+    virtual std::vector<std::shared_ptr<Airport>> findAirport(const std::string &keyWord) const = 0;
 
-    std::shared_ptr<Airport> findAirportByID(const std::string &id) const;
-    std::shared_ptr<Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const;
-    std::vector<std::shared_ptr<Airport>> findAirport(const std::string &keyWord) const;
+    virtual std::shared_ptr<Region> findOrCreateRegion(const std::string &id) = 0;
+    virtual std::shared_ptr<Airport> findOrCreateAirport(const std::string &id) = 0;
+    virtual std::shared_ptr<Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl) = 0;
 
-    void forEachAirport(std::function<void(std::shared_ptr<Airport>)> f);
-    void addFix(std::shared_ptr<Fix> fix);
-    std::shared_ptr<Region> findOrCreateRegion(const std::string &id);
-    std::shared_ptr<Airport> findOrCreateAirport(const std::string &id);
-    std::shared_ptr<Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
+    virtual void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) = 0;
 
-    void cancelLoading();
-    bool shouldCancelLoading() const;
-
-    void registerNavNodes();
-    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f);
-
-private:
-    std::atomic_bool loadCancelled { false };
-
-    // Unique IDs
-    std::map<std::string, std::shared_ptr<Region>> regions;
-    std::map<std::string, std::shared_ptr<Airport>> airports;
-
-    // Unique only within region
-    std::multimap<std::string, std::shared_ptr<Fix>> fixes;
-
-    // Unique within airway level
-    std::multimap<std::string, std::shared_ptr<Airway>> airways;
-
-    // To search by location
-    std::map<std::pair<int, int>, std::vector<std::shared_ptr<world::NavNode>>> allNodes;
 };
 
 


### PR DESCRIPTION
Convert world::World to an abstact interface class, removing XPlane-specific methods. Restore the world::World class to the libxdata library as xdata::XWorld.