### PR TITLE
Fix compilation at least on macOS Ventura

### DIFF
--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -29,10 +29,6 @@ XWorld::XWorld()
 {
 }
 
-XWorld::~XWorld()
-{
-}
-
 void XWorld::cancelLoading() {
     loadCancelled = true;
 }

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -29,6 +29,10 @@ XWorld::XWorld()
 {
 }
 
+XWorld::~XWorld()
+{
+}
+
 void XWorld::cancelLoading() {
     loadCancelled = true;
 }

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -31,7 +31,7 @@ class XWorld : public world::World {
 public:
     XWorld();
 
-    virtual ~XWorld();
+    virtual ~XWorld() = default;
 
     std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;
     std::shared_ptr<world::Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const override;

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -31,6 +31,8 @@ class XWorld : public world::World {
 public:
     XWorld();
 
+    virtual ~XWorld();
+
     std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;
     std::shared_ptr<world::Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const override;
     std::vector<std::shared_ptr<world::Airport>> findAirport(const std::string &keyWord) const override;
@@ -45,7 +47,7 @@ public:
     bool shouldCancelLoading() const;
 
     void registerNavNodes();
-    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f);
+    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) override;
 
 private:
     std::atomic_bool loadCancelled { false };


### PR DESCRIPTION
Hi,

Thank you for avitab! I tried to build it myself on my MacBook running macOS Ventura 13.4.1 using cmake. It failed due to compilation errors. My c++ is a bit rusty, but the errors made sense to me and I offer you a fix that made it compile again.

Errors:

/Users/matteo/Developer/avitab/src/libxdata/XWorld.h:48:10: error: 'visitNodes' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f);
         ^
/Users/matteo/Developer/avitab/src/world/World.h:49:18: note: overridden virtual function is here
    virtual void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) = 0;

/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/c++/v1/__memory/shared_ptr.h:311:9: error: destructor called on non-final 'xdata::XWorld' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
        __get_elem()->~_Tp();


Best regards,
Matteo
Frankfurt/Germany