### PR TITLE
Visual menu feedback about the enabled online map

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -137,7 +137,10 @@ void MapApp::createSettingsLayout() {
     onlineMapsButton->setFit(false, true);
     onlineMapsButton->setDimensions(openTopoButton->getWidth(), openTopoButton->getHeight());
     onlineMapsButton->alignBelow(mercatorButton, 10);
-    auto onlineMapsLabel = std::make_shared<Label>(settingsContainer, "Select slippy tiles from online sources.");
+    // The onlineMapsLabel is defined as a private variable; We want
+    // to refer to it throught the program's execution to update the label
+    // when selecting a different online map, or selecting a non-online map
+    onlineMapsLabel = std::make_shared<Label>(settingsContainer, baseOnlineMapsLabel);
     onlineMapsLabel->alignRightOf(onlineMapsButton, 10);
     onlineMapsLabel->setManaged();
 }
@@ -195,6 +198,10 @@ void MapApp::setMapSource(MapSource style) {
         selectOnlineMaps();
         break;
     }
+    // Update the current active map after the switch statement;
+    // If we reached at this point, the new map style has been applied successfully
+    // (i.e., no exceptions were thrown when trying to apply the map)
+    currentActiveMapSource = style;
 
     settingsContainer->setVisible(false);
 }
@@ -376,6 +383,7 @@ void MapApp::selectOnlineMaps() {
             conf.protocol);
 
         setTileSource(newSource);
+        currentActiveOnlineMap = conf.name;
     });
 
     containerWithClickableList->setCancelCallback([this] () {
@@ -496,6 +504,12 @@ void MapApp::onSettingsButton() {
         naviLabel->alignRightOf(naviWorldButton, 10);
         naviLabel->setManaged();
     }
+
+    if (currentActiveMapSource != MapSource::ONLINE_TILES) {
+        currentActiveOnlineMap = "";
+    } 
+    onlineMapsLabel->setText(baseOnlineMapsLabel + (
+                currentActiveOnlineMap != "" ? "\nCurrent active map: " + currentActiveOnlineMap : ""));
 
     settingsContainer->setVisible(!settingsContainer->isVisible());
 }

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -63,6 +63,8 @@ private:
         ONLINE_TILES,
     };
 
+    MapSource currentActiveMapSource;
+    std::string currentActiveOnlineMap;
     std::shared_ptr<maps::OverlayConfig> overlayConf;
     std::unique_ptr<FileChooser> fileChooser;
     std::unique_ptr<ContainerWithClickableCustomList> containerWithClickableList;
@@ -90,6 +92,9 @@ private:
 
     std::shared_ptr<avitab::Settings> savedSettings;
     std::map<size_t, maps::OnlineSlippyMapConfig> slippyMaps;
+
+    const std::string baseOnlineMapsLabel = "Select slippy tiles from online sources.";
+    std::shared_ptr<Label> onlineMapsLabel;
 
     Timer updateTimer;
     bool trackPlane = true;


### PR DESCRIPTION
The "Online" maps button brings up a menu and allows you to select from one or more maps. With this commit we store the name of the selected online map when successfully applied, and show the name of the selected map in the onlineMapsLabel next time the user clicks on the button that shows the map settings menu.

![Peek 2023-11-12 18-40](https://github.com/fpw/avitab/assets/5658474/d190a211-20fb-4375-bc29-ac6c0fd561bf)
