### PR TITLE
Configurable online slippy maps 1

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -183,6 +183,7 @@ void MapApp::setMapSource(MapSource style) {
         selectNavigraph(maps::NavigraphMapType::WORLD);
         break;
     case MapSource::ONLINE_TILES:
+        selectOnlineMaps();
         break;
     }
 
@@ -269,6 +270,27 @@ void MapApp::selectEPSG() {
         });
     });
     fileChooser->show(chooserContainer);
+    chooserContainer->setVisible(true);
+}
+
+void MapApp::selectOnlineMaps() {
+    std::vector<std::string> slippyMapNames{"Dummy map 1", "Dummy map 2"};
+
+    containerWithClickableList = std::make_unique<ContainerWithClickableCustomList>(&api(), "Select online slippy maps");
+    containerWithClickableList->setListItems(slippyMapNames);
+
+    containerWithClickableList->setSelectCallback([this](int selectedItem) {
+        logger::verbose("selected map %d: %s", selectedItem,
+                containerWithClickableList->getEntry(selectedItem).c_str());
+    });
+    containerWithClickableList->setCancelCallback([this] () {
+        api().executeLater([this] () {
+            containerWithClickableList.reset();
+            chooserContainer->setVisible(false);
+        });
+    });
+
+    containerWithClickableList->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -89,7 +89,7 @@ void MapApp::createSettingsLayout() {
     stamenButton->setCallback([this] (const Button &) { setMapSource(MapSource::STAMEN_TERRAIN); });
     stamenButton->setFit(false, true);
     stamenButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());
-    stamenButton->alignBelow(openTopoButton, 30);
+    stamenButton->alignBelow(openTopoButton, 20);
     auto stamenLabel = std::make_shared<Label>(settingsContainer,
             "Map Data (c) OpenStreetMap\nEnglish map tiles by Stamen Design");
     stamenLabel->alignRightOf(stamenButton, 10);
@@ -130,6 +130,15 @@ void MapApp::createSettingsLayout() {
     auto mercatorLabel = std::make_shared<Label>(settingsContainer, "Uses any PDF or image as Mercator map.");
     mercatorLabel->alignRightOf(mercatorButton, 10);
     mercatorLabel->setManaged();
+
+    onlineMapsButton = std::make_shared<Button>(settingsContainer, "Online");
+    onlineMapsButton->setCallback([this] (const Button &) { setMapSource(MapSource::ONLINE_TILES); });
+    onlineMapsButton->setFit(false, true);
+    onlineMapsButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());
+    onlineMapsButton->alignBelow(mercatorButton, 10);
+    auto onlineMapsLabel = std::make_shared<Label>(settingsContainer, "Select slippy tiles from online sources.");
+    onlineMapsLabel->alignRightOf(onlineMapsButton, 10);
+    onlineMapsLabel->setManaged();
 }
 
 void MapApp::setMapSource(MapSource style) {
@@ -172,6 +181,8 @@ void MapApp::setMapSource(MapSource style) {
         break;
     case MapSource::NAVIGRAPH_WORLD:
         selectNavigraph(maps::NavigraphMapType::WORLD);
+        break;
+    case MapSource::ONLINE_TILES:
         break;
     }
 

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "App.h"
 #include "src/avitab/apps/components/FileChooser.h"
+#include "src/avitab/apps/components/ContainerWithClickableCustomList.h"
 #include "src/gui_toolkit/widgets/PixMap.h"
 #include "src/gui_toolkit/widgets/Window.h"
 #include "src/gui_toolkit/widgets/Button.h"
@@ -65,6 +66,7 @@ private:
 
     std::shared_ptr<maps::OverlayConfig> overlayConf;
     std::unique_ptr<FileChooser> fileChooser;
+    std::unique_ptr<ContainerWithClickableCustomList> containerWithClickableList;
     std::shared_ptr<img::TileSource> tileSource;
     std::shared_ptr<img::Image> mapImage;
     std::shared_ptr<img::Stitcher> mapStitcher;
@@ -103,6 +105,7 @@ private:
     void selectGeoTIFF();
     void selectMercator();
     void selectEPSG();
+    void selectOnlineMaps();
     void selectNavigraph(maps::NavigraphMapType type);
     void selectUserFixesFile();
 

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -60,6 +60,7 @@ private:
         NAVIGRAPH_LOW,
         NAVIGRAPH_VFR,
         NAVIGRAPH_WORLD,
+        ONLINE_TILES,
     };
 
     std::shared_ptr<maps::OverlayConfig> overlayConf;
@@ -74,7 +75,7 @@ private:
     std::shared_ptr<Button> trackButton;
     std::shared_ptr<Button> rotateButton;
     std::shared_ptr<Container> settingsContainer, chooserContainer, overlaysContainer;
-    std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton;
+    std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton, onlineMapsButton;
     std::shared_ptr<Label> overlayLabel;
     std::shared_ptr<Checkbox> myAircraftCheckbox, otherAircraftCheckbox, routeCheckbox;
     std::shared_ptr<Checkbox> airportCheckbox, heliseaportCheckbox, airstripCheckbox;

--- a/src/avitab/apps/components/CMakeLists.txt
+++ b/src/avitab/apps/components/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(avitab_common PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/ContainerWithClickableCustomList.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FilesysBrowser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileSelect.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileChooser.cpp

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
@@ -1,0 +1,87 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ContainerWithClickableCustomList.h"
+
+namespace avitab {
+
+ContainerWithClickableCustomList::ContainerWithClickableCustomList(
+    App::FuncsPtr appFunctions, const std::string &windowTitle)
+    : api(appFunctions), windowTitle(windowTitle) {}
+
+void ContainerWithClickableCustomList::setCancelCallback(CancelCallback cb) {
+    onCancel = cb;
+}
+
+void ContainerWithClickableCustomList::setSelectCallback(SelectCallback cb) {
+    onSelect = cb;
+}
+
+void ContainerWithClickableCustomList::setListItems(
+    const std::vector<std::string> &items) {
+    currentEntries.clear();
+    for (const auto &item : items) {
+        currentEntries.push_back(item);
+    }
+}
+
+void ContainerWithClickableCustomList::show(std::shared_ptr<Container> parent) {
+    window = std::make_shared<Window>(parent, "");
+    window->addSymbol(Widget::Symbol::CLOSE, [this]() {
+        if (onCancel) {
+            onCancel();
+        }
+    });
+    window->setCaption(windowTitle);
+    list = std::make_shared<List>(window);
+    list->setDimensions(window->getContentWidth(), window->getContentHeight());
+    list->centerInParent();
+    list->setCallback([this](int index) {
+        api->executeLater([this, index] { onListSelect(index); });
+    });
+
+    showCurrentEntries();
+}
+
+std::string ContainerWithClickableCustomList::getEntry(uint32_t index) {
+    if (index < currentEntries.size()) {
+        return currentEntries[index];
+    }
+    return std::string("Unknown entry for index ") + std::to_string(index);
+}
+
+void ContainerWithClickableCustomList::showCurrentEntries() {
+    list->clear();
+
+    for (size_t i = 0; i < currentEntries.size(); i++) {
+        auto &entry = currentEntries[i];
+        list->add(entry, i);
+    }
+}
+
+void ContainerWithClickableCustomList::onListSelect(int index) {
+    if (index < 0) {
+        return;
+    }
+
+    if (onSelect) {
+        onSelect(index);
+    }
+}
+
+} // namespace avitab

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.h
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.h
@@ -1,0 +1,63 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_
+#define SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_
+
+#include "src/avitab/apps/App.h"
+#include "src/gui_toolkit/widgets/Container.h"
+#include "src/gui_toolkit/widgets/List.h"
+#include "src/gui_toolkit/widgets/Window.h"
+#include <string>
+#include <vector>
+
+namespace avitab {
+
+// dialog that lists a custom set of objects
+class ContainerWithClickableCustomList {
+  public:
+    using CancelCallback = std::function<void(void)>;
+    using SelectCallback = std::function<void(int)>;
+
+    ContainerWithClickableCustomList(App::FuncsPtr appFunctions,
+                                     const std::string &windowTitle);
+
+    void setCancelCallback(CancelCallback cb);
+    void setSelectCallback(SelectCallback cb);
+    void setListItems(const std::vector<std::string> &items);
+    void show(std::shared_ptr<Container> parent);
+    std::string getEntry(uint32_t index);
+
+  private:
+    App::FuncsPtr api{};
+    const std::string windowTitle;
+    std::shared_ptr<Window> window;
+    std::shared_ptr<List> list;
+
+    CancelCallback onCancel;
+    SelectCallback onSelect;
+
+    std::vector<std::string> currentEntries{};
+
+    void showCurrentEntries();
+    void onListSelect(int index);
+};
+
+} /* namespace avitab */
+
+#endif /* SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_ */


### PR DESCRIPTION
This is first PR in a series of (likely 3 or 4) PRs that I'm planning to do to introduce configurable online slippy maps via a json configuration.

Please do not merge this yet, but start reviewing the code :)

Let me finish with all the PRs and we can the merge them together.

The plan is:
PR 1 (this): introduce basic components for adding a new clickable and configurable list

![Commit 1](https://github.com/fpw/avitab/assets/5658474/28bba9da-6e8b-45ae-a7c9-d25a47253854)

![Commit 2_1](https://github.com/fpw/avitab/assets/5658474/18b81c5e-6c23-4b31-ade9-ab9695eb9978)

![Commit 2_2](https://github.com/fpw/avitab/assets/5658474/f73a4ac2-a7d1-4043-a687-c7feb63ae290)

PR 2: Introduce the map configuration format and the actual feature with a sample map (default OpenStreetMap) as part of the default json configuration - not all the functionality of the configuration is here yet (#166)

PR 3: Make changes to the base OpenTopoSource class to support all the configuration parameters introduced by PR 2

PR 4: Move Stamen terrain (is this even working? Doesn't work for me) and OpenTopoMaps under the new Online Maps button?

PR 5: I'll add the .clang-config that I used to format the newly added files for reference. It doesn't hurt to have the config in the repo; as long as you don't use clang-format explicitly to format a file it does nothing. We can make adjustments to the clang-config and you can use it to format other files in the future too if you want.