### PR TITLE
Refactoring and defect fix relating to NAV data and user fix loading

### DIFF
--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -48,11 +48,11 @@ std::shared_ptr<Settings> Environment::getSettings() {
     return settings;
 }
 
-void Environment::setWorldManager(std::shared_ptr<world::Manager> mgr) {
+void Environment::setWorldManager(std::shared_ptr<world::LoadManager> mgr) {
     worldManager = mgr;
 }
 
-std::shared_ptr<world::Manager> Environment::getWorldManager() {
+std::shared_ptr<world::LoadManager> Environment::getWorldManager() {
     return worldManager;
 }
 

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <future>
 #include <atomic>
-#include "src/world/Manager.h"
+#include "src/world/LoadManager.h"
 #include "src/libxdata/XData.h"
 #include "src/gui_toolkit/LVGLToolkit.h"
 #include "EnvData.h"
@@ -103,8 +103,8 @@ public:
 
 protected:
     void runEnvironmentCallbacks();
-    void setWorldManager(std::shared_ptr<world::Manager> mgr);
-    std::shared_ptr<world::Manager> getWorldManager();
+    void setWorldManager(std::shared_ptr<world::LoadManager> mgr);
+    std::shared_ptr<world::LoadManager> getWorldManager();
     void sendUserFixesFilenameToWorldMgr(std::string filename);
     void setLastFrameTime(float t);
 
@@ -115,7 +115,7 @@ private:
     std::vector<EnvironmentCallback> envCallbacks;
     std::shared_future<std::shared_ptr<world::World>> navWorldFuture;
     std::shared_ptr<world::World> navWorld;
-    std::shared_ptr<world::Manager> worldManager;
+    std::shared_ptr<world::LoadManager> worldManager;
     std::atomic_bool navWorldLoadAttempted {false};
     std::atomic<float> lastFrameTime {};
 

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -24,7 +24,6 @@
 #include "loaders/AirwayLoader.h"
 #include "loaders/CIFPLoader.h"
 #include "loaders/MetarLoader.h"
-#include "loaders/UserFixLoader.h"
 #include "parsers/CustomSceneryParser.h"
 #include "src/Logger.h"
 
@@ -67,10 +66,6 @@ void XData::discoverSceneries() {
     } catch (const std::exception &e) {
         logger::warn("Could not load scenery_packs.ini: %s", e.what());
     }
-}
-
-void XData::setUserFixesFilename(std::string filename) {
-    userFixesFilename = filename;
 }
 
 std::shared_ptr<world::World> XData::getWorld() {
@@ -171,26 +166,6 @@ void XData::loadMetar() {
     } catch (const std::exception &e) {
         // metar is optional, so only log
         logger::warn("Error parsing METAR: %s", e.what());
-    }
-}
-
-void XData::loadUserFixes() {
-    if (userFixesFilename == "") {
-        logger::info("No user fixes file specified");
-        return;
-    } else {
-        loadUserFixes(userFixesFilename);
-    }
-}
-
-void XData::loadUserFixes(std::string userFixesFilename) {
-    try {
-        UserFixLoader loader(this);
-        loader.load(userFixesFilename);
-        logger::info("Loaded %s", userFixesFilename.c_str());
-    } catch (const std::exception &e) {
-        // User fixes are optional, so could be no CSV file or parse error
-        logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());
     }
 }
 

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -101,12 +101,8 @@ void XData::load() {
     logger::info("Loaded nav data in %.2f seconds", millis / 1000.0f);
 }
 
-void XData::cancelLoading() {
-    xworld->cancelLoading();
-}
-
 void XData::loadAirports() {
-    const AirportLoader loader(xworld);
+    const AirportLoader loader(this);
 
     loadCustomScenery(loader);
 
@@ -136,29 +132,29 @@ void XData::loadCustomScenery(const AirportLoader& loader) {
 }
 
 void XData::loadFixes() {
-    FixLoader loader(xworld);
+    FixLoader loader(this);
     loader.load(navDataPath + "earth_fix.dat");
 }
 
 void XData::loadNavaids() {
-    NavaidLoader loader(xworld);
+    NavaidLoader loader(this);
     loader.load(navDataPath + "earth_nav.dat");
 }
 
 void XData::loadAirways() {
-    AirwayLoader loader(xworld);
+    AirwayLoader loader(this);
     loader.load(navDataPath + "earth_awy.dat");
 }
 
 void XData::loadProcedures() {
-    CIFPLoader loader(xworld);
+    CIFPLoader loader(this);
     xworld->forEachAirport([this, &loader] (std::shared_ptr<world::Airport> ap) {
         try {
             loader.load(ap, navDataPath + "CIFP/" + ap->getID() + ".dat");
         } catch (const std::exception &e) {
             // many airports do not have CIFP data, so ignore silently
         }
-        if (xworld->shouldCancelLoading()) {
+        if (shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });
@@ -170,7 +166,7 @@ void XData::loadMetar() {
     logger::verbose("Loading METAR...");
 
     try {
-        MetarLoader loader(xworld);
+        MetarLoader loader(this);
         loader.load(xplaneRoot + "METAR.rwx");
     } catch (const std::exception &e) {
         // metar is optional, so only log
@@ -189,10 +185,9 @@ void XData::loadUserFixes() {
 
 void XData::loadUserFixes(std::string userFixesFilename) {
     try {
-        UserFixLoader loader(xworld);
+        UserFixLoader loader(this);
         loader.load(userFixesFilename);
         logger::info("Loaded %s", userFixesFilename.c_str());
-
     } catch (const std::exception &e) {
         // User fixes are optional, so could be no CSV file or parse error
         logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -191,8 +191,6 @@ void XData::loadUserFixes(std::string userFixesFilename) {
     try {
         UserFixLoader loader(xworld);
         loader.load(userFixesFilename);
-        // Re-register all nodes, but shouldn't affect existing items, just adds new
-        xworld->registerNavNodes();
         logger::info("Loaded %s", userFixesFilename.c_str());
 
     } catch (const std::exception &e) {

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -35,8 +35,6 @@ public:
     void discoverSceneries() override;
     void load() override;
     void reloadMetar() override;
-    void loadUserFixes(std::string filename) override;
-    void setUserFixesFilename(std::string filename) override;
 private:
     std::string xplaneRoot;
     std::string navDataPath;
@@ -53,7 +51,6 @@ private:
     void loadProcedures();
     void loadMetar();
     void loadCustomScenery(const AirportLoader& loader);
-    void loadUserFixes();
 
 };
 

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -21,22 +21,21 @@
 #include <string>
 #include <memory>
 #include <vector>
-#include "src/world/Manager.h"
+#include "src/world/LoadManager.h"
 #include "src/libxdata/XWorld.h"
 #include "src/libxdata/loaders/AirportLoader.h"
 
 namespace xdata {
 
-class XData : public world::Manager {
+class XData : public world::LoadManager {
 public:
     XData(const std::string &dataRootPath);
     virtual ~XData() = default;
+    std::shared_ptr<world::World> getWorld() override;
     void discoverSceneries() override;
     void load() override;
-    void cancelLoading() override;
     void reloadMetar() override;
     void loadUserFixes(std::string filename) override;
-    std::shared_ptr<world::World> getWorld() override;
     void setUserFixesFilename(std::string filename) override;
 private:
     std::string xplaneRoot;

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -67,7 +67,8 @@ std::shared_ptr<world::Fix> XWorld::findFixByRegionAndID(const std::string& regi
     auto range = fixes.equal_range(id);
 
     for (auto it = range.first; it != range.second; ++it) {
-        if (it->second->getRegion()->getId() == region) {
+        auto r = it->second->getRegion();
+        if (r && (r->getId() == region)) {
             return it->second;
         }
     }
@@ -81,7 +82,7 @@ void XWorld::forEachAirport(std::function<void(std::shared_ptr<world::Airport>)>
     }
 }
 
-std::shared_ptr<world::Region> XWorld::getRegion(const std::string& id) {
+std::shared_ptr<world::Region> XWorld::findOrCreateRegion(const std::string& id) {
     auto iter = regions.find(id);
     if (iter == regions.end()) {
         auto ptr = std::make_shared<world::Region>(id);
@@ -131,6 +132,18 @@ bool XWorld::areConnected(std::shared_ptr<world::NavNode> from, const std::share
         }
     }
     return false;
+}
+
+void XWorld::addRegion(const std::string &code) {
+    findOrCreateRegion(code);
+}
+
+std::shared_ptr<world::Region> XWorld::getRegion(const std::string &id) {
+    auto iter = regions.find(id);
+    if (iter == regions.end()) {
+        return nullptr;
+    }
+    return iter->second;
 }
 
 void XWorld::connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to) {

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -81,7 +81,7 @@ void XWorld::forEachAirport(std::function<void(std::shared_ptr<world::Airport>)>
     }
 }
 
-std::shared_ptr<world::Region> XWorld::findOrCreateRegion(const std::string& id) {
+std::shared_ptr<world::Region> XWorld::getRegion(const std::string& id) {
     auto iter = regions.find(id);
     if (iter == regions.end()) {
         auto ptr = std::make_shared<world::Region>(id);

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -153,26 +153,29 @@ void XWorld::connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<wor
 void XWorld::addFix(std::shared_ptr<world::Fix> fix) {
     fix->setGlobal(true);
     fixes.insert(std::make_pair(fix->getID(), fix));
+    // fixes may be added after the initial loading of the NAV world.
+    // if so, register the node independently here
+    if (allNodesRegistered) {
+        registerNode(fix);
+    }
 }
 
 void XWorld::registerNavNodes() {
+    if (allNodesRegistered) return;
     for (auto it: airports) {
-        auto node = it.second;
-        auto &loc = node->getLocation();
-        int lat = (int) loc.latitude;
-        int lon = (int) loc.longitude;
-
-        allNodes[std::make_pair(lat, lon)].push_back(node);
+        registerNode(it.second);
     }
-
     for (auto it: fixes) {
-        auto node = it.second;
-        auto &loc = node->getLocation();
-        int lat = (int) loc.latitude;
-        int lon = (int) loc.longitude;
-
-        allNodes[std::make_pair(lat, lon)].push_back(node);
+        registerNode(it.second);
     }
+    allNodesRegistered = true;
+}
+
+void XWorld::registerNode(std::shared_ptr<world::NavNode> n) {
+    auto &loc = n->getLocation();
+    int lat = (int) loc.latitude;
+    int lon = (int) loc.longitude;
+    allNodes[std::make_pair(lat, lon)].push_back(n);
 }
 
 int XWorld::countNodes(const world::Location &bottomLeft, const world::Location &topRight) {

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -29,14 +29,6 @@ XWorld::XWorld()
 {
 }
 
-void XWorld::cancelLoading() {
-    loadCancelled = true;
-}
-
-bool XWorld::shouldCancelLoading() const {
-    return loadCancelled;
-}
-
 std::shared_ptr<world::Airport> XWorld::findAirportByID(const std::string& id) const {
     std::string cleanId = platform::upper(id);
     cleanId.erase(std::remove(cleanId.begin(), cleanId.end(), ' '), cleanId.end());

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -43,9 +43,11 @@ public:
     std::vector<world::World::Connection> &getConnections(std::shared_ptr<world::NavNode> from) override;
     bool areConnected(std::shared_ptr<world::NavNode> from, const std::shared_ptr<world::NavNode> to) override;
 
+    std::shared_ptr<world::Region> getRegion(const std::string &id) override;
+
+    void addFix(std::shared_ptr<world::Fix> fix) override;
+
     void forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f);
-    void addFix(std::shared_ptr<world::Fix> fix);
-    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id);
     std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id);
     std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
     void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -43,11 +43,13 @@ public:
     std::vector<world::World::Connection> &getConnections(std::shared_ptr<world::NavNode> from) override;
     bool areConnected(std::shared_ptr<world::NavNode> from, const std::shared_ptr<world::NavNode> to) override;
 
+    void addRegion(const std::string &code) override;
     std::shared_ptr<world::Region> getRegion(const std::string &id) override;
 
     void addFix(std::shared_ptr<world::Fix> fix) override;
 
     void forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f);
+    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id);
     std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id);
     std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
     void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -50,9 +50,6 @@ public:
     std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
     void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);
 
-    void cancelLoading();
-    bool shouldCancelLoading() const;
-
     void registerNavNodes();
 
 private:
@@ -60,7 +57,6 @@ private:
 
 private:
     bool allNodesRegistered { false };
-    std::atomic_bool loadCancelled { false };
 
     // Unique IDs
     std::map<std::string, std::shared_ptr<world::Region>> regions;

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -56,6 +56,10 @@ public:
     void registerNavNodes();
 
 private:
+    void registerNode(std::shared_ptr<world::NavNode> n);
+
+private:
+    bool allNodesRegistered { false };
     std::atomic_bool loadCancelled { false };
 
     // Unique IDs

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -87,7 +87,7 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
     airport->setElevation(port.elevation);
 
     if (!port.region.empty()) {
-        auto region = world->findOrCreateRegion(port.region);
+        auto region = world->getRegion(port.region);
         airport->setRegion(region);
         if (!port.country.empty()) {
             region->setName(port.country);

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -47,8 +47,8 @@ inline world::Runway::SurfaceMaterial mapToSurfaceMaterial(AirportData::SurfaceC
     return runwaySurfaceMap[(size_t)c];
 }
 
-AirportLoader::AirportLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+AirportLoader::AirportLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -60,7 +60,7 @@ void AirportLoader::load(const std::string& file) const {
         } catch (const std::exception &e) {
             logger::warn("Can't parse airport %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -87,7 +87,7 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
     airport->setElevation(port.elevation);
 
     if (!port.region.empty()) {
-        auto region = world->getRegion(port.region);
+        auto region = world->findOrCreateRegion(port.region);
         airport->setRegion(region);
         if (!port.country.empty()) {
             region->setName(port.country);

--- a/src/libxdata/loaders/AirportLoader.h
+++ b/src/libxdata/loaders/AirportLoader.h
@@ -19,17 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_AIRPORTLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/AirportData.h"
-#include "src/libxdata/parsers/AirportParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/AirportParser.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class AirportLoader {
 public:
-    AirportLoader(std::shared_ptr<XWorld> worldPtr);
+    AirportLoader(world::LoadManager *mgr);
     void load(const std::string &file) const;
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirportLoaded(const AirportData &port) const;

--- a/src/libxdata/loaders/AirwayLoader.cpp
+++ b/src/libxdata/loaders/AirwayLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-AirwayLoader::AirwayLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+AirwayLoader::AirwayLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void AirwayLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse airway %s: %s", data.name.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/AirwayLoader.h
+++ b/src/libxdata/loaders/AirwayLoader.h
@@ -19,17 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_AIRWAYLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/AirwayData.h"
-#include "src/libxdata/parsers/AirwayParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/objects/AirwayData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class AirwayLoader {
 public:
-    AirwayLoader(std::shared_ptr<XWorld> worldPtr);
+    AirwayLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirwayLoaded(const AirwayData &airway);

--- a/src/libxdata/loaders/CIFPLoader.cpp
+++ b/src/libxdata/loaders/CIFPLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-CIFPLoader::CIFPLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+CIFPLoader::CIFPLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void CIFPLoader::load(std::shared_ptr<world::Airport> airport, const std::string
         } catch (const std::exception &e) {
             logger::warn("CIFP error in %s: %s", cifp.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/CIFPLoader.h
+++ b/src/libxdata/loaders/CIFPLoader.h
@@ -19,17 +19,19 @@
 #define SRC_LIBXDATA_LOADERS_CIFPLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/CIFPData.h"
+#include "src/world/LoadManager.h"
 #include "src/world/models/airport/Airport.h"
-#include "src/libxdata/XWorld.h"
+#include "../parsers/objects/CIFPData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class CIFPLoader {
 public:
-    CIFPLoader(std::shared_ptr<XWorld> worldPtr);
+    CIFPLoader(world::LoadManager *mgr);
     void load(std::shared_ptr<world::Airport> airport, const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onProcedureLoaded(std::shared_ptr<world::Airport> airport, const CIFPData &procedure);

--- a/src/libxdata/loaders/CMakeLists.txt
+++ b/src/libxdata/loaders/CMakeLists.txt
@@ -5,5 +5,4 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/AirwayLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/CIFPLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MetarLoader.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/UserFixLoader.cpp
 )

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-FixLoader::FixLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+FixLoader::FixLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void FixLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse fix %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -52,7 +52,7 @@ void FixLoader::onFixLoaded(const FixData& fix) {
 void FixLoader::loadEnrouteFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->findOrCreateRegion(fix.icaoRegion);
+    auto region = world->getRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);
@@ -62,7 +62,7 @@ void FixLoader::loadEnrouteFix(const FixData& fix) {
 void FixLoader::loadTerminalFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->findOrCreateRegion(fix.icaoRegion);
+    auto region = world->getRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -52,7 +52,7 @@ void FixLoader::onFixLoaded(const FixData& fix) {
 void FixLoader::loadEnrouteFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->getRegion(fix.icaoRegion);
+    auto region = world->findOrCreateRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);
@@ -62,7 +62,7 @@ void FixLoader::loadEnrouteFix(const FixData& fix) {
 void FixLoader::loadTerminalFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->getRegion(fix.icaoRegion);
+    auto region = world->findOrCreateRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);

--- a/src/libxdata/loaders/FixLoader.h
+++ b/src/libxdata/loaders/FixLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_FIXLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/FixParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "src/libxdata/parsers/objects/FixData.h"
 
 namespace xdata {
 
 class FixLoader {
 public:
-    FixLoader(std::shared_ptr<XWorld> worldPtr);
+    FixLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onFixLoaded(const FixData &fix);

--- a/src/libxdata/loaders/MetarLoader.cpp
+++ b/src/libxdata/loaders/MetarLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-MetarLoader::MetarLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+MetarLoader::MetarLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void MetarLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse METAR for %s: %s", data.icaoCode.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/MetarLoader.h
+++ b/src/libxdata/loaders/MetarLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_METARLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/MetarData.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "../parsers/objects/MetarData.h"
 
 namespace xdata {
 
 class MetarLoader {
 public:
-    MetarLoader(std::shared_ptr<XWorld> worldPtr);
+    MetarLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onMetarLoaded(const MetarData &metar);

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -55,7 +55,7 @@ void NavaidLoader::onNavaidLoaded(const NavaidData& navaid) {
     }
     if (!fix || dontPair) {
         world::Location location(navaid.latitude, navaid.longitude);
-        auto region = world->findOrCreateRegion(navaid.icaoRegion);
+        auto region = world->getRegion(navaid.icaoRegion);
         fix = std::make_shared<world::Fix>(region, navaid.id, location);
         world->addFix(fix);
     }

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -22,8 +22,8 @@
 
 namespace xdata {
 
-NavaidLoader::NavaidLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+NavaidLoader::NavaidLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -35,7 +35,7 @@ void NavaidLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse navaid %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -55,7 +55,7 @@ void NavaidLoader::onNavaidLoaded(const NavaidData& navaid) {
     }
     if (!fix || dontPair) {
         world::Location location(navaid.latitude, navaid.longitude);
-        auto region = world->getRegion(navaid.icaoRegion);
+        auto region = world->findOrCreateRegion(navaid.icaoRegion);
         fix = std::make_shared<world::Fix>(region, navaid.id, location);
         world->addFix(fix);
     }

--- a/src/libxdata/loaders/NavaidLoader.h
+++ b/src/libxdata/loaders/NavaidLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_NAVAIDLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/NavaidParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "../parsers/NavaidParser.h"
 
 namespace xdata {
 
 class NavaidLoader {
 public:
-    NavaidLoader(std::shared_ptr<XWorld> worldPtr);
+    NavaidLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onNavaidLoaded(const NavaidData &navaid);

--- a/src/libxdata/loaders/UserFixLoader.cpp
+++ b/src/libxdata/loaders/UserFixLoader.cpp
@@ -22,8 +22,8 @@
 
 namespace xdata {
 
-UserFixLoader::UserFixLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+UserFixLoader::UserFixLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -35,7 +35,7 @@ void UserFixLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse userfix %s: %s", data.ident.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/UserFixLoader.h
+++ b/src/libxdata/loaders/UserFixLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/UserFixParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/objects/UserFixData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class UserFixLoader {
 public:
-    UserFixLoader(std::shared_ptr<XWorld> worldPtr);
+    UserFixLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onUserFixLoaded(const UserFixData &navaid);

--- a/src/libxdata/parsers/CMakeLists.txt
+++ b/src/libxdata/parsers/CMakeLists.txt
@@ -6,5 +6,4 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/AirwayParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MetarParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/CustomSceneryParser.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/UserFixParser.cpp
 )

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -7,5 +7,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/parsers/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/router/CMakeLists.txt)
 
 target_sources(world PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Manager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/LoadManager.cpp
 )

--- a/src/world/LoadManager.cpp
+++ b/src/world/LoadManager.cpp
@@ -15,28 +15,31 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_WORLD_MANAGER_H_
-#define SRC_WORLD_MANAGER_H_
-
-#include "src/world/World.h"
+#include "LoadManager.h"
+#include "loaders/FMSLoader.h"
+#include "src/Logger.h"
 
 namespace world {
 
-class Manager {
-public:
+void LoadManager::cancelLoading() {
+    loadCancelled = true;
+}
 
-    virtual void discoverSceneries() = 0;
-    virtual void load() = 0;
-    virtual void cancelLoading() = 0;
-    virtual void reloadMetar() = 0;
-    virtual void loadUserFixes(std::string filename) = 0;
-    virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
-    virtual std::shared_ptr<World> getWorld() = 0;
-    virtual void setUserFixesFilename(std::string filename) = 0;
+bool LoadManager::shouldCancelLoading() const {
+    return loadCancelled;
+}
 
-};
+std::vector<std::shared_ptr<NavNode>> LoadManager::loadFlightPlan(const std::string filename)
+{
+    try {
+        FMSLoader loader(getWorld());
+        auto res = loader.load(filename);
+        return res;
 
-} /* namespace world */
+    } catch (const std::exception &e) {
+        logger::warn("Unable to load/parse flight plan file '%s' %s", filename.c_str(), e.what());
+        return std::vector<std::shared_ptr<NavNode>>();
+    }
+}
 
-#endif /* SRC_WORLD_MANAGER_H_ */
-
+}

--- a/src/world/LoadManager.cpp
+++ b/src/world/LoadManager.cpp
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "LoadManager.h"
+#include "loaders/UserFixLoader.h"
 #include "loaders/FMSLoader.h"
 #include "src/Logger.h"
 
@@ -27,6 +28,31 @@ void LoadManager::cancelLoading() {
 
 bool LoadManager::shouldCancelLoading() const {
     return loadCancelled;
+}
+
+void LoadManager::setUserFixesFilename(std::string &filename) {
+    userFixesFilename = filename;
+}
+
+void LoadManager::loadUserFixes(std::string &userFixesFilename) {
+    try {
+        UserFixLoader loader(this);
+        loader.load(userFixesFilename);
+        logger::info("Loaded %s", userFixesFilename.c_str());
+
+    } catch (const std::exception &e) {
+        // User fixes are optional, so could be no CSV file or parse error
+        logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());
+    }
+}
+
+void LoadManager::loadUserFixes() {
+    if (userFixesFilename == "") {
+        logger::info("No user fixes file specified");
+        return;
+    } else {
+        loadUserFixes(userFixesFilename);
+    }
 }
 
 std::vector<std::shared_ptr<NavNode>> LoadManager::loadFlightPlan(const std::string filename)

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -24,21 +24,27 @@ namespace world {
 
 class LoadManager {
 public:
-
     virtual std::shared_ptr<World> getWorld() = 0;
 
     virtual void discoverSceneries() = 0;
     virtual void load() = 0;
     virtual void reloadMetar() = 0;
-    virtual void loadUserFixes(std::string filename) = 0;
-    virtual void setUserFixesFilename(std::string filename) = 0;
+
     virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
+
+    void setUserFixesFilename(std::string &filename);
+    void loadUserFixes(std::string &filename);
 
     void cancelLoading();
     bool shouldCancelLoading() const;
 
 protected:
+    void loadUserFixes();
+
+protected:
     std::atomic_bool loadCancelled { false };
+    std::string userFixesFilename;
+
 };
 
 } /* namespace world */

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -15,23 +15,32 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "Manager.h"
-#include "loaders/FMSLoader.h"
-#include "src/Logger.h"
+#ifndef SRC_WORLD_LOADMANAGER_H_
+#define SRC_WORLD_LOADMANAGER_H_
+
+#include "src/world/World.h"
 
 namespace world {
 
-std::vector<std::shared_ptr<NavNode>> Manager::loadFlightPlan(const std::string filename)
-{
-    try {
-        FMSLoader loader(getWorld());
-        auto res = loader.load(filename);
-        return res;
+class LoadManager {
+public:
 
-    } catch (const std::exception &e) {
-        logger::warn("Unable to load/parse flight plan file '%s' %s", filename.c_str(), e.what());
-        return std::vector<std::shared_ptr<NavNode>>();
-    }
-}
+    virtual std::shared_ptr<World> getWorld() = 0;
 
-}
+    virtual void discoverSceneries() = 0;
+    virtual void load() = 0;
+    virtual void reloadMetar() = 0;
+    virtual void loadUserFixes(std::string filename) = 0;
+    virtual void setUserFixesFilename(std::string filename) = 0;
+    virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
+
+    void cancelLoading();
+    bool shouldCancelLoading() const;
+
+protected:
+    std::atomic_bool loadCancelled { false };
+};
+
+} /* namespace world */
+
+#endif /* SRC_WORLD_LOADMANAGER_H_ */

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -56,6 +56,10 @@ public:
 
     virtual std::vector<Connection> &getConnections(std::shared_ptr<NavNode> from) = 0;
     virtual bool areConnected(std::shared_ptr<NavNode> from, const std::shared_ptr<NavNode> to) = 0;
+
+    virtual std::shared_ptr<Region> getRegion(const std::string &code) = 0;
+
+    virtual void addFix(std::shared_ptr<Fix> f) = 0;
 };
 
 

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -57,6 +57,7 @@ public:
     virtual std::vector<Connection> &getConnections(std::shared_ptr<NavNode> from) = 0;
     virtual bool areConnected(std::shared_ptr<NavNode> from, const std::shared_ptr<NavNode> to) = 0;
 
+    virtual void addRegion(const std::string &code) = 0;
     virtual std::shared_ptr<Region> getRegion(const std::string &code) = 0;
 
     virtual void addFix(std::shared_ptr<Fix> f) = 0;

--- a/src/world/loaders/CMakeLists.txt
+++ b/src/world/loaders/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(world PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/UserFixLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FMSLoader.cpp
 )

--- a/src/world/loaders/UserFixLoader.cpp
+++ b/src/world/loaders/UserFixLoader.cpp
@@ -16,14 +16,14 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "UserFixLoader.h"
-#include "src/libxdata/parsers/UserFixParser.h"
-#include "src/world/models/navaids/Fix.h"
+#include "../parsers/UserFixParser.h"
+#include "../models/navaids/Fix.h"
 #include "src/Logger.h"
 
-namespace xdata {
+namespace world {
 
-UserFixLoader::UserFixLoader(world::LoadManager *mgr):
-    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
+UserFixLoader::UserFixLoader(LoadManager *mgr):
+    loadMgr(mgr), world(mgr->getWorld())
 {
 }
 
@@ -45,14 +45,14 @@ void UserFixLoader::load(const std::string& file) {
 void UserFixLoader::onUserFixLoaded(const UserFixData& userfixdata) {
     // User fixes are unique, so create new fix each time
     // No region in LNM/PlanG csv format, so just use dummy one
-    auto region = world->findOrCreateRegion("USER_FIX");
-    world::Location location(userfixdata.latitude, userfixdata.longitude);
-    auto fix = std::make_shared<world::Fix>(region, userfixdata.ident, location);
-    auto userFix = std::make_shared<world::UserFix>();
+    auto region = world->getRegion("USER");
+    Location location(userfixdata.latitude, userfixdata.longitude);
+    auto fix = std::make_shared<Fix>(region, userfixdata.ident, location);
+    auto userFix = std::make_shared<UserFix>();
     userFix->setType(userfixdata.type);
     userFix->setName(userfixdata.name);
     fix->attachUserFix(userFix);
     world->addFix(fix);
 }
 
-} /* namespace xdata */
+} /* namespace world */

--- a/src/world/loaders/UserFixLoader.cpp
+++ b/src/world/loaders/UserFixLoader.cpp
@@ -22,9 +22,13 @@
 
 namespace world {
 
+constexpr const char *USER_REGION = "USER";
+
 UserFixLoader::UserFixLoader(LoadManager *mgr):
     loadMgr(mgr), world(mgr->getWorld())
 {
+    // Create a dummy region for user fixes (they are normally not region coded)
+    world->addRegion(USER_REGION);
 }
 
 void UserFixLoader::load(const std::string& file) {
@@ -45,7 +49,7 @@ void UserFixLoader::load(const std::string& file) {
 void UserFixLoader::onUserFixLoaded(const UserFixData& userfixdata) {
     // User fixes are unique, so create new fix each time
     // No region in LNM/PlanG csv format, so just use dummy one
-    auto region = world->getRegion("USER");
+    auto region = world->getRegion(USER_REGION);
     Location location(userfixdata.latitude, userfixdata.longitude);
     auto fix = std::make_shared<Fix>(region, userfixdata.ident, location);
     auto userFix = std::make_shared<UserFix>();

--- a/src/world/loaders/UserFixLoader.h
+++ b/src/world/loaders/UserFixLoader.h
@@ -15,27 +15,28 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
-#define SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
+#ifndef SRC_WORLD_LOADERS_USERFIXLOADER_H_
+#define SRC_WORLD_LOADERS_USERFIXLOADER_H_
 
 #include <memory>
-#include "src/world/LoadManager.h"
-#include "../parsers/objects/UserFixData.h"
-#include "../XWorld.h"
+#include "../LoadManager.h"
+#include "../World.h"
 
-namespace xdata {
+namespace world {
+
+struct UserFixData;
 
 class UserFixLoader {
 public:
-    UserFixLoader(world::LoadManager *mgr);
+    UserFixLoader(LoadManager *mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
-    std::shared_ptr<XWorld> world;
+    LoadManager * const loadMgr;
+    std::shared_ptr<World> world;
 
     void onUserFixLoaded(const UserFixData &navaid);
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_ */
+#endif /* SRC_WORLD_LOADERS_USERFIXLOADER_H_ */

--- a/src/world/parsers/CMakeLists.txt
+++ b/src/world/parsers/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(world PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/BaseParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FMSParser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/UserFixParser.cpp
 )

--- a/src/world/parsers/UserFixParser.cpp
+++ b/src/world/parsers/UserFixParser.cpp
@@ -21,7 +21,7 @@
 #include <cmath>
 #include "src/platform/strtod.h"
 
-namespace xdata {
+namespace world {
 
 UserFixParser::UserFixParser(const std::string& file):
     parser(file)
@@ -48,7 +48,7 @@ void UserFixParser::parseLine() {
     // See online manual for Little Nav Map, and Manual in Plan G install folder for further info
 
     std::string typeString = parser.nextCSVValue();
-    if (parseType(typeString) == world::UserFix::Type::NONE) {
+    if (parseType(typeString) == UserFix::Type::NONE) {
         lineNum++;
         return;
     }
@@ -90,16 +90,16 @@ void UserFixParser::parseLine() {
     lineNum++;
 }
 
-world::UserFix::Type UserFixParser::parseType(std::string& typeString) {
+UserFix::Type UserFixParser::parseType(std::string& typeString) {
     if ((typeString == "VRP") || (typeString == "11")) {
-        return world::UserFix::Type::VRP;
+        return UserFix::Type::VRP;
     } else if ((typeString == "POI") || (typeString == "8")) {
-        return world::UserFix::Type::POI;
+        return UserFix::Type::POI;
     } else if ((typeString == "Marker") || (typeString == "9") || (typeString == "10")) {
-        return world::UserFix::Type::MARKER;
+        return UserFix::Type::MARKER;
     } else {
-        return world::UserFix::Type::NONE;
+        return UserFix::Type::NONE;
     }
 }
 
-} /* namespace xdata */
+} /* namespace world */

--- a/src/world/parsers/UserFixParser.h
+++ b/src/world/parsers/UserFixParser.h
@@ -15,23 +15,35 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_
-#define SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_
+#ifndef SRC_WORLD_PARSERS_USERFIXPARSER_H_
+#define SRC_WORLD_PARSERS_USERFIXPARSER_H_
 
 #include <string>
-#include <limits>
-#include "src/world/models/navaids/UserFix.h"
+#include <functional>
+#include "../models/navaids/UserFix.h"
+#include "objects/UserFixData.h"
+#include "BaseParser.h"
 
-namespace xdata {
+namespace world {
 
-struct UserFixData {
-    world::UserFix::Type type = world::UserFix::Type::NONE;
-    std::string name;
-    std::string ident;
-    double latitude = std::numeric_limits<double>::quiet_NaN();
-    double longitude = std::numeric_limits<double>::quiet_NaN();
+class UserFixParser {
+public:
+    using Acceptor = std::function<void(const UserFixData &)>;
+
+    UserFixParser(const std::string &file);
+    void setAcceptor(Acceptor a);
+    std::string getHeader() const;
+    void loadUserFixes();
+private:
+    Acceptor acceptor;
+    std::string header;
+    BaseParser parser;
+    int lineNum;
+
+    void parseLine();
+    UserFix::Type parseType(std::string& typeString);
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_ */
+#endif /* SRC_WORLD_PARSERS_USERFIXPARSER_H_ */

--- a/src/world/parsers/objects/UserFixData.h
+++ b/src/world/parsers/objects/UserFixData.h
@@ -15,35 +15,23 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_
-#define SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_
+#ifndef SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_
+#define SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_
 
 #include <string>
-#include <functional>
-#include "src/world/models/navaids/UserFix.h"
-#include "objects/UserFixData.h"
-#include "src/world/parsers/BaseParser.h"
+#include <limits>
+#include "../../models/navaids/UserFix.h"
 
-namespace xdata {
+namespace world {
 
-class UserFixParser {
-public:
-    using Acceptor = std::function<void(const UserFixData &)>;
-
-    UserFixParser(const std::string &file);
-    void setAcceptor(Acceptor a);
-    std::string getHeader() const;
-    void loadUserFixes();
-private:
-    Acceptor acceptor;
-    std::string header;
-    world::BaseParser parser;
-    int lineNum;
-
-    void parseLine();
-    world::UserFix::Type parseType(std::string& typeString);
+struct UserFixData {
+    UserFix::Type type = UserFix::Type::NONE;
+    std::string name;
+    std::string ident;
+    double latitude = std::numeric_limits<double>::quiet_NaN();
+    double longitude = std::numeric_limits<double>::quiet_NaN();
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_ */
+#endif /* SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_ */


### PR DESCRIPTION
Fix a small defect causing duplication and wasted memory when loading user fixes. All existing airports and fixes were re-added to the fast lookup maps, indexed by integer long,lat areas. This update stops those entries being duplicated. However user fixes can be reloaded several times (if the user decides to do this) and will still be duplicated. This is slightly wasteful, but acceptable. It could be fixed later if considered a problem.

Remove NAV data load cancelling responsibility from the World class. The World class provides an API for obtaining NAV data, it shouldn't be involved in control aspects of loading this data. This has been moved into the Manager class, and rename it as LoadManager which clarifies its purpose.

Move user fix loading into the load manager base class. This makes user fix loading independent of the source of the world NAV data so that it will be supported by the forthcoming variant of Avitab for Microsoft Flight Simulator.

Split this PR into 3 changes to help with review.
