### PR TITLE
NAV world refactoring towards supporting SQLite databases.

### DIFF
--- a/src/avitab/apps/RouteApp.cpp
+++ b/src/avitab/apps/RouteApp.cpp
@@ -144,7 +144,7 @@ void RouteApp::onArrivalEntered(const std::string& arrival) {
 
     arrivalNode = ap;
 
-    route = std::make_shared<world::Route>(departureNode, arrivalNode);
+    route = std::make_shared<world::Route>(navWorld, departureNode, arrivalNode);
     route->setAirwayLevel(airwayLevel);
     route->setGetMagVarsCallback([this] (std::vector<std::pair<double, double>> locations) {
         return api().getMagneticVariations(locations);
@@ -348,7 +348,7 @@ void RouteApp::parseFMS(const std::string &fmsFilename) {
         prevNode = node;
     }
     arrivalNode = prevNode;
-    route = std::make_shared<world::Route>(departureNode, arrivalNode);
+    route = std::make_shared<world::Route>(api().getNavWorld(), departureNode, arrivalNode);
     route->loadRoute(fmsRoute);
     api().setRoute(route);
 }

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -124,6 +124,32 @@ std::shared_ptr<world::Airway> XWorld::findOrCreateAirway(const std::string& nam
     return awy;
 }
 
+std::vector<world::World::Connection> &XWorld::getConnections(std::shared_ptr<world::NavNode> from) {
+    auto iter = connections.find(from);
+    if (iter != connections.end()) {
+        return iter->second;
+    }
+    return noConnection;
+}
+
+bool XWorld::areConnected(std::shared_ptr<world::NavNode> from, const std::shared_ptr<world::NavNode> to) {
+    for (auto &c: getConnections(from)) {
+        if (c.second == to) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void XWorld::connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to) {
+    auto iter = connections.find(from);
+    if (iter == connections.end()) {
+        connections[from] = std::vector<world::World::Connection>();
+        iter = connections.find(from);
+    }
+    (iter->second).push_back(std::make_pair(via, to));
+}
+
 void XWorld::addFix(std::shared_ptr<world::Fix> fix) {
     fix->setGlobal(true);
     fixes.insert(std::make_pair(fix->getID(), fix));

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -33,21 +33,26 @@ public:
 
     virtual ~XWorld() = default;
 
+    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) override;
+
     std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;
     std::shared_ptr<world::Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const override;
     std::vector<std::shared_ptr<world::Airport>> findAirport(const std::string &keyWord) const override;
 
+    std::vector<world::World::Connection> &getConnections(std::shared_ptr<world::NavNode> from) override;
+    bool areConnected(std::shared_ptr<world::NavNode> from, const std::shared_ptr<world::NavNode> to) override;
+
     void forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f);
     void addFix(std::shared_ptr<world::Fix> fix);
-    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id) override;
-    std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id) override;
-    std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl) override;
+    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id);
+    std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id);
+    std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
+    void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);
 
     void cancelLoading();
     bool shouldCancelLoading() const;
 
     void registerNavNodes();
-    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) override;
 
 private:
     std::atomic_bool loadCancelled { false };
@@ -64,6 +69,10 @@ private:
 
     // To search by location
     std::map<std::pair<int, int>, std::vector<std::shared_ptr<world::NavNode>>> allNodes;
+
+    // Connections between nodes (airports, heliports, runways, fixes)
+    std::map<std::shared_ptr<world::NavNode>, std::vector<world::World::Connection>> connections;
+    std::vector<world::World::Connection> noConnection;
 };
 
 

--- a/src/libxdata/loaders/AirwayLoader.cpp
+++ b/src/libxdata/loaders/AirwayLoader.cpp
@@ -59,14 +59,14 @@ void AirwayLoader::onAirwayLoaded(const AirwayData& airway) {
     auto awy = world->findOrCreateAirway(airway.name, level);
     switch (airway.dirRestriction) {
     case AirwayData::DirectionRestriction::FORWARD:
-        fromFix->connectTo(awy, toFix);
+        world->connectTo(fromFix, awy, toFix);
         break;
     case AirwayData::DirectionRestriction::BACKWARD:
-        toFix->connectTo(awy, fromFix);
+        world->connectTo(fromFix, awy, fromFix);
         break;
     case AirwayData::DirectionRestriction::NONE:
-        fromFix->connectTo(awy, toFix);
-        toFix->connectTo(awy, fromFix);
+        world->connectTo(fromFix, awy, toFix);
+        world->connectTo(toFix, awy, fromFix);
         break;
     }
 }

--- a/src/libxdata/loaders/CIFPLoader.cpp
+++ b/src/libxdata/loaders/CIFPLoader.cpp
@@ -73,9 +73,10 @@ void CIFPLoader::loadSID(std::shared_ptr<world::Airport> airport, const CIFPData
     loadEnroute(procedure, *sid, airport);
 
     airport->addSID(sid);
-    sid->iterate([&sid, &airport] (std::shared_ptr<world::Runway> rw, std::shared_ptr<world::Fix> finalFix) {
+    auto w = this->world;
+    sid->iterate([w, &sid, &airport] (std::shared_ptr<world::Runway> rw, std::shared_ptr<world::Fix> finalFix) {
         if (finalFix->isGlobalFix()) {
-            airport->connectTo(sid, finalFix);
+            w->connectTo(airport, sid, finalFix);
         }
     });
 }
@@ -88,9 +89,10 @@ void CIFPLoader::loadSTAR(std::shared_ptr<world::Airport> airport, const CIFPDat
     loadRunwayTransition(procedure, *star, airport);
 
     airport->addSTAR(star);
-    star->iterate([&star, &airport] (std::shared_ptr<world::Runway> rw, std::shared_ptr<world::Fix> startFix, std::shared_ptr<world::NavNode> endPoint) {
+    auto w = this->world;
+    star->iterate([w, &star, &airport] (std::shared_ptr<world::Runway> rw, std::shared_ptr<world::Fix> startFix, std::shared_ptr<world::NavNode> endPoint) {
         if (startFix->isGlobalFix()) {
-            startFix->connectTo(star, airport);
+            w->connectTo(startFix, star, airport);
         }
     });
 }
@@ -105,12 +107,13 @@ void CIFPLoader::loadApproach(std::shared_ptr<world::Airport> airport, const CIF
 
     auto startFix = approach->getStartFix();
     if (startFix != nullptr && startFix->isGlobalFix()) {
-        startFix->connectTo(approach, airport);
+        world->connectTo(startFix, approach, airport);
     }
 
-    approach->iterateTransitions([&approach, &airport] (const std::string &name, std::shared_ptr<world::Fix> startFix, std::shared_ptr<world::Runway> rw) {
+    auto w = this->world;
+    approach->iterateTransitions([w, &approach, &airport] (const std::string &name, std::shared_ptr<world::Fix> startFix, std::shared_ptr<world::Runway> rw) {
         if (startFix != nullptr && startFix->isGlobalFix()) {
-            startFix->connectTo(approach, airport);
+            w->connectTo(startFix, approach, airport);
         }
     });
 }

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -36,18 +36,18 @@ constexpr const double M_TO_FT = 3.28084;
 class World {
 public:
     static constexpr const int MAX_SEARCH_RESULTS = 10;
+
     using NodeAcceptor = std::function<void(const world::NavNode &node)>;
+    using Connection = std::pair<std::shared_ptr<NavEdge>, std::shared_ptr<NavNode>>;
+
+    virtual void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) = 0;
 
     virtual std::shared_ptr<Airport> findAirportByID(const std::string &id) const = 0;
     virtual std::shared_ptr<Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const = 0;
     virtual std::vector<std::shared_ptr<Airport>> findAirport(const std::string &keyWord) const = 0;
 
-    virtual std::shared_ptr<Region> findOrCreateRegion(const std::string &id) = 0;
-    virtual std::shared_ptr<Airport> findOrCreateAirport(const std::string &id) = 0;
-    virtual std::shared_ptr<Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl) = 0;
-
-    virtual void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor f) = 0;
-
+    virtual std::vector<Connection> &getConnections(std::shared_ptr<NavNode> from) = 0;
+    virtual bool areConnected(std::shared_ptr<NavNode> from, const std::shared_ptr<NavNode> to) = 0;
 };
 
 

--- a/src/world/graph/NavNode.cpp
+++ b/src/world/graph/NavNode.cpp
@@ -21,23 +21,6 @@
 
 namespace world {
 
-void NavNode::connectTo(std::shared_ptr<NavEdge> via, std::shared_ptr<NavNode> to) {
-    connections.push_back(std::make_tuple(via, to));
-}
-
-const std::vector<NavNode::Connection>& NavNode::getConnections() const {
-    return connections;
-}
-
-bool NavNode::isConnectedTo(const std::shared_ptr<NavNode> other) const {
-    for (auto &conn: connections) {
-        if (std::get<1>(conn) == other) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool NavNode::isRunway() const {
     return false;
 }

--- a/src/world/graph/NavNode.h
+++ b/src/world/graph/NavNode.h
@@ -27,20 +27,12 @@ namespace world {
 
 class NavNode {
 public:
-    using Connection = std::tuple<std::shared_ptr<NavEdge>, std::shared_ptr<NavNode>>;
-
     virtual const std::string &getID() const = 0;
     virtual const Location& getLocation() const = 0;
     virtual bool isRunway() const;
     virtual bool isGlobalFix() const;
 
-    void connectTo(std::shared_ptr<NavEdge> via, std::shared_ptr<NavNode> to);
-    const std::vector<Connection> &getConnections() const;
-    bool isConnectedTo(const std::shared_ptr<NavNode> other) const;
-
     virtual ~NavNode() = default;
-private:
-    std::vector<Connection> connections;
 };
 
 } /* namespace world */

--- a/src/world/models/Region.cpp
+++ b/src/world/models/Region.cpp
@@ -29,7 +29,9 @@ const std::string& Region::getId() const {
 }
 
 void Region::setName(const std::string& name) {
-    this->name = name;
+    if (this->name.empty()) {
+        this->name = name;
+    }
 }
 
 } /* namespace world */

--- a/src/world/router/Route.cpp
+++ b/src/world/router/Route.cpp
@@ -21,7 +21,9 @@
 
 namespace world {
 
-Route::Route(std::shared_ptr<NavNode> start, std::shared_ptr<NavNode> dest):
+Route::Route(std::shared_ptr<world::World> w, std::shared_ptr<NavNode> start, std::shared_ptr<NavNode> dest):
+    world(w),
+    router(w),
     startNode(start),
     destNode(dest)
 {
@@ -61,7 +63,7 @@ bool Route::checkEdge(const RouteFinder::EdgePtr via, const RouteFinder::NodePtr
     if (via->isProcedure()) {
         // We only allow SIDs, STARs etc. if they are start or end of the route.
         // This prevents routes that use SIDs and STARs of other airports as waypoints
-        return startNode->isConnectedTo(to) || to == destNode;
+        return world->areConnected(startNode, to) || (to == destNode);
     } else {
         // Normal airways are allowed if their level matches the desired level
         return via->supportsLevel(airwayLevel);

--- a/src/world/router/Route.h
+++ b/src/world/router/Route.h
@@ -40,7 +40,7 @@ public:
             double initialTrueBearing,
             double initialMagneticBearing)>;
 
-    Route(std::shared_ptr<NavNode> start, std::shared_ptr<NavNode> dest);
+    Route(std::shared_ptr<world::World> world, std::shared_ptr<NavNode> start, std::shared_ptr<NavNode> dest);
 
     void setAirwayLevel(AirwayLevel level);
 
@@ -58,6 +58,7 @@ public:
     double getRouteDistance() const;
 
 private:
+    std::shared_ptr<World> world;
     RouteFinder router;
     std::shared_ptr<NavNode> startNode, destNode;
     AirwayLevel airwayLevel = AirwayLevel::LOWER;

--- a/src/world/router/RouteFinder.cpp
+++ b/src/world/router/RouteFinder.cpp
@@ -23,11 +23,17 @@
 
 namespace world {
 
+RouteFinder::RouteFinder(std::shared_ptr<world::World> w):
+    world(w)
+{
+}
+
 void RouteFinder::setAirwayChangePenalty(float percent) {
     airwayChangePenalty = percent;
 }
 
-void RouteFinder::setEdgeFilter(EdgeFilter filter) {
+void RouteFinder::setEdgeFilter(EdgeFilter filter)
+{
     edgeFilter = filter;
 }
 
@@ -60,7 +66,7 @@ std::vector<RouteFinder::RouteDirection> RouteFinder::findRoute(NodePtr from, No
         openSet.erase(current);
         closedSet.insert(current);
 
-        auto &neighbors = current->getConnections();
+        auto &neighbors = world->getConnections(current);
         for (auto neighborConn: neighbors) {
             auto &edge = std::get<0>(neighborConn);
             auto &neighbor = std::get<1>(neighborConn);

--- a/src/world/router/RouteFinder.h
+++ b/src/world/router/RouteFinder.h
@@ -56,12 +56,17 @@ public:
         }
     };
 
+    RouteFinder() = delete;
+    RouteFinder(std::shared_ptr<world::World> world);
+
     void setEdgeFilter(EdgeFilter filter);
     void setGetMagVarsCallback(GetMagVarsCallback cb);
     void setAirwayChangePenalty(float percent);
     std::vector<RouteDirection> findRoute(NodePtr from, NodePtr to);
 
 private:
+    std::shared_ptr<World> world;
+
     EdgeFilter edgeFilter;
     GetMagVarsCallback getMagneticVariations;
 


### PR DESCRIPTION
This is a further refactoring of the World NAV data API and implementation to create a baseline for future support for obtaining NAV data from a SQLite database.

It updates the way that NavNode connections are queried and implemented. Previously the NavNode object contained a vector of all NavEdges (connections) from that NavNode. This is suitable for a design where all NavNodes are held in memory, but in the SQLite implementation NavNodes will  only be loaded when required. The connections from a NavNode have been moved into a separate container, and the API for querying these connections has been moved to the main World class API. There is virtually no difference in memory usage for the XData implementation.

A number of xdata-specific implementation functions have been removed from the World abstract API. These were overlooked in earlier refactoring PRs/

Region names are only set if the region does not already have a name.