### PR TITLE
Catch an exception and exit if cannot load config in standalone mode

### DIFF
--- a/src/StandAlone.cpp
+++ b/src/StandAlone.cpp
@@ -29,7 +29,12 @@ int main() {
     try {
         // Using the heap so we can debug destructors with log messages
         auto env = std::make_shared<avitab::StandAloneEnvironment>();
-        env->loadConfig();
+        try {
+            env->loadConfig();
+        } catch (const std::exception &e) {
+            std::cerr << "Exception: " << e.what() << std::endl;
+            exit(1);
+        }
         logger::setStdOut(env->getConfig()->getBool("/AviTab/logToStdOut"));
         logger::init(env->getProgramPath());
         logger::verbose("Main thread has id %d", std::this_thread::get_id());


### PR DESCRIPTION
Print an error with std::cerr as the logger hasn't been loaded yet (it depends on the config.json being present). Without this, we get a silent failure with an incorrect 0 exit code (that indicates success) instead of 1, that I was only able to figure out with strace.

Note that this is only fixing the Standalone app; The same bug exists in the plugins. The following lines will currently cause the same behaviour, but I don't know what will the behaviour be if we add an "exit(1)" in the plugins (will the entire X-Plane exit in this case?), and even if we do, we probably don't want to use std::cerr to indicate that we cannot find the config.json, but a function that prints something that the user can see in the simulator somehow.

https://github.com/fpw/avitab/blob/2228fa8c12f630a87876faaf3cce887268ef303d/src/Plugin.cpp#L42

https://github.com/fpw/avitab/blob/2228fa8c12f630a87876faaf3cce887268ef303d/src/MsfsAddon.cpp#L32