### PR TITLE
Add .cache and compile_commands.json in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ cmake-build-debug
 
 # VSCode IDE
 .vscode/
+
+# clangd index and compilation database
+.cache
+compile_commands.json


### PR DESCRIPTION
clangd, used for code refactoring and completion, creates this folder (.cache) and this file (.compile_commands.json)