### PR TITLE
Improvements to route overlaying at the -180/+180 longitude discontinuity

### DIFF
--- a/src/maps/OverlayedRoute.cpp
+++ b/src/maps/OverlayedRoute.cpp
@@ -49,66 +49,60 @@ void OverlayedRoute::draw(std::shared_ptr<world::Route> route) {
     overlayHelper->getMapImage()->fillCircle(toX, toY, 3, img::COLOR_BLACK);
 }
 
-void OverlayedRoute::handleIDLcrossing(world::Location &to, world::Location &from,
-                                     int trueBearing, int magneticBearing) {
-    // Handle leg crossing -180/+180 latitude
-    // Split leg rendering into 2 sections for east and west hemispheres
-    // At what latitude does the leg cross longitude = -180/+180 ?
-    // Leg line equation is : lat = m.long + c
-    // Need to get both from and to longitudes to same polarity first
-    double toLongitude = (to.longitude < 0) ? to.longitude + 360 : to.longitude - 360;
-    double m = (from.latitude - to.latitude) / (from.longitude - toLongitude);
-    double c = from.latitude - m * from.longitude;
-    double latitudeCross = m * 180.0 + c;
-    world::Location fromCross { latitudeCross, (from.longitude < 0) ? -180.0 : 180.0 };
-    world::Location toCross { latitudeCross, (to.longitude < 0) ? -180.0 : 180.0 };
-    double fromDistance = (from.distanceTo(fromCross) / 1000) * world::KM_TO_NM;
-    double toDistance = (toCross.distanceTo(to) / 1000) * world::KM_TO_NM;
-    drawLeg(from, fromCross, fromDistance, trueBearing, magneticBearing);
-    drawLeg(toCross, to, toDistance, trueBearing, magneticBearing);
-}
-
 void OverlayedRoute::drawLeg(world::Location &from, world::Location &to, double distance,
                              double trueBearing, double magneticBearing) {
-    bool oppositeHemispheres = (from.longitude * to.longitude) < 0;
-    int longitudeDistance = std::abs(from.longitude - to.longitude);
-    if (oppositeHemispheres && (longitudeDistance > 180)) {
-        handleIDLcrossing(to, from, trueBearing, magneticBearing);
-        return;
+    world::Location crossingPoint(0,0);
+    if (((from.longitude * to.longitude) < 0) && (std::abs(from.longitude - to.longitude) > 180)) {
+        // this leg of the route crosses the -180/+180 longitude discontinuity. it needs special
+        // handling by dividing it into two parts at the point where the discontinuity is crossed.
+        double lonStart = from.longitude;
+        double lonEnd = to.longitude;
+        double crossingFraction = (lonStart > lonEnd)
+            ? (180 - lonStart) / ((lonEnd + 360) - lonStart)    // crossing eastbound
+            : (-180 - lonStart) / (lonEnd - (lonStart + 360));  // westbound, both parts -ve
+        crossingPoint.longitude = (lonStart > lonEnd) ? 180 : -180;
+        crossingPoint.latitude = from.latitude + (crossingFraction * (to.latitude - from.latitude));
     }
 
-    int iTrueBearing = (int)(trueBearing + 0.5) % 360;
-    int iMagneticBearing = (int)(magneticBearing + 0.5) % 360;
-
-    int fromX, fromY, toX, toY;
+    int fromX, fromY, midX, midY, toX, toY;
     overlayHelper->positionToPixel(from.latitude, from.longitude, fromX, fromY);
     overlayHelper->positionToPixel(to.latitude, to.longitude, toX, toY);
-    int xmin = std::min(fromX, toX);
-    int ymin = std::min(fromY, toY);
-    int xmax = std::max(fromX, toX);
-    int ymax = std::max(fromY, toY);
 
-    if (!overlayHelper->isAreaVisible(xmin, ymin, xmax, ymax)) {
-        return;
+    std::pair<int, int> legDims(0,0);
+    if (crossingPoint.longitude == 0) {
+        // the leg doesn't cross the -180/+180 longitude discontinuity - easy!
+        legDims = drawLeg(fromX, fromY, toX, toY);
+        midX = (fromX + toX) / 2;
+        midY = (fromY + toY) / 2;
+    } else {
+        // the leg crosses the-180/+180 longitude discontinuity. draw the 2 parts of the leg
+        // separately. additionally the midpoint is most likely not the same as the crossing
+        // point and needs to be calculated using the 2 parts of the leg.
+        int crossX, crossY;
+        overlayHelper->positionToPixel(crossingPoint.latitude, crossingPoint.longitude, crossX, crossY);
+        legDims = drawLeg(fromX, fromY, crossX, crossY);
+        int deltaX = (crossX - fromX);
+        int deltaY = (crossY - fromY);
+        crossingPoint.longitude = -crossingPoint.longitude;
+        overlayHelper->positionToPixel(crossingPoint.latitude, crossingPoint.longitude, crossX, crossY);
+        auto leg2Dims = drawLeg(crossX, crossY, toX, toY);
+        legDims.first += leg2Dims.first;
+        legDims.second += leg2Dims.second;
+        midX = fromX + ((deltaX + toX - crossX) / 2);
+        midY = fromY + ((deltaY + toY - crossY) / 2);
     }
 
     auto mapImage = overlayHelper->getMapImage();
 
-    // Draw leg graphic
-    int s = (std::abs(toY - fromY) > std::abs(toX - fromX)) ? 1 : 0;
-    mapImage->drawLine(fromX + s * -3, fromY + !s * -3, toX + s * -3, toY + !s * -3, img::COLOR_BLACK);
-    for (int i = -2; i <= 2; i++) {
-        mapImage->drawLine(fromX + s * i, fromY + !s * i, toX + s * i, toY + !s * i, img::COLOR_YELLOW);
-    }
-    mapImage->drawLine(fromX + s * 3, fromY + !s * 3, toX + s * 3, toY + !s * 3, img::COLOR_BLACK);
-
     // Draw node graphic
-    if ((xmax - xmin) > 6 || (ymax - ymin) > 6) {
+    if ((legDims.first > 6) || (legDims.second > 6)) {
         mapImage->fillCircle(fromX, fromY, 3, img::COLOR_BLACK);
     }
 
     // Draw distance/track annotation text, rotated appropriately
-    // We're caching the rotated image of this annotation, since the rotation is expensive
+    // We cache the rotated image of this annotation, since the rotation is expensive
+    int iTrueBearing = (int)(trueBearing + 0.5) % 360;
+    int iMagneticBearing = (int)(magneticBearing + 0.5) % 360;
     uint32_t key = (uint32_t)(distance) << 18 | iTrueBearing << 9 | iMagneticBearing;
     std::shared_ptr<img::Image> pImage;
     auto it = routeAnnotationCache.find(key);
@@ -119,11 +113,34 @@ void OverlayedRoute::drawLeg(world::Location &from, world::Location &to, double 
         routeAnnotationCache.insert(std::make_pair(key, pImage));
     }
 
-    if (pImage->getWidth() < (xmax - xmin) || pImage->getHeight() < (ymax - ymin)) {
+    if (pImage->getWidth() < legDims.first || pImage->getHeight() < legDims.second) {
         int off = pImage->getWidth() / 2;
-        mapImage->blendImage0(*pImage, ((fromX + toX) / 2) - off, ((fromY + toY) / 2) - off);
+        mapImage->blendImage0(*pImage, midX - off, midY - off);
     }
 }
+
+std::pair<int, int> OverlayedRoute::drawLeg(int x0, int y0, int x1, int y1) {
+    int xmin = std::min(x0, x1);
+    int xmax = std::max(x0, x1);
+    int ymin = std::min(y0, y1);
+    int ymax = std::max(y0, y1);
+
+    if (!overlayHelper->isAreaVisible(xmin, ymin, xmax, ymax)) {
+        return std::pair<int, int>(0,0);
+    }
+
+    // Draw leg graphic
+    auto mapImage = overlayHelper->getMapImage();
+    int s = (std::abs(y1 - y0) > std::abs(x1 - x0)) ? 1 : 0;
+    mapImage->drawLine(x0 + s * -3, y0 + !s * -3, x1 + s * -3, y1 + !s * -3, img::COLOR_BLACK);
+    for (int i = -2; i <= 2; i++) {
+        mapImage->drawLine(x0 + s * i, y0 + !s * i, x1 + s * i, y1 + !s * i, img::COLOR_YELLOW);
+    }
+    mapImage->drawLine(x0 + s * 3, y0 + !s * 3, x1 + s * 3, y1 + !s * 3, img::COLOR_BLACK);
+
+    return std::pair<int, int>(xmax - xmin, ymax - ymin);
+}
+
 
 std::shared_ptr<img::Image> OverlayedRoute::createRouteAnnotation(int distance, int trueBearing, int magBearing) {
     const int font = 16;

--- a/src/maps/OverlayedRoute.h
+++ b/src/maps/OverlayedRoute.h
@@ -39,8 +39,8 @@ private:
 
     void drawLeg(world::Location &from, world::Location &to, double distance,
                  double trueBearing, double magneticBearing);
+    std::pair<int, int> drawLeg(int x0, int y0, int x1, int y1);
     std::shared_ptr<img::Image> createRouteAnnotation(int distance, int trueBearing, int magBearing);
-    void handleIDLcrossing(world::Location &to, world::Location &from, int trueBearing, int magBearing);
 };
 
 } /* namespace maps */


### PR DESCRIPTION
These modifications enhance the depiction of the route leg that crosses the discontinuity by avoiding the addition of a route waypoint at the discontinuity. The update also fixes a route overlay bug at the -180/+180 longitude discontinuity. The formula for working out the latitude where the route leg crossed the boundary contained an error which resulted in the image::drawLine() method getting stuck in an infinite loop. This update fixes the algorithm and prevents the problem occuring. There should probably be something in the drawLine function to check for and avoid this.
