### PR TITLE
Configurable online slippy maps 3

### DIFF
--- a/res/online-maps/mapconfig.json
+++ b/res/online-maps/mapconfig.json
@@ -2,18 +2,21 @@
     {
         "name": "OpenStreetMap",
         "servers": [
-            ".tile.openstreetmap.org"
+            "tile.openstreetmap.org"
         ],
         "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
         "url": "{z}/{x}/{y}.png",
         "min_zoom_level": 1,
         "max_zoom_level": 17,
-        "enabled": false
+        "enabled": false,
+        "comment": "https://wiki.openstreetmap.org/wiki/Raster_tile_providers"
     },
     {
         "name": "OpenTopoMap",
         "servers": [
-            ".tile.opentopomap.org"
+            "a.tile.opentopomap.org",
+            "b.tile.opentopomap.org",
+            "c.tile.opentopomap.org"
         ],
         "copyright": "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)",
         "url": "{z}/{x}/{y}.png",

--- a/res/online-maps/mapconfig.json
+++ b/res/online-maps/mapconfig.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "OpenStreetMap",
+        "servers": [
+            ".tile.openstreetmap.org"
+        ],
+        "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
+        "url": "{z}/{x}/{y}.png",
+        "min_zoom_level": 1,
+        "max_zoom_level": 17
+    },
+    {
+        "name": "OpenTopoMap",
+        "servers": [
+            ".tile.opentopomap.org"
+        ],
+        "copyright": "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)",
+        "url": "{z}/{x}/{y}.png",
+        "enabled": false
+    }
+]

--- a/res/online-maps/mapconfig.json
+++ b/res/online-maps/mapconfig.json
@@ -7,7 +7,8 @@
         "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
         "url": "{z}/{x}/{y}.png",
         "min_zoom_level": 1,
-        "max_zoom_level": 17
+        "max_zoom_level": 17,
+        "enabled": false
     },
     {
         "name": "OpenTopoMap",
@@ -16,6 +17,8 @@
         ],
         "copyright": "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)",
         "url": "{z}/{x}/{y}.png",
-        "enabled": false
+        "min_zoom_level": 1,
+        "max_zoom_level": 17,
+        "enabled": true
     }
 ]

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -302,7 +302,7 @@ void MapApp::selectOnlineMaps() {
 
     // Read the config
     std::string mapConfigPath(api().getDataPath() + "online-maps/mapconfig.json");
-    std::ifstream mapConfigFstream(fs::u8path(mapConfigPath));
+    fs::ifstream mapConfigFstream(fs::u8path(mapConfigPath));
 
     if (!mapConfigFstream) {
         logger::error("No mapconfig.json file found in '%s'",
@@ -314,15 +314,15 @@ void MapApp::selectOnlineMaps() {
     }
 
     // Parse the config content
-    try{
+    try {
         const auto &mapConfig = nlohmann::json::parse(mapConfigFstream);
         logger::verbose("Found %u maps in %s", mapConfig.size(), mapConfigPath.c_str());
 
         uint32_t i = 0;
         for (const auto &item : mapConfig.items()){
-            const auto &conf = item.value().get<OnlineSlippyMapConfig>();
+            const auto &conf = item.value().get<maps::OnlineSlippyMapConfig>();
             if (conf.enabled) {
-                slippyMaps.insert(std::pair<uint32_t, OnlineSlippyMapConfig>(i++, conf));
+                slippyMaps.insert(std::pair<size_t, maps::OnlineSlippyMapConfig>(i++, conf));
                 slippyMapNames.push_back(conf.name);
             }
         }

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -183,6 +183,7 @@ void MapApp::setMapSource(MapSource style) {
         selectNavigraph(maps::NavigraphMapType::WORLD);
         break;
     case MapSource::ONLINE_TILES:
+        selectOnlineMaps();
         break;
     }
 
@@ -269,6 +270,27 @@ void MapApp::selectEPSG() {
         });
     });
     fileChooser->show(chooserContainer);
+    chooserContainer->setVisible(true);
+}
+
+void MapApp::selectOnlineMaps() {
+    std::vector<std::string> slippyMapNames{"Dummy map 1", "Dummy map 2"};
+
+    containerWithClickableList = std::make_unique<ContainerWithClickableCustomList>(&api(), "Select online slippy maps");
+    containerWithClickableList->setListItems(slippyMapNames);
+
+    containerWithClickableList->setSelectCallback([this](int selectedItem) {
+        logger::verbose("selected map %d: %s", selectedItem,
+                containerWithClickableList->getEntry(selectedItem).c_str());
+    });
+    containerWithClickableList->setCancelCallback([this] () {
+        api().executeLater([this] () {
+            containerWithClickableList.reset();
+            chooserContainer->setVisible(false);
+        });
+    });
+
+    containerWithClickableList->show(chooserContainer);
     chooserContainer->setVisible(true);
 }
 

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -89,7 +89,7 @@ void MapApp::createSettingsLayout() {
     stamenButton->setCallback([this] (const Button &) { setMapSource(MapSource::STAMEN_TERRAIN); });
     stamenButton->setFit(false, true);
     stamenButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());
-    stamenButton->alignBelow(openTopoButton, 30);
+    stamenButton->alignBelow(openTopoButton, 20);
     auto stamenLabel = std::make_shared<Label>(settingsContainer,
             "Map Data (c) OpenStreetMap\nEnglish map tiles by Stamen Design");
     stamenLabel->alignRightOf(stamenButton, 10);
@@ -130,6 +130,15 @@ void MapApp::createSettingsLayout() {
     auto mercatorLabel = std::make_shared<Label>(settingsContainer, "Uses any PDF or image as Mercator map.");
     mercatorLabel->alignRightOf(mercatorButton, 10);
     mercatorLabel->setManaged();
+
+    onlineMapsButton = std::make_shared<Button>(settingsContainer, "Online");
+    onlineMapsButton->setCallback([this] (const Button &) { setMapSource(MapSource::ONLINE_TILES); });
+    onlineMapsButton->setFit(false, true);
+    onlineMapsButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());
+    onlineMapsButton->alignBelow(mercatorButton, 10);
+    auto onlineMapsLabel = std::make_shared<Label>(settingsContainer, "Select slippy tiles from online sources.");
+    onlineMapsLabel->alignRightOf(onlineMapsButton, 10);
+    onlineMapsLabel->setManaged();
 }
 
 void MapApp::setMapSource(MapSource style) {
@@ -172,6 +181,8 @@ void MapApp::setMapSource(MapSource style) {
         break;
     case MapSource::NAVIGRAPH_WORLD:
         selectNavigraph(maps::NavigraphMapType::WORLD);
+        break;
+    case MapSource::ONLINE_TILES:
         break;
     }
 

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -148,13 +148,21 @@ void MapApp::setMapSource(MapSource style) {
     switch (style) {
     case MapSource::OPEN_TOPO:
         newSource = std::make_shared<maps::OpenTopoSource>(
-            ".tile.opentopomap.org/",
+            std::vector<std::string>{
+                "a.tile.opentopomap.org",
+                "b.tile.opentopomap.org",
+                "c.tile.opentopomap.org",
+            },
+            "{z}/{x}/{y}.png",
+            0, 17,
             "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)");
         setTileSource(newSource);
         break;
     case MapSource::STAMEN_TERRAIN:
         newSource = std::make_shared<maps::OpenTopoSource>(
-            ".tile.stamen.com/terrain/",
+            std::vector<std::string>{"a.tile.stamen.com"},
+            "terrain/{z}/{x}/{y}.png",
+            0, 17,
             "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.");
         setTileSource(newSource);
         break;
@@ -363,7 +371,7 @@ void MapApp::selectOnlineMaps() {
         const auto &conf = slippyMaps.at(selectedItem);
 
         newSource = std::make_shared<maps::OpenTopoSource>(
-            conf.servers[0], conf.copyright);
+            conf.servers, conf.url, conf.minZoomLevel, conf.maxZoomLevel, conf.copyright);
 
         setTileSource(newSource);
     });

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <cmath>
 #include "MapApp.h"
+#include "ghc/filesystem.hpp"
 #include "src/Logger.h"
 #include "src/platform/Platform.h"
 #include "src/platform/strtod.h"
@@ -274,15 +275,99 @@ void MapApp::selectEPSG() {
 }
 
 void MapApp::selectOnlineMaps() {
-    std::vector<std::string> slippyMapNames{"Dummy map 1", "Dummy map 2"};
+    auto showOnlineMapsError([this](std::vector<std::string> errorMsgs) {
+        // Lambda function to show an error in the online maps window
+        // when we have trouble loading the user-defined online map
+        // configuration. JSON configs are very delicate (an extra comma
+        // can cause trouble), so it will be annoying if the user configured
+        // some maps, but can't see anything when starting AviTab. At least
+        // an error message briefing the user and advising them to look at
+        // the AviTab logs for more information improves the user experience
+        containerWithClickableList = std::make_unique<ContainerWithClickableCustomList>(
+                &api(), "Error loading online maps");
+        containerWithClickableList->setListItems(errorMsgs);
+        containerWithClickableList->setSelectCallback([](int selectedItem) {});
+        containerWithClickableList->setCancelCallback([this] () {
+            api().executeLater([this] () {
+                containerWithClickableList.reset();
+                chooserContainer->setVisible(false);
+            });
+        });
+        containerWithClickableList->show(chooserContainer);
+        chooserContainer->setVisible(true);
+    });
 
-    containerWithClickableList = std::make_unique<ContainerWithClickableCustomList>(&api(), "Select online slippy maps");
+    slippyMaps.clear();
+    std::vector<std::string> slippyMapNames;
+
+    // Read the config
+    std::string mapConfigPath(api().getDataPath() + "online-maps/mapconfig.json");
+    std::ifstream mapConfigFstream(fs::u8path(mapConfigPath));
+
+    if (!mapConfigFstream) {
+        logger::error("No mapconfig.json file found in '%s'",
+                fs::u8path(mapConfigPath).c_str());
+        showOnlineMapsError(std::vector<std::string>{
+                "cannot load mapconfig.json from path:",
+                fs::u8path(mapConfigPath)});
+        return;
+    }
+
+    // Parse the config content
+    try{
+        const auto &mapConfig = nlohmann::json::parse(mapConfigFstream);
+        logger::verbose("Found %u maps in %s", mapConfig.size(), mapConfigPath.c_str());
+
+        uint32_t i = 0;
+        for (const auto &item : mapConfig.items()){
+            const auto &conf = item.value().get<OnlineSlippyMapConfig>();
+            if (conf.enabled) {
+                slippyMaps.insert(std::pair<uint32_t, OnlineSlippyMapConfig>(i++, conf));
+                slippyMapNames.push_back(conf.name);
+            }
+        }
+    } catch (const nlohmann::json::exception &e) {
+        logger::error("Failed to parse '%s': %s", mapConfigPath.c_str(), e.what());
+        showOnlineMapsError(std::vector<std::string>{
+                "Failed to parse mapconfig.json",
+                "Please check the AviTab logs for more details"});
+        return;
+    } catch (const std::runtime_error &e) {
+        logger::error("Failed to parse '%s': %s", mapConfigPath.c_str(), e.what());
+        showOnlineMapsError(std::vector<std::string>{
+                "Failed to parse mapconfig.json:",
+                e.what(),
+                "Please check the AviTab logs for more details"});
+        return;
+    }
+
+    // At this point we parse the config correctly - if the config is empty,
+    // Give a hint to the user that they need to populate the config and
+    // point the user to documentation
+    if (slippyMapNames.size() == 0) {
+        logger::warn("No enabled online maps found in %s", mapConfigPath.c_str());
+        showOnlineMapsError(std::vector<std::string>{
+                "No enabled online maps found in mapconfig.json",
+                "Please read the docs to learn how you can add your own",
+                "maps from an online source"});
+        return;
+    }
+
+    // List the user-defined online maps
+    containerWithClickableList = std::make_unique<ContainerWithClickableCustomList>(
+            &api(), "Select online slippy maps");
     containerWithClickableList->setListItems(slippyMapNames);
 
     containerWithClickableList->setSelectCallback([this](int selectedItem) {
-        logger::verbose("selected map %d: %s", selectedItem,
-                containerWithClickableList->getEntry(selectedItem).c_str());
+        std::shared_ptr<img::TileSource> newSource;
+        const auto &conf = slippyMaps.at(selectedItem);
+
+        newSource = std::make_shared<maps::OpenTopoSource>(
+            conf.servers[0], conf.copyright);
+
+        setTileSource(newSource);
     });
+
     containerWithClickableList->setCancelCallback([this] () {
         api().executeLater([this] () {
             containerWithClickableList.reset();

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "App.h"
 #include "src/avitab/apps/components/FileChooser.h"
+#include "src/avitab/apps/components/ContainerWithClickableCustomList.h"
 #include "src/gui_toolkit/widgets/PixMap.h"
 #include "src/gui_toolkit/widgets/Window.h"
 #include "src/gui_toolkit/widgets/Button.h"
@@ -65,6 +66,7 @@ private:
 
     std::shared_ptr<maps::OverlayConfig> overlayConf;
     std::unique_ptr<FileChooser> fileChooser;
+    std::unique_ptr<ContainerWithClickableCustomList> containerWithClickableList;
     std::shared_ptr<img::TileSource> tileSource;
     std::shared_ptr<img::Image> mapImage;
     std::shared_ptr<img::Stitcher> mapStitcher;
@@ -103,6 +105,7 @@ private:
     void selectGeoTIFF();
     void selectMercator();
     void selectEPSG();
+    void selectOnlineMaps();
     void selectNavigraph(maps::NavigraphMapType type);
     void selectUserFixesFile();
 

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -60,6 +60,7 @@ private:
         NAVIGRAPH_LOW,
         NAVIGRAPH_VFR,
         NAVIGRAPH_WORLD,
+        ONLINE_TILES,
     };
 
     std::shared_ptr<maps::OverlayConfig> overlayConf;
@@ -74,7 +75,7 @@ private:
     std::shared_ptr<Button> trackButton;
     std::shared_ptr<Button> rotateButton;
     std::shared_ptr<Container> settingsContainer, chooserContainer, overlaysContainer;
-    std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton;
+    std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton, onlineMapsButton;
     std::shared_ptr<Label> overlayLabel;
     std::shared_ptr<Checkbox> myAircraftCheckbox, otherAircraftCheckbox, routeCheckbox;
     std::shared_ptr<Checkbox> airportCheckbox, heliseaportCheckbox, airstripCheckbox;

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -19,8 +19,11 @@
 #define SRC_AVITAB_APPS_MAPAPP_H_
 
 #include <memory>
+#include <stdexcept>
 #include <vector>
 #include "App.h"
+#include <nlohmann/json.hpp>
+#include <optional>
 #include "src/avitab/apps/components/FileChooser.h"
 #include "src/avitab/apps/components/ContainerWithClickableCustomList.h"
 #include "src/gui_toolkit/widgets/PixMap.h"
@@ -40,6 +43,83 @@
 #include "src/maps/sources/NavigraphSource.h"
 
 namespace avitab {
+
+struct OnlineSlippyMapConfig {
+    std::string name;
+    std::string copyright;
+    std::vector<std::string> servers;
+    std::string url;
+    uint32_t minZoomLevel;
+    uint32_t maxZoomLevel;
+    bool enabled;
+};
+
+/***
+ * Attemps to parse a json value of type T from a json key, with an
+ * optional default value when the key cannot be found or unmarshalled
+ * correctly.
+ *
+ * If a default value is not given, the json key is treated as a required
+ * key. If the parsing of a required json key fails, an error is logged
+ * and an std::runtime_error exception is thrown, unless
+ * ignoreError == true
+ *
+ * The function will return true if the parsing succeeds and false
+ * otherwise
+ */
+template <typename T>
+inline bool parse_json_key(const nlohmann::json &j, std::string json_key, T &var_to_unmarshall, std::optional<T> default_val, bool ignoreError = false) {
+    try {
+        j.at(json_key).get_to(var_to_unmarshall);
+    } catch (const nlohmann::json::out_of_range &) {
+        if (default_val) {
+            var_to_unmarshall = *default_val;
+        } else {
+            if (!ignoreError) {
+                logger::error("    '%s' is a required config key but was not found in the json configuration", json_key.c_str());
+                throw std::runtime_error(std::string("missing required config key '") + json_key + std::string("'"));
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+// Function to deserialize the OnlineSlippyMapConfig
+// https://json.nlohmann.me/api/adl_serializer/from_json/
+// https://github.com/nlohmann/json#basic-usage
+inline void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
+    parse_json_key<bool>(j, "enabled", c.enabled, true, true);
+
+    parse_json_key<std::string>(j, "name", c.name, std::nullopt);
+
+    if (!c.enabled) {
+        logger::verbose("Hiding (explicitly disabled in json config) %s online map", c.name.c_str());
+        return;
+    }
+
+    logger::verbose("Enabling %s online map", c.name.c_str());
+
+    parse_json_key<std::string>(j, "copyright", c.copyright, std::nullopt);
+    parse_json_key<std::vector<std::string>>(j, "servers", c.servers, std::nullopt);
+    parse_json_key<std::string>(j, "url", c.url, std::nullopt);
+    parse_json_key<uint32_t>(j, "min_zoom_level", c.minZoomLevel, 0);
+    parse_json_key<uint32_t>(j, "max_zoom_level", c.maxZoomLevel, 16);
+
+    logger::verbose("    Map copyright: '%s'", c.copyright.c_str());
+    logger::verbose("    Servers to download tiles from: [");
+    for (const auto &s : c.servers)
+        logger::verbose("        '%s',", s.c_str());
+    logger::verbose("    ]");
+    logger::verbose("    Server URL: '%s'", c.url.c_str());
+    logger::verbose("    Min zoom level: %u", c.minZoomLevel);
+    logger::verbose("    Max zoom level: %u", c.maxZoomLevel);
+
+    if (c.servers.size() < 1)
+        throw std::runtime_error(
+                std::string("no servers found for ") + c.name + std::string(". Requires at least one"));
+
+}
 
 class MapApp: public App {
 public:
@@ -90,6 +170,7 @@ private:
     std::unique_ptr<Keyboard> keyboard;
 
     std::shared_ptr<avitab::Settings> savedSettings;
+    std::map<uint32_t, OnlineSlippyMapConfig> slippyMaps;
 
     Timer updateTimer;
     bool trackPlane = true;

--- a/src/avitab/apps/components/CMakeLists.txt
+++ b/src/avitab/apps/components/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(avitab_common PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/ContainerWithClickableCustomList.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FilesysBrowser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileSelect.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FileChooser.cpp

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
@@ -1,0 +1,87 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ContainerWithClickableCustomList.h"
+
+namespace avitab {
+
+ContainerWithClickableCustomList::ContainerWithClickableCustomList(
+    App::FuncsPtr appFunctions, const std::string &windowTitle)
+    : api(appFunctions), windowTitle(windowTitle) {}
+
+void ContainerWithClickableCustomList::setCancelCallback(CancelCallback cb) {
+    onCancel = cb;
+}
+
+void ContainerWithClickableCustomList::setSelectCallback(SelectCallback cb) {
+    onSelect = cb;
+}
+
+void ContainerWithClickableCustomList::setListItems(
+    const std::vector<std::string> &items) {
+    currentEntries.clear();
+    for (const auto &item : items) {
+        currentEntries.push_back(item);
+    }
+}
+
+void ContainerWithClickableCustomList::show(std::shared_ptr<Container> parent) {
+    window = std::make_shared<Window>(parent, "");
+    window->addSymbol(Widget::Symbol::CLOSE, [this]() {
+        if (onCancel) {
+            onCancel();
+        }
+    });
+    window->setCaption(windowTitle);
+    list = std::make_shared<List>(window);
+    list->setDimensions(window->getContentWidth(), window->getContentHeight());
+    list->centerInParent();
+    list->setCallback([this](int index) {
+        api->executeLater([this, index] { onListSelect(index); });
+    });
+
+    showCurrentEntries();
+}
+
+std::string ContainerWithClickableCustomList::getEntry(uint32_t index) {
+    if (index < currentEntries.size()) {
+        return currentEntries[index];
+    }
+    return std::string("Unknown entry for index ") + std::to_string(index);
+}
+
+void ContainerWithClickableCustomList::showCurrentEntries() {
+    list->clear();
+
+    for (size_t i = 0; i < currentEntries.size(); i++) {
+        auto &entry = currentEntries[i];
+        list->add(entry, i);
+    }
+}
+
+void ContainerWithClickableCustomList::onListSelect(int index) {
+    if (index < 0) {
+        return;
+    }
+
+    if (onSelect) {
+        onSelect(index);
+    }
+}
+
+} // namespace avitab

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.cpp
@@ -58,11 +58,8 @@ void ContainerWithClickableCustomList::show(std::shared_ptr<Container> parent) {
     showCurrentEntries();
 }
 
-std::string ContainerWithClickableCustomList::getEntry(uint32_t index) {
-    if (index < currentEntries.size()) {
-        return currentEntries[index];
-    }
-    return std::string("Unknown entry for index ") + std::to_string(index);
+std::string ContainerWithClickableCustomList::getEntry(int index) {
+    return currentEntries.at(index);
 }
 
 void ContainerWithClickableCustomList::showCurrentEntries() {

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.h
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.h
@@ -1,0 +1,63 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_
+#define SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_
+
+#include "src/avitab/apps/App.h"
+#include "src/gui_toolkit/widgets/Container.h"
+#include "src/gui_toolkit/widgets/List.h"
+#include "src/gui_toolkit/widgets/Window.h"
+#include <string>
+#include <vector>
+
+namespace avitab {
+
+// dialog that lists a custom set of objects
+class ContainerWithClickableCustomList {
+  public:
+    using CancelCallback = std::function<void(void)>;
+    using SelectCallback = std::function<void(int)>;
+
+    ContainerWithClickableCustomList(App::FuncsPtr appFunctions,
+                                     const std::string &windowTitle);
+
+    void setCancelCallback(CancelCallback cb);
+    void setSelectCallback(SelectCallback cb);
+    void setListItems(const std::vector<std::string> &items);
+    void show(std::shared_ptr<Container> parent);
+    std::string getEntry(uint32_t index);
+
+  private:
+    App::FuncsPtr api{};
+    const std::string windowTitle;
+    std::shared_ptr<Window> window;
+    std::shared_ptr<List> list;
+
+    CancelCallback onCancel;
+    SelectCallback onSelect;
+
+    std::vector<std::string> currentEntries{};
+
+    void showCurrentEntries();
+    void onListSelect(int index);
+};
+
+} /* namespace avitab */
+
+#endif /* SRC_AVITAB_APPS_COMPONENTS_CONTAINERWITHCLICKABLECUSTOMLIST_H_ */

--- a/src/avitab/apps/components/ContainerWithClickableCustomList.h
+++ b/src/avitab/apps/components/ContainerWithClickableCustomList.h
@@ -41,7 +41,7 @@ class ContainerWithClickableCustomList {
     void setSelectCallback(SelectCallback cb);
     void setListItems(const std::vector<std::string> &items);
     void show(std::shared_ptr<Container> parent);
-    std::string getEntry(uint32_t index);
+    std::string getEntry(int index);
 
   private:
     App::FuncsPtr api{};

--- a/src/maps/sources/CMakeLists.txt
+++ b/src/maps/sources/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(avitab_common PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/XPlaneSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/OpenTopoSource.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/OnlineSlippyMapConfig.cpp
     ${CMAKE_CURRENT_LIST_DIR}/PDFSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/GeoTIFFSource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/EPSGSource.cpp

--- a/src/maps/sources/OnlineSlippyMapConfig.cpp
+++ b/src/maps/sources/OnlineSlippyMapConfig.cpp
@@ -1,0 +1,99 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "OnlineSlippyMapConfig.h"
+#include "src/Logger.h"
+
+namespace maps {
+
+/***
+ * Attemps to parse a json value of type T from a json key, with an
+ * optional default value when the key cannot be found or unmarshalled
+ * correctly.
+ *
+ * If a default value is not given, the json key is treated as a required
+ * key. If the parsing of a required json key fails, an error is logged
+ * and an std::runtime_error exception is thrown, unless
+ * ignoreError == true
+ *
+ * The function will return true if the parsing succeeds and false
+ * otherwise
+ */
+template <typename T>
+static inline bool parse_json_key(const nlohmann::json &j, std::string json_key,
+                                  T &var_to_unmarshall,
+                                  std::optional<T> default_val,
+                                  bool ignoreError = false) {
+    try {
+        j.at(json_key).get_to(var_to_unmarshall);
+    } catch (const nlohmann::json::out_of_range &) {
+        if (default_val) {
+            var_to_unmarshall = *default_val;
+        } else {
+            if (!ignoreError) {
+                logger::error("    '%s' is a required config key but was not "
+                              "found in the json configuration",
+                              json_key.c_str());
+                throw std::runtime_error(
+                    std::string("missing required config key '") + json_key +
+                    std::string("'"));
+            }
+        }
+        return false;
+    }
+    return true;
+}
+
+void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
+    parse_json_key<bool>(j, "enabled", c.enabled, true, true);
+
+    parse_json_key<std::string>(j, "name", c.name, std::nullopt);
+
+    if (!c.enabled) {
+        logger::verbose(
+            "Hiding (explicitly disabled in json config) %s online map",
+            c.name.c_str());
+        return;
+    }
+
+    logger::verbose("Enabling %s online map", c.name.c_str());
+
+    parse_json_key<std::string>(j, "copyright", c.copyright, std::nullopt);
+    parse_json_key<std::vector<std::string>>(j, "servers", c.servers,
+                                             std::nullopt);
+    parse_json_key<std::string>(j, "url", c.url, std::nullopt);
+    parse_json_key<size_t>(j, "min_zoom_level", c.minZoomLevel, 0);
+    parse_json_key<size_t>(j, "max_zoom_level", c.maxZoomLevel, 16);
+
+    logger::verbose("    Map copyright: '%s'", c.copyright.c_str());
+    logger::verbose("    Servers to download tiles from: [");
+    for (const auto &s : c.servers) {
+        logger::verbose("        '%s',", s.c_str());
+    }
+    logger::verbose("    ]");
+    logger::verbose("    Server URL: '%s'", c.url.c_str());
+    logger::verbose("    Min zoom level: %u", c.minZoomLevel);
+    logger::verbose("    Max zoom level: %u", c.maxZoomLevel);
+
+    if (c.servers.size() < 1) {
+        throw std::runtime_error(std::string("no servers found for ") + c.name +
+                                 std::string(". Requires at least one"));
+    }
+}
+
+} // namespace maps

--- a/src/maps/sources/OnlineSlippyMapConfig.cpp
+++ b/src/maps/sources/OnlineSlippyMapConfig.cpp
@@ -35,10 +35,10 @@ namespace maps {
  * otherwise
  */
 template <typename T>
-static inline bool parse_json_key(const nlohmann::json &j, std::string json_key,
-                                  T &var_to_unmarshall,
-                                  std::optional<T> default_val,
-                                  bool ignoreError = false) {
+static bool parse_json_key(const nlohmann::json &j, std::string json_key,
+                           T &var_to_unmarshall, std::optional<T> default_val,
+                           std::optional<std::string> mapName,
+                           bool ignoreError = false) {
     try {
         j.at(json_key).get_to(var_to_unmarshall);
     } catch (const nlohmann::json::out_of_range &) {
@@ -46,12 +46,15 @@ static inline bool parse_json_key(const nlohmann::json &j, std::string json_key,
             var_to_unmarshall = *default_val;
         } else {
             if (!ignoreError) {
+                std::string errorSuffix = "";
+                if (mapName) {
+                    errorSuffix = " for " + *mapName;
+                }
                 logger::error("    '%s' is a required config key but was not "
-                              "found in the json configuration",
-                              json_key.c_str());
-                throw std::runtime_error(
-                    std::string("missing required config key '") + json_key +
-                    std::string("'"));
+                              "found in the json configuration%s",
+                              json_key.c_str(), errorSuffix.c_str());
+                throw std::runtime_error("missing required config key '" +
+                                         json_key + "'" + errorSuffix);
             }
         }
         return false;
@@ -59,10 +62,52 @@ static inline bool parse_json_key(const nlohmann::json &j, std::string json_key,
     return true;
 }
 
-void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
-    parse_json_key<bool>(j, "enabled", c.enabled, true, true);
+static void sanitizeTileServers(std::vector<std::string> &tileServers) {
+    // Be a bit forgiving with how users can define servers.
+    // We don't want any trailing slashes, as we append a slash
+    // later when combining the server with the url, so cleanup
+    // any trailing forward slashes that have been provided by
+    // the user here
+    for (std::vector<std::string>::iterator it = tileServers.begin();
+         it != tileServers.end();) {
+        it->erase(it->find_last_not_of('/') + 1, std::string::npos);
+        if (it->size() == 0) {
+            it = tileServers.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
 
-    parse_json_key<std::string>(j, "name", c.name, std::nullopt);
+static void sanitizeUrl(std::string &url) {
+    // Likewise, we don't want any leading slashes to the url and
+    // we'll make sure that we append one later when combining the server
+    // with the url string
+    url.erase(0, std::min(url.find_first_not_of('/'), url.size() - 1));
+}
+
+static void validateTileServers(const std::vector<std::string> &tileServers,
+                                std::string mapName) {
+    if (tileServers.size() < 1) {
+        throw std::runtime_error("no valid servers found for " + mapName +
+                                 ". Requires at least one");
+    }
+}
+
+static void validateUrl(const std::string &url, std::string mapName) {
+    if (url.find("{z}") == std::string::npos ||
+        url.find("{x}") == std::string::npos ||
+        url.find("{y}") == std::string::npos) {
+        throw std::runtime_error(
+            "the url for " + mapName +
+            " must contain the placeholders: {z}, {x}, {y}");
+    }
+}
+
+void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
+    parse_json_key<bool>(j, "enabled", c.enabled, true, std::nullopt, true);
+
+    parse_json_key<std::string>(j, "name", c.name, std::nullopt, std::nullopt);
 
     if (!c.enabled) {
         logger::verbose(
@@ -73,12 +118,15 @@ void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
 
     logger::verbose("Enabling %s online map", c.name.c_str());
 
-    parse_json_key<std::string>(j, "copyright", c.copyright, std::nullopt);
+    parse_json_key<std::string>(j, "copyright", c.copyright, std::nullopt, c.name);
     parse_json_key<std::vector<std::string>>(j, "servers", c.servers,
-                                             std::nullopt);
-    parse_json_key<std::string>(j, "url", c.url, std::nullopt);
-    parse_json_key<size_t>(j, "min_zoom_level", c.minZoomLevel, 0);
-    parse_json_key<size_t>(j, "max_zoom_level", c.maxZoomLevel, 16);
+                                             std::nullopt, c.name);
+    parse_json_key<std::string>(j, "url", c.url, std::nullopt, c.name);
+    parse_json_key<size_t>(j, "min_zoom_level", c.minZoomLevel, 0, c.name);
+    parse_json_key<size_t>(j, "max_zoom_level", c.maxZoomLevel, 16, c.name);
+
+    sanitizeTileServers(c.servers);
+    sanitizeUrl(c.url);
 
     logger::verbose("    Map copyright: '%s'", c.copyright.c_str());
     logger::verbose("    Servers to download tiles from: [");
@@ -90,10 +138,12 @@ void from_json(const nlohmann::json &j, OnlineSlippyMapConfig &c) {
     logger::verbose("    Min zoom level: %u", c.minZoomLevel);
     logger::verbose("    Max zoom level: %u", c.maxZoomLevel);
 
-    if (c.servers.size() < 1) {
-        throw std::runtime_error(std::string("no servers found for ") + c.name +
-                                 std::string(". Requires at least one"));
-    }
+    // The validation functions throw exceptions, so call them after the
+    // verbose print out so in the case of an exception, the user can look
+    // through the logs and see what was the actual value that caused the issue
+    // with the validation
+    validateTileServers(c.servers, c.name);
+    validateUrl(c.url, c.name);
 }
 
 } // namespace maps

--- a/src/maps/sources/OnlineSlippyMapConfig.h
+++ b/src/maps/sources/OnlineSlippyMapConfig.h
@@ -1,0 +1,47 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Vangelis Tasoulas <cyberang3l@gmail.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SRC_MAPS_ONLINESLIPPYMAPCONFIG_H
+#define SRC_MAPS_ONLINESLIPPYMAPCONFIG_H
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace maps {
+
+struct OnlineSlippyMapConfig {
+    std::string name;
+    std::string copyright;
+    std::vector<std::string> servers;
+    std::string url;
+    size_t minZoomLevel;
+    size_t maxZoomLevel;
+    bool enabled;
+};
+
+// Function to deserialize the OnlineSlippyMapConfig
+// https://json.nlohmann.me/api/adl_serializer/from_json/
+// https://github.com/nlohmann/json#basic-usage
+void from_json(const nlohmann::json &, OnlineSlippyMapConfig &);
+
+} // namespace maps
+
+#endif /* SRC_MAPS_ONLINESLIPPYMAPCONFIG_H */

--- a/src/maps/sources/OpenTopoSource.cpp
+++ b/src/maps/sources/OpenTopoSource.cpp
@@ -131,7 +131,7 @@ std::string OpenTopoSource::getTileURL(bool randomHost, int x, int y, int zoom) 
         nameStream << *hosts.begin();
     }
     nameStream << tileServer;
-    nameStream << zoom << "/" << x << "/" << y << ".png";
+    nameStream << "/" << zoom << "/" << x << "/" << y << ".png";
     return nameStream.str();
 }
 

--- a/src/maps/sources/OpenTopoSource.h
+++ b/src/maps/sources/OpenTopoSource.h
@@ -25,7 +25,9 @@ namespace maps {
 
 class OpenTopoSource: public img::TileSource {
 public:
-    OpenTopoSource(std::string tile_server, std::string copyrightInfo);
+    OpenTopoSource(std::vector<std::string> tileServers, std::string url,
+           size_t minZoom, size_t maxZoom,
+           std::string copyrightInfo);
 
     // Basic information
     int getMinZoomLevel() override;
@@ -56,9 +58,13 @@ public:
 private:
     bool cancelToken = false;
     uint8_t hostIndex = 0;
-    std::string hosts = "abc";
     Downloader downloader;
-    std::string tileServer;
+    std::vector<std::string> tileServers;
+    std::string url;
+    size_t minZoom;
+    size_t maxZoom;
+    int tileWidth = 256;
+    int tileHeight = 256;
     std::string copyrightInfo;
 };
 


### PR DESCRIPTION
 Enable the remaining features for the online maps

* Multiple tile servers are now supported in the mapconfig.json. The
  default mapconfig.json has been updated to reflect these changes.
* The url is now parsed correctly and used by the OpenTopoSource class
* The min/max zoom levels are also properly parsed and used by the
  OpenTopoSource class
* Added more sanity and validation checks to reduce failing in cases
  where users add leading or trailing slashes to the servers and/or
  urls. Part of the validation checks are better error messages to
  help users root cause mistakes in the configuration of newly added
  maps

After this diff the support for used-defined online maps is mostly "feature-complete".
Some things that are left to be done, but probably not so urgent:
* Introduce two more json config params for `tile_width` and `tile_height`.
  I think openflightmaps uses 512x512 tiles, so this would be useful, and
  it would be pretty straight forward to add (:crossed_fingers:) - **Update**:
  This was indeed trivial, and can be found in the PR #168 
* Rename the `OpenTopoSource` filenames and class to something more
  generic like `SlippyMapSource` or `OnlineMapSource`?
* If a map from the custom online maps is enabled, store it's name in a variable
  and add it to the description beside the "Online" button as a hint to the user to
  know which custom map is currently in use? I was thinking this will be nice. E.g.,
  if the OpenTopoMap is enabled, the next time the user clicks the map settings,
  instead of seeing only the description "Select slippy tiles from online sources",
  we could show a second line "Currently active map: OpenTopoMap" (change
  OpenTopoMap with actual map name that is enabled)
* Get rid of the Stamen and OpenTopo buttons and move these maps under the
  "Online" button. Then move the "Online" button to the top of the list.
* Update the wiki with some documentation? The behaviour is mostly documented
  in this commit message: https://github.com/fpw/avitab/commit/f9128d1015dde1c37fd5908001c63e3de70b94a9