### PR TITLE
Remove OpenTopo button; use first online map in mapconfig as default

### DIFF
--- a/res/online-maps/mapconfig.json
+++ b/res/online-maps/mapconfig.json
@@ -1,20 +1,5 @@
 [
     {
-        "name": "OpenStreetMap",
-        "servers": [
-            "tile.openstreetmap.org"
-        ],
-        "protocol": "https",
-        "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
-        "url": "{z}/{x}/{y}.png",
-        "min_zoom_level": 1,
-        "max_zoom_level": 17,
-        "tile_width_px": 256,
-        "tile_height_px": 256,
-        "enabled": false,
-        "comment": "https://wiki.openstreetmap.org/wiki/Raster_tile_providers"
-    },
-    {
         "name": "OpenTopoMap",
         "servers": [
             "a.tile.opentopomap.org",
@@ -29,5 +14,20 @@
         "tile_width_px": 256,
         "tile_height_px": 256,
         "enabled": true
+    },
+    {
+        "name": "OpenStreetMap",
+        "servers": [
+            "tile.openstreetmap.org"
+        ],
+        "protocol": "https",
+        "copyright": "Map tiles (c) OpenStreetMap (ODbL)",
+        "url": "{z}/{x}/{y}.png",
+        "min_zoom_level": 1,
+        "max_zoom_level": 17,
+        "tile_width_px": 256,
+        "tile_height_px": 256,
+        "enabled": false,
+        "comment": "https://wiki.openstreetmap.org/wiki/Raster_tile_providers"
     }
 ]

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -37,8 +37,27 @@
 #include "src/maps/OverlayedMap.h"
 #include "src/maps/sources/NavigraphSource.h"
 #include "src/maps/sources/OnlineSlippyMapConfig.h"
+#include "src/maps/sources/OnlineSlippySource.h"
 
 namespace avitab {
+
+const struct maps::OnlineSlippyMapConfig fallbackOnlineMap = {
+    .name = "OpenTopoMap",
+    .copyright = "Map Data (c) OpenStreetMap, SRTM - Map Style (c) OpenTopoMap (CC-BY-SA)",
+    .servers = std::vector<std::string>
+    {
+        "a.tile.opentopomap.org",
+        "b.tile.opentopomap.org",
+        "c.tile.opentopomap.org",
+    },
+    .protocol = "https",
+    .url = "{z}/{x}/{y}.png",
+    .minZoomLevel = 1,
+    .maxZoomLevel = 16,
+    .tileWidthPx = 256,
+    .tileHeightPx = 256,
+    .enabled = true,
+};
 
 class MapApp: public App {
 public:
@@ -50,7 +69,6 @@ public:
     void resume() override;
 private:
     enum class MapSource {
-        OPEN_TOPO,
         XPLANE,
         MERCATOR,
         GEOTIFF,
@@ -77,7 +95,7 @@ private:
     std::shared_ptr<Button> trackButton;
     std::shared_ptr<Button> rotateButton;
     std::shared_ptr<Container> settingsContainer, chooserContainer, overlaysContainer;
-    std::shared_ptr<Button> openTopoButton, stamenButton, mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton, onlineMapsButton;
+    std::shared_ptr<Button> mercatorButton, xplaneButton, geoTiffButton, epsgButton, naviLowButton, naviHighButton, naviVFRButton, naviWorldButton, onlineMapsButton;
     std::shared_ptr<Label> overlayLabel;
     std::shared_ptr<Checkbox> myAircraftCheckbox, otherAircraftCheckbox, routeCheckbox;
     std::shared_ptr<Checkbox> airportCheckbox, heliseaportCheckbox, airstripCheckbox;
@@ -104,12 +122,22 @@ private:
 
     void createSettingsLayout();
     void showOverlaySettings();
-    void setMapSource(MapSource style);
+    void setMapSource(MapSource style, bool init = false);
     void setTileSource(std::shared_ptr<img::TileSource> source);
     void selectGeoTIFF();
     void selectMercator();
     void selectEPSG();
-    void selectOnlineMaps();
+    void selectOnlineMaps(bool interactive = true, const std::shared_ptr<maps::OnlineSlippySource> fallback = 
+            std::make_shared<maps::OnlineSlippySource>(
+                fallbackOnlineMap.servers,
+                fallbackOnlineMap.url,
+                fallbackOnlineMap.minZoomLevel,
+                fallbackOnlineMap.maxZoomLevel,
+                fallbackOnlineMap.tileWidthPx,
+                fallbackOnlineMap.tileHeightPx,
+                fallbackOnlineMap.copyright,
+                fallbackOnlineMap.name,
+                fallbackOnlineMap.protocol));
     void selectNavigraph(maps::NavigraphMapType type);
     void selectUserFixesFile();
 

--- a/src/maps/sources/OnlineSlippySource.cpp
+++ b/src/maps/sources/OnlineSlippySource.cpp
@@ -26,7 +26,8 @@ namespace maps {
 OnlineSlippySource::OnlineSlippySource(
         std::vector<std::string> tileServers, std::string url,
         size_t minZoom, size_t maxZoom, size_t tileWidth, size_t tileHeight,
-        std::string copyrightInfo, std::string protocol):
+        std::string copyrightInfo, std::string name, std::string protocol):
+    name(name),
     tileServers(tileServers),
     minZoom(minZoom),
     maxZoom(maxZoom),

--- a/src/maps/sources/OnlineSlippySource.h
+++ b/src/maps/sources/OnlineSlippySource.h
@@ -27,7 +27,7 @@ class OnlineSlippySource: public img::TileSource {
 public:
     OnlineSlippySource(std::vector<std::string> tileServers, std::string url,
            size_t minZoom, size_t maxZoom, size_t tileWidth, size_t tileHeight,
-           std::string copyrightInfo, std::string protocol = "https");
+           std::string copyrightInfo, std::string name, std::string protocol = "https");
 
     // Basic information
     int getMinZoomLevel() override;
@@ -55,6 +55,7 @@ public:
     img::Point<double> xyToWorld(double x, double y, int zoom) override;
 
     std::string getCopyrightInfo() override;
+    const std::string name;
 private:
     bool cancelToken = false;
     uint8_t hostIndex = 0;


### PR DESCRIPTION
Removing the OpenTopo button was a bit more challenging that we thought, as when the map config is broken AviTab will fail to load any map. I came up with a solution that uses a hardcoded fallback map (OpenTopoMap) to get around this issue. The hardcoded fallback map will only be used when the config is broken. When the config is correct, the first enabled map that is found in the config is used as the default map. As a bonus, we now also support letting users choose their favorite default map by modifying the config. The feature in this commit commit work as follow:

* I added a new bool init flag in the `MapApp::setMapSource` function. The init flag is false by default, and the only time I set it to true is when calling the `setMapSource` function from the `MapApp` constructor.
* The `MapApp::selectOnlineMaps` function was also extended with two additional variables: One to hint if the function is called for interactive usage or not, and the second one passes a hardcoded fallback OnlineSlippySource (OpenTopoMap) that is used whenever we fail to read the `mapconfig.json` properly.
* When the `setMapSource` function is called with `init == true`, and the map source is `MapSource::ONLINE_TILES`, the `selectOnlineMaps` method is called in non-interactive mode.
* `selectOnlineMaps` in non-interactive mode will first try to parse the `mapconfig.json`. If that fails, it will show an error to the user (so now when the user messes up with the `mapconfig.json`, they will be notified to fix it right when they start AviTab), and set the default map to the hardcoded fallback map (`OpenTopoMap`). If the `mapconfig.json` can be parsed correctly, the first enabled map that is found in the config will be used as the default map. By default, with the config we ship in AviTab, the default map is `OpenTopoMap`. But if user wants to use a different default they can now do that by moving to the top of the `mapconfig.json` the map definition of their choosing.
* `selectOnlineMaps` in interactive mode will work as it used to: show up the menu if the `mapconfig.json` can be parsed correctly, and let the user pick their map. In the unlikely event that the map can't be parsed correctly after they started AviTab, the fallback is also used as described above. Note the latter failure in interactive mode can only happen when the user is explicitly messing up with the config without closing the program. In this case, it means that the user knows what they are doing. In any other case where the config was edited before opening the program, an error message will be shown to the user when starting AviTab (see screenshots in this PR).

This is what the user now will see when they start AviTab with a broken `mapconfig.json` config:
![Broken-mapconfig-AviTab-Start](https://github.com/fpw/avitab/assets/5658474/8b47ddb0-b99b-4a3d-b648-2e348eb685d2)

Once they explicitly acknowledge the error by clicking on the `X` button of the error window, they can still use AviTab and when they go to the MapApp the default hardcoded fallback (OpenTopoMap) is used:
![When broken conf, the fallback map is used](https://github.com/fpw/avitab/assets/5658474/c37f67a2-6ddd-483e-aa75-4804c285ec37)