### PR TITLE
Add support for optional user defined comms protocol in mapconfig.json

### DIFF
--- a/res/online-maps/mapconfig.json
+++ b/res/online-maps/mapconfig.json
@@ -4,10 +4,13 @@
         "servers": [
             "tile.openstreetmap.org"
         ],
+        "protocol": "https",
         "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
         "url": "{z}/{x}/{y}.png",
         "min_zoom_level": 1,
         "max_zoom_level": 17,
+        "tile_width_px": 256,
+        "tile_height_px": 256,
         "enabled": false,
         "comment": "https://wiki.openstreetmap.org/wiki/Raster_tile_providers"
     },
@@ -18,10 +21,13 @@
             "b.tile.opentopomap.org",
             "c.tile.opentopomap.org"
         ],
+        "protocol": "https",
         "copyright": "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)",
         "url": "{z}/{x}/{y}.png",
         "min_zoom_level": 1,
         "max_zoom_level": 17,
+        "tile_width_px": 256,
+        "tile_height_px": 256,
         "enabled": true
     }
 ]

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -372,7 +372,8 @@ void MapApp::selectOnlineMaps() {
 
         newSource = std::make_shared<maps::OpenTopoSource>(
             conf.servers, conf.url, conf.minZoomLevel, conf.maxZoomLevel,
-            conf.tileWidthPx, conf.tileHeightPx, conf.copyright);
+            conf.tileWidthPx, conf.tileHeightPx, conf.copyright,
+            conf.protocol);
 
         setTileSource(newSource);
     });

--- a/src/maps/sources/OnlineSlippyMapConfig.h
+++ b/src/maps/sources/OnlineSlippyMapConfig.h
@@ -31,6 +31,7 @@ struct OnlineSlippyMapConfig {
     std::string name;
     std::string copyright;
     std::vector<std::string> servers;
+    std::string protocol;
     std::string url;
     size_t minZoomLevel;
     size_t maxZoomLevel;

--- a/src/maps/sources/OpenTopoSource.h
+++ b/src/maps/sources/OpenTopoSource.h
@@ -27,7 +27,7 @@ class OpenTopoSource: public img::TileSource {
 public:
     OpenTopoSource(std::vector<std::string> tileServers, std::string url,
            size_t minZoom, size_t maxZoom, size_t tileWidth, size_t tileHeight,
-           std::string copyrightInfo);
+           std::string copyrightInfo, std::string protocol = "https");
 
     // Basic information
     int getMinZoomLevel() override;
@@ -66,6 +66,7 @@ private:
     int tileWidth = 256;
     int tileHeight = 256;
     std::string copyrightInfo;
+    std::string protocol = "https";
 };
 
 } /* namespace maps */


### PR DESCRIPTION
Add a new `protocol` configuration option in the map definitions in mapconfig.json. This defines the communication protocol that is spoken by the tile servers. The `protocol` config option is optional, and if skipped, `https` is assumed by default. The only accepted values are `https` and `http`.

Most of the public servers nowadays speak HTTPS, but still some use HTTP (without the S). Moreover, when using a local test tile server, setting up a valid SSL certificate can be a pain, so adding support for HTTP servers compliments the "custom online slippy tiles" feature nicely.