### PR TITLE
Fix compile errors on Mac OSX

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -fPIC")
+if (APPLE)
+# This should be considered as a temporary fix until resolved in the nlohmann/json submodule
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
 
 add_library(avitab_common "${CMAKE_CURRENT_LIST_DIR}/Logger.cpp")
 add_library(avitab_xplane "")

--- a/src/avitab/AviTab.h
+++ b/src/avitab/AviTab.h
@@ -61,7 +61,7 @@ public:
     void onHomeButton() override;
     std::shared_ptr<world::World> getNavWorld() override;
     using MagVarMap = std::map<std::pair<double, double>, double>;
-    MagVarMap getMagneticVariations(std::vector<std::pair<double, double>> locations);
+    MagVarMap getMagneticVariations(std::vector<std::pair<double, double>> locations) override;
     std::string getMETARForAirport(const std::string &icao) override;
     void reloadMetar() override;
     void loadUserFixes(std::string filename) override;

--- a/src/maps/OverlayedRoute.cpp
+++ b/src/maps/OverlayedRoute.cpp
@@ -18,6 +18,7 @@
 
 #include "OverlayedRoute.h"
 #include "src/Logger.h"
+#include <sstream>
 #include <iomanip>
 
 namespace maps {


### PR DESCRIPTION
Two source code errors in recent updates which were not detected by Windows or Linux toolchains. One temporary change to ignore deprecation warnings until the nlohmann/json submodule has been updated.