### PR TITLE
Fix build issues in Xcode on Mac OS X (issue #181)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-conversion -fPIC")
 if (APPLE)
 # This should be considered as a temporary fix until resolved in the nlohmann/json submodule
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")

--- a/src/avitab/apps/HeaderApp.cpp
+++ b/src/avitab/apps/HeaderApp.cpp
@@ -17,6 +17,7 @@
  */
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 #include "HeaderApp.h"
 #include "src/platform/Platform.h"
 #include "src/Logger.h"


### PR DESCRIPTION
An Xcode project was generated by cmake. The build failed due to stricter defaults in the -Wall compiler flag. Added -Wno-conversion for all platforms in case other build systems also adopt this approach. Also added a required header that other toolchains did not detect.