### PR TITLE
Support wrapping of map tiles at -180/180 longitude.

### DIFF
--- a/src/environment/standalone/StandAloneEnvironment.cpp
+++ b/src/environment/standalone/StandAloneEnvironment.cpp
@@ -102,9 +102,15 @@ Location StandAloneEnvironment::getAircraftLocation(AircraftID id) {
     static double vel[4];
     static double asc[4];
     if (t == 0) {
+#if 1 // normal setting, user aircraft at EDHL, no lateral movement
         loc[0] = { 10.7017287, 53.8019434, 400, 70 };
         vel[0] = 0.0;
         asc[0] = 2;
+#else // these settings can be enabed for reviewing map tiling behaviour at the 180/-180 boundary
+        loc[0] = { 179.8, 67.8, 400, 20 };
+        vel[0] = 0.005;
+        asc[0] = 2;
+#endif
         loc[1] = { 10.69, 53.81, 400, 230 };
         vel[1] = 0.00007;
         asc[1] = 3;
@@ -118,6 +124,8 @@ Location StandAloneEnvironment::getAircraftLocation(AircraftID id) {
         for (size_t i = 0; i < 4; ++i) {
             if ( vel[i] > 0.0 ) {
                 loc[i].longitude += (std::sin(loc[i].heading * 3.14159265 / 180.0) * vel[i]);
+                if (loc[i].longitude >= 180) loc[i].longitude -= 360;
+                if (loc[i].longitude < -180) loc[i].longitude += 360;
                 loc[i].latitude += (std::cos(loc[i].heading * 3.14159265 / 180.0) * vel[i]);
             }
         }

--- a/src/libimg/stitcher/Stitcher.cpp
+++ b/src/libimg/stitcher/Stitcher.cpp
@@ -107,6 +107,7 @@ void Stitcher::pan(int dx, int dy) {
         centerY += dx / (double) dim.x;
         break;
     }
+    tileSource->constrainXY(centerX, centerY, zoomLevel);
     updateImage();
 }
 

--- a/src/libimg/stitcher/TileCache.cpp
+++ b/src/libimg/stitcher/TileCache.cpp
@@ -38,6 +38,7 @@ void TileCache::setCacheDirectory(const std::string& utf8Path) {
 }
 
 std::shared_ptr<Image> TileCache::getTile(int page, int x, int y, int zoom) {
+    tileSource->constrainXY(x, y, zoom);
     if (!tileSource->isTileValid(page, x, y, zoom)) {
         // coords out of bounds: treat as transparent
         throw std::runtime_error(std::string("Invalid coordinates in ") + __FUNCTION__);

--- a/src/libimg/stitcher/TileSource.h
+++ b/src/libimg/stitcher/TileSource.h
@@ -39,6 +39,8 @@ public:
     virtual Point<int> getTileDimensions(int zoom) = 0;
     virtual bool supportsWorldCoords() = 0;
     virtual img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) = 0;
+    virtual void constrainXY(int &x, int &y, int zoom) { /* default is a noop */ }
+    virtual void constrainXY(double &x, double &y, int zoom) { /* default is a noop */ }
     virtual std::string getCalibrationReport() {return "No calibration"; };
     virtual double getNorthOffsetAngle() { return 0.0; };
     virtual bool isPDFSource() { return false; };

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -33,8 +33,8 @@ public:
 
     virtual ~XWorld() = default;
 
-    int countNodes(const world::Location &upLeft, const world::Location &lowRight) override;
-    void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor callback, int filter) override;
+    int countNodes(const world::Location &bottomLeft, const world::Location &topRight) override;
+    void visitNodes(const world::Location &bottomLeft, const world::Location &topRight, NodeAcceptor callback, int filter) override;
 
     std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;
     std::shared_ptr<world::Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const override;

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -281,25 +281,19 @@ void OverlayedMap::drawDataOverlays() {
     }
 
     double leftLon, rightLon;
-    double upLat, bottomLat;
-    pixelToPosition(0, 0, upLat, leftLon);
+    double bottomLat, topLat;
+    pixelToPosition(0, 0, topLat, leftLon);
     pixelToPosition(mapImage->getWidth() - 1, mapImage->getHeight() - 1, bottomLat, rightLon);
+    // Don't overlay anything if zoomed out beyond half of the globe
+    if (rightLon > (leftLon + 180)) return;
+    if ((rightLon < leftLon) && ((rightLon + 360) > (leftLon + 180))) return;
 
-    world::Location upLeft { upLat, leftLon };
-    world::Location downRight { bottomLat, rightLon };
-
-    double deltaLon = rightLon - leftLon;
-
-    // Don't overlay anything if zoomed out to world view. Too much to draw.
-    // And haversine formula used by distanceTo misbehaves in world views.
-    // We also don't handle things properly if the antimeridian is in area
-    if ((deltaLon > 180) || ((leftLon > 0) && (rightLon < 0))) {
-        return;
-    }
+    world::Location bottomLeft { bottomLat, leftLon };
+    world::Location topRight { topLat, rightLon };
 
     // Calculate scaling from a hybrid of horizontal and vertical axes
     double diagonalPixels = sqrt(pow(mapImage->getWidth(), 2) + pow(mapImage->getHeight(), 2));
-    double metresPerPixel = upLeft.distanceTo(downRight) / diagonalPixels;
+    double metresPerPixel = bottomLeft.distanceTo(topRight) / diagonalPixels;
     double nmPerPixel = metresPerPixel / 1852;
     mapWidthNM = nmPerPixel * mapImage->getWidth();
 
@@ -323,16 +317,17 @@ void OverlayedMap::drawDataOverlays() {
     // Gather list of visible OverlayedNodes, instancing those that are visible
     std::vector<std::shared_ptr<OverlayedNode>> overlayedAerodromes;
     std::vector<std::shared_ptr<OverlayedNode>> overlayedFixes;
-    auto nodeCount = navWorld->countNodes(upLeft, downRight);
+    auto nodeCount = navWorld->countNodes(bottomLeft, topRight);
 
     // Will use nodeCount in a future update to improve performance, by: filtering objects
     // reported in the visit callback, and determining text size and detail.
     if (nodeCount <= MAX_VISIT_OBJECTS_IN_FRAME) {
-        navWorld->visitNodes(upLeft, downRight, [this, &overlayedAerodromes, &overlayedFixes,
-                                                lastXClicked, lastYClicked, &closestDistanceToLastClicked,
-                                                planeX, planeY, &closestDistanceToPlane,
-                                                centreX, centreY, &closestDistanceToCentre]
-                                                (const world::NavNode &node) {
+        navWorld->visitNodes(bottomLeft, topRight,
+                                [this, &overlayedAerodromes, &overlayedFixes,
+                                lastXClicked, lastYClicked, &closestDistanceToLastClicked,
+                                planeX, planeY, &closestDistanceToPlane,
+                                centreX, centreY, &closestDistanceToCentre]
+                                (const world::NavNode &node) {
             auto overlayedNode = OverlayedNode::getInstanceIfVisible(shared_from_this(), node);
             if (overlayedNode) {
                 if (dynamic_cast<const world::Airport *>(&node)) {
@@ -391,8 +386,8 @@ void OverlayedMap::drawDataOverlays() {
 
     showHotspotDetailedText();
 
-    LOG_INFO(dbg, "zoom = %2d, deltaLon = %7.3f, %5.4f nm/pix, mapWidth = %6.1f nm, approxNodes = %d",
-        stitcher->getZoomLevel(), deltaLon, nmPerPixel, mapWidthNM, nodeCount);
+    LOG_INFO(dbg, "zoom = %2d, %5.4f nm/pix, mapWidth = %6.1f nm, approxNodes = %d",
+        stitcher->getZoomLevel(), nmPerPixel, mapWidthNM, nodeCount);
 
     drawScale(nmPerPixel);
 }
@@ -456,6 +451,7 @@ void OverlayedMap::positionToPixel(double lat, double lon, int& px, int& py) con
 }
 
 void OverlayedMap::positionToPixel(double lat, double lon, int& px, int& py, int zoomLevel) const {
+    auto mapWidth = tileSource->getPageDimensions(0, zoomLevel).x;
     auto dim = tileSource->getTileDimensions(zoomLevel);
 
     // Center tile num
@@ -463,6 +459,13 @@ void OverlayedMap::positionToPixel(double lat, double lon, int& px, int& py, int
 
     // Target tile num
     auto tileXY = tileSource->worldToXY(lon, lat, zoomLevel);
+
+    // Adjust for wrapping at the -180/180 meridian
+    if (tileXY.x > (centerXY.x + (mapWidth / 2))) {
+        tileXY.x -= mapWidth;
+    } else if (tileXY.x < (centerXY.x - (mapWidth / 2))) {
+        tileXY.x += mapWidth;
+    }
 
     px = mapImage->getWidth() / 2 + (tileXY.x - centerXY.x) * dim.x;
     py = mapImage->getHeight() / 2 + (tileXY.y - centerXY.y) * dim.y;

--- a/src/maps/sources/OnlineSlippySource.h
+++ b/src/maps/sources/OnlineSlippySource.h
@@ -37,6 +37,8 @@ public:
     bool supportsWorldCoords() override;
     img::Point<int> getTileDimensions(int zoom) override;
     img::Point<double> transformZoomedPoint(int page, double oldX, double oldY, int oldZoom, int newZoom) override;
+    void constrainXY(int &x, int &y, int zoom) override;
+    void constrainXY(double &x, double &y, int zoom) override;
 
     // Control the underlying loader
     void cancelPendingLoads() override;

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -47,8 +47,8 @@ public:
     using NodeAcceptor = std::function<void(const world::NavNode &node)>;
     using Connection = std::pair<std::shared_ptr<NavEdge>, std::shared_ptr<NavNode>>;
 
-    virtual int countNodes(const world::Location &upLeft, const world::Location &lowRight) = 0;
-    virtual void visitNodes(const world::Location &upLeft, const world::Location &lowRight, NodeAcceptor calllback, int filter) = 0;
+    virtual int countNodes(const world::Location &bottomLeft, const world::Location &topRight) = 0;
+    virtual void visitNodes(const world::Location &bottomLeft, const world::Location &topRight, NodeAcceptor calllback, int filter) = 0;
 
     virtual std::shared_ptr<Airport> findAirportByID(const std::string &id) const = 0;
     virtual std::shared_ptr<Fix> findFixByRegionAndID(const std::string &region, const std::string &id) const = 0;


### PR DESCRIPTION
This enhancement shows the map and NAV overlays on both sides of the line when in the vicinity of the -180/180 meridian.

A transform functions has been added to the tile source API. This adjusts tile coordinates to constrain them in the tile sources allowable range. The tile cache asks the tile source to constrain the x,y indices before handling, so that only legitimate tile indices are loaded.

This allows the slippy map and stitcher's tile coordinates to be extended beyond the edges to support wrapping the map at the -180/180 edges. During panning the stitcher's center coordinates may be adjusted to keep them in range.

The overlayed map has been adapted to visit NAV nodes either side of the -180/180 meridian when the base map crosses the line and posiiton them correctly on the base map image. (The corners of the visited area have also been redefined to use a more logical pairing of (minX,minY) and (maxX,maxY), this is largely cosmetic).

The new feature is currently only enabled when the map is using online slippy tile sources. All other map sources will behave as previously.

An alternative start location and flight path fir the user plane is added to the standalone build. A small source edit will be required to select this if required for testing.