### PR TITLE
Optimisation and enhancements to map overlay drawing

### DIFF
--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -646,12 +646,22 @@ void MapApp::onRedrawNeeded() {
 
 void MapApp::onMapPan(int x, int y, bool start, bool end) {
     if (start) {
+        wasTrackingPlaneAtPanStart = trackPlane;
         trackPlane = false;
         trackButton->setToggleState(trackPlane);
+        (void)map->mouse(x, y, true);
     } else if (!end) {
         int panVecX = panPosX - x;
         int panVecY = panPosY - y;
         map->pan(panVecX, panVecY, x, y);
+    } else {
+        if (map->mouse(x, y, false)) {
+            // restore the trackPlane setting before the pan started
+            if (wasTrackingPlaneAtPanStart) {
+                trackPlane = true;
+                trackButton->setToggleState(trackPlane);
+            }
+        }
     }
     panPosX = x;
     panPosY = y;

--- a/src/avitab/apps/MapApp.h
+++ b/src/avitab/apps/MapApp.h
@@ -118,6 +118,7 @@ private:
     bool suspended = true;
 
     int panPosX = 0, panPosY = 0;
+    bool wasTrackingPlaneAtPanStart;
     std::string mercatorDir;
 
     void createSettingsLayout();

--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -48,11 +48,11 @@ std::shared_ptr<Settings> Environment::getSettings() {
     return settings;
 }
 
-void Environment::setWorldManager(std::shared_ptr<world::Manager> mgr) {
+void Environment::setWorldManager(std::shared_ptr<world::LoadManager> mgr) {
     worldManager = mgr;
 }
 
-std::shared_ptr<world::Manager> Environment::getWorldManager() {
+std::shared_ptr<world::LoadManager> Environment::getWorldManager() {
     return worldManager;
 }
 

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <future>
 #include <atomic>
-#include "src/world/Manager.h"
+#include "src/world/LoadManager.h"
 #include "src/libxdata/XData.h"
 #include "src/gui_toolkit/LVGLToolkit.h"
 #include "EnvData.h"
@@ -103,8 +103,8 @@ public:
 
 protected:
     void runEnvironmentCallbacks();
-    void setWorldManager(std::shared_ptr<world::Manager> mgr);
-    std::shared_ptr<world::Manager> getWorldManager();
+    void setWorldManager(std::shared_ptr<world::LoadManager> mgr);
+    std::shared_ptr<world::LoadManager> getWorldManager();
     void sendUserFixesFilenameToWorldMgr(std::string filename);
     void setLastFrameTime(float t);
 
@@ -115,7 +115,7 @@ private:
     std::vector<EnvironmentCallback> envCallbacks;
     std::shared_future<std::shared_ptr<world::World>> navWorldFuture;
     std::shared_ptr<world::World> navWorld;
-    std::shared_ptr<world::Manager> worldManager;
+    std::shared_ptr<world::LoadManager> worldManager;
     std::atomic_bool navWorldLoadAttempted {false};
     std::atomic<float> lastFrameTime {};
 

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -24,7 +24,6 @@
 #include "loaders/AirwayLoader.h"
 #include "loaders/CIFPLoader.h"
 #include "loaders/MetarLoader.h"
-#include "loaders/UserFixLoader.h"
 #include "parsers/CustomSceneryParser.h"
 #include "src/Logger.h"
 
@@ -67,10 +66,6 @@ void XData::discoverSceneries() {
     } catch (const std::exception &e) {
         logger::warn("Could not load scenery_packs.ini: %s", e.what());
     }
-}
-
-void XData::setUserFixesFilename(std::string filename) {
-    userFixesFilename = filename;
 }
 
 std::shared_ptr<world::World> XData::getWorld() {
@@ -171,26 +166,6 @@ void XData::loadMetar() {
     } catch (const std::exception &e) {
         // metar is optional, so only log
         logger::warn("Error parsing METAR: %s", e.what());
-    }
-}
-
-void XData::loadUserFixes() {
-    if (userFixesFilename == "") {
-        logger::info("No user fixes file specified");
-        return;
-    } else {
-        loadUserFixes(userFixesFilename);
-    }
-}
-
-void XData::loadUserFixes(std::string userFixesFilename) {
-    try {
-        UserFixLoader loader(this);
-        loader.load(userFixesFilename);
-        logger::info("Loaded %s", userFixesFilename.c_str());
-    } catch (const std::exception &e) {
-        // User fixes are optional, so could be no CSV file or parse error
-        logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());
     }
 }
 

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -101,12 +101,8 @@ void XData::load() {
     logger::info("Loaded nav data in %.2f seconds", millis / 1000.0f);
 }
 
-void XData::cancelLoading() {
-    xworld->cancelLoading();
-}
-
 void XData::loadAirports() {
-    const AirportLoader loader(xworld);
+    const AirportLoader loader(this);
 
     loadCustomScenery(loader);
 
@@ -136,29 +132,29 @@ void XData::loadCustomScenery(const AirportLoader& loader) {
 }
 
 void XData::loadFixes() {
-    FixLoader loader(xworld);
+    FixLoader loader(this);
     loader.load(navDataPath + "earth_fix.dat");
 }
 
 void XData::loadNavaids() {
-    NavaidLoader loader(xworld);
+    NavaidLoader loader(this);
     loader.load(navDataPath + "earth_nav.dat");
 }
 
 void XData::loadAirways() {
-    AirwayLoader loader(xworld);
+    AirwayLoader loader(this);
     loader.load(navDataPath + "earth_awy.dat");
 }
 
 void XData::loadProcedures() {
-    CIFPLoader loader(xworld);
+    CIFPLoader loader(this);
     xworld->forEachAirport([this, &loader] (std::shared_ptr<world::Airport> ap) {
         try {
             loader.load(ap, navDataPath + "CIFP/" + ap->getID() + ".dat");
         } catch (const std::exception &e) {
             // many airports do not have CIFP data, so ignore silently
         }
-        if (xworld->shouldCancelLoading()) {
+        if (shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });
@@ -170,7 +166,7 @@ void XData::loadMetar() {
     logger::verbose("Loading METAR...");
 
     try {
-        MetarLoader loader(xworld);
+        MetarLoader loader(this);
         loader.load(xplaneRoot + "METAR.rwx");
     } catch (const std::exception &e) {
         // metar is optional, so only log
@@ -189,10 +185,9 @@ void XData::loadUserFixes() {
 
 void XData::loadUserFixes(std::string userFixesFilename) {
     try {
-        UserFixLoader loader(xworld);
+        UserFixLoader loader(this);
         loader.load(userFixesFilename);
         logger::info("Loaded %s", userFixesFilename.c_str());
-
     } catch (const std::exception &e) {
         // User fixes are optional, so could be no CSV file or parse error
         logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());

--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -191,8 +191,6 @@ void XData::loadUserFixes(std::string userFixesFilename) {
     try {
         UserFixLoader loader(xworld);
         loader.load(userFixesFilename);
-        // Re-register all nodes, but shouldn't affect existing items, just adds new
-        xworld->registerNavNodes();
         logger::info("Loaded %s", userFixesFilename.c_str());
 
     } catch (const std::exception &e) {

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -35,8 +35,6 @@ public:
     void discoverSceneries() override;
     void load() override;
     void reloadMetar() override;
-    void loadUserFixes(std::string filename) override;
-    void setUserFixesFilename(std::string filename) override;
 private:
     std::string xplaneRoot;
     std::string navDataPath;
@@ -53,7 +51,6 @@ private:
     void loadProcedures();
     void loadMetar();
     void loadCustomScenery(const AirportLoader& loader);
-    void loadUserFixes();
 
 };
 

--- a/src/libxdata/XData.h
+++ b/src/libxdata/XData.h
@@ -21,22 +21,21 @@
 #include <string>
 #include <memory>
 #include <vector>
-#include "src/world/Manager.h"
+#include "src/world/LoadManager.h"
 #include "src/libxdata/XWorld.h"
 #include "src/libxdata/loaders/AirportLoader.h"
 
 namespace xdata {
 
-class XData : public world::Manager {
+class XData : public world::LoadManager {
 public:
     XData(const std::string &dataRootPath);
     virtual ~XData() = default;
+    std::shared_ptr<world::World> getWorld() override;
     void discoverSceneries() override;
     void load() override;
-    void cancelLoading() override;
     void reloadMetar() override;
     void loadUserFixes(std::string filename) override;
-    std::shared_ptr<world::World> getWorld() override;
     void setUserFixesFilename(std::string filename) override;
 private:
     std::string xplaneRoot;

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -81,7 +81,7 @@ void XWorld::forEachAirport(std::function<void(std::shared_ptr<world::Airport>)>
     }
 }
 
-std::shared_ptr<world::Region> XWorld::findOrCreateRegion(const std::string& id) {
+std::shared_ptr<world::Region> XWorld::getRegion(const std::string& id) {
     auto iter = regions.find(id);
     if (iter == regions.end()) {
         auto ptr = std::make_shared<world::Region>(id);

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -170,8 +170,8 @@ void XWorld::registerNode(std::shared_ptr<world::NavNode> n) {
     allNodes[std::make_pair(lat, lon)].push_back(n);
 }
 
-int XWorld::countNodes(const world::Location &bottomLeft, const world::Location &topRight) {
-    int total = 0;
+int XWorld::maxDensity(const world::Location &bottomLeft, const world::Location &topRight) {
+    int m = 0;
 
     // nodes are grouped by integer lat/lon 'squares'.
     int latl = std::max((int)std::floor(bottomLeft.latitude), -90);
@@ -179,27 +179,23 @@ int XWorld::countNodes(const world::Location &bottomLeft, const world::Location 
     int lonl = (int)std::floor(bottomLeft.longitude);
     int lonh = (int)std::ceil(topRight.longitude);
 
-    // the area might span the -180/180 meridian. bias it here, normalise again in iteration
+    // the area might span the -180/180 meridian. bias it here, normalise again in the iteration
     if (lonh < lonl) { lonh += 360; }
-
     for (int laty = latl; laty <= lath; ++laty) {
         for (int lonx = lonl; lonx <= lonh; ++lonx) {
             int normx = (lonx >= 180) ? (lonx - 360) : lonx;
             auto it = allNodes.find(std::make_pair(laty, normx));
             if (it == allNodes.end()) continue;
-            total += it->second.size();
+            m = std::max(m, (int)it->second.size());
         }
     }
 
-    // the total might include some nodes that are external to the requested area.
-    // return an approximation assuming a uniform distribution of nodes. this will be
-    // inaccurate, but should be good enough.
-    float areaMap = (topRight.longitude > bottomLeft.longitude)
+    // pretend that each grid area has 'max' nodes in it, and report the total number of visible nodes that
+    // would be seen if this was the case.
+    float mapArea = (topRight.longitude > bottomLeft.longitude)
                     ? (topRight.latitude - bottomLeft.latitude) * (topRight.longitude - bottomLeft.longitude)
                     : (topRight.latitude - bottomLeft.latitude) * (360 + topRight.longitude - bottomLeft.longitude);
-    float areaCounted = (1 + lath - latl) * (1 + lonh - lonl);
-    float r = areaMap / areaCounted;
-    return (int)((float)total * r);
+    return (int)(mapArea * m);
 }
 
 void XWorld::visitNodes(const world::Location& bottomLeft, const world::Location &topRight, NodeAcceptor callback, int filter) {
@@ -215,17 +211,19 @@ void XWorld::visitNodes(const world::Location& bottomLeft, const world::Location
     for (int laty = latl; laty <= lath; ++laty) {
         for (int lonx = lonl; lonx <= lonh; ++lonx) {
             int normx = (lonx >= 180) ? (lonx - 360) : lonx;
-            auto it = allNodes.find(std::make_pair(laty, normx));
+            std::pair<int, int> key = std::make_pair(laty, normx);
+            auto it = allNodes.find(key);
             if (it == allNodes.end()) {
                 continue;
             }
             for (auto node: it->second) {
+                if (!node->getLocation().isInArea(bottomLeft, topRight)) continue;
                 bool accept = false;
                 if (node->isAirport()) {
                     if (std::dynamic_pointer_cast<world::Airport>(node)->hasControlTower()) {
-                        accept = (filter & world::World::VISIT_AIRPORTS);
+                        accept = (filter & world::World::VISIT_TOWERED_AIRPORTS);
                     } else {
-                        accept = (filter & world::World::VISIT_AIRFIELDS);
+                        accept = (filter & world::World::VISIT_OTHER_AIRPORTS);
                     }
                 } else if (node->isFix()) {
                     auto f = std::dynamic_pointer_cast<world::Fix>(node);
@@ -237,7 +235,7 @@ void XWorld::visitNodes(const world::Location& bottomLeft, const world::Location
                         accept = (filter & world::World::VISIT_FIXES);
                     }
                 }
-                if (accept) callback(*node);
+                if (accept) callback(node.get());
             }
         }
     }

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -153,26 +153,29 @@ void XWorld::connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<wor
 void XWorld::addFix(std::shared_ptr<world::Fix> fix) {
     fix->setGlobal(true);
     fixes.insert(std::make_pair(fix->getID(), fix));
+    // fixes may be added after the initial loading of the NAV world.
+    // if so, register the node independently here
+    if (allNodesRegistered) {
+        registerNode(fix);
+    }
 }
 
 void XWorld::registerNavNodes() {
+    if (allNodesRegistered) return;
     for (auto it: airports) {
-        auto node = it.second;
-        auto &loc = node->getLocation();
-        int lat = (int) loc.latitude;
-        int lon = (int) loc.longitude;
-
-        allNodes[std::make_pair(lat, lon)].push_back(node);
+        registerNode(it.second);
     }
-
     for (auto it: fixes) {
-        auto node = it.second;
-        auto &loc = node->getLocation();
-        int lat = (int) loc.latitude;
-        int lon = (int) loc.longitude;
-
-        allNodes[std::make_pair(lat, lon)].push_back(node);
+        registerNode(it.second);
     }
+    allNodesRegistered = true;
+}
+
+void XWorld::registerNode(std::shared_ptr<world::NavNode> n) {
+    auto &loc = n->getLocation();
+    int lat = (int) loc.latitude;
+    int lon = (int) loc.longitude;
+    allNodes[std::make_pair(lat, lon)].push_back(n);
 }
 
 int XWorld::countNodes(const world::Location &bottomLeft, const world::Location &topRight) {

--- a/src/libxdata/XWorld.cpp
+++ b/src/libxdata/XWorld.cpp
@@ -29,14 +29,6 @@ XWorld::XWorld()
 {
 }
 
-void XWorld::cancelLoading() {
-    loadCancelled = true;
-}
-
-bool XWorld::shouldCancelLoading() const {
-    return loadCancelled;
-}
-
 std::shared_ptr<world::Airport> XWorld::findAirportByID(const std::string& id) const {
     std::string cleanId = platform::upper(id);
     cleanId.erase(std::remove(cleanId.begin(), cleanId.end(), ' '), cleanId.end());

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -43,9 +43,11 @@ public:
     std::vector<world::World::Connection> &getConnections(std::shared_ptr<world::NavNode> from) override;
     bool areConnected(std::shared_ptr<world::NavNode> from, const std::shared_ptr<world::NavNode> to) override;
 
+    std::shared_ptr<world::Region> getRegion(const std::string &id) override;
+
+    void addFix(std::shared_ptr<world::Fix> fix) override;
+
     void forEachAirport(std::function<void(std::shared_ptr<world::Airport>)> f);
-    void addFix(std::shared_ptr<world::Fix> fix);
-    std::shared_ptr<world::Region> findOrCreateRegion(const std::string &id);
     std::shared_ptr<world::Airport> findOrCreateAirport(const std::string &id);
     std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
     void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -33,7 +33,7 @@ public:
 
     virtual ~XWorld() = default;
 
-    int countNodes(const world::Location &bottomLeft, const world::Location &topRight) override;
+    int maxDensity(const world::Location &bottomLeft, const world::Location &topRight) override;
     void visitNodes(const world::Location &bottomLeft, const world::Location &topRight, NodeAcceptor callback, int filter) override;
 
     std::shared_ptr<world::Airport> findAirportByID(const std::string &id) const override;

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -50,9 +50,6 @@ public:
     std::shared_ptr<world::Airway> findOrCreateAirway(const std::string &name, world::AirwayLevel lvl);
     void connectTo(std::shared_ptr<world::NavNode> from, std::shared_ptr<world::NavEdge> via, std::shared_ptr<world::NavNode> to);
 
-    void cancelLoading();
-    bool shouldCancelLoading() const;
-
     void registerNavNodes();
 
 private:
@@ -60,7 +57,6 @@ private:
 
 private:
     bool allNodesRegistered { false };
-    std::atomic_bool loadCancelled { false };
 
     // Unique IDs
     std::map<std::string, std::shared_ptr<world::Region>> regions;

--- a/src/libxdata/XWorld.h
+++ b/src/libxdata/XWorld.h
@@ -56,6 +56,10 @@ public:
     void registerNavNodes();
 
 private:
+    void registerNode(std::shared_ptr<world::NavNode> n);
+
+private:
+    bool allNodesRegistered { false };
     std::atomic_bool loadCancelled { false };
 
     // Unique IDs

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -87,7 +87,7 @@ void AirportLoader::onAirportLoaded(const AirportData& port) const {
     airport->setElevation(port.elevation);
 
     if (!port.region.empty()) {
-        auto region = world->findOrCreateRegion(port.region);
+        auto region = world->getRegion(port.region);
         airport->setRegion(region);
         if (!port.country.empty()) {
             region->setName(port.country);

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -47,8 +47,8 @@ inline world::Runway::SurfaceMaterial mapToSurfaceMaterial(AirportData::SurfaceC
     return runwaySurfaceMap[(size_t)c];
 }
 
-AirportLoader::AirportLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+AirportLoader::AirportLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -60,7 +60,7 @@ void AirportLoader::load(const std::string& file) const {
         } catch (const std::exception &e) {
             logger::warn("Can't parse airport %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/AirportLoader.h
+++ b/src/libxdata/loaders/AirportLoader.h
@@ -19,17 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_AIRPORTLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/AirportData.h"
-#include "src/libxdata/parsers/AirportParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/AirportParser.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class AirportLoader {
 public:
-    AirportLoader(std::shared_ptr<XWorld> worldPtr);
+    AirportLoader(world::LoadManager *mgr);
     void load(const std::string &file) const;
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirportLoaded(const AirportData &port) const;

--- a/src/libxdata/loaders/AirwayLoader.cpp
+++ b/src/libxdata/loaders/AirwayLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-AirwayLoader::AirwayLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+AirwayLoader::AirwayLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void AirwayLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse airway %s: %s", data.name.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/AirwayLoader.h
+++ b/src/libxdata/loaders/AirwayLoader.h
@@ -19,17 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_AIRWAYLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/AirwayData.h"
-#include "src/libxdata/parsers/AirwayParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/objects/AirwayData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class AirwayLoader {
 public:
-    AirwayLoader(std::shared_ptr<XWorld> worldPtr);
+    AirwayLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirwayLoaded(const AirwayData &airway);

--- a/src/libxdata/loaders/CIFPLoader.cpp
+++ b/src/libxdata/loaders/CIFPLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-CIFPLoader::CIFPLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+CIFPLoader::CIFPLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void CIFPLoader::load(std::shared_ptr<world::Airport> airport, const std::string
         } catch (const std::exception &e) {
             logger::warn("CIFP error in %s: %s", cifp.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/CIFPLoader.h
+++ b/src/libxdata/loaders/CIFPLoader.h
@@ -19,17 +19,19 @@
 #define SRC_LIBXDATA_LOADERS_CIFPLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/CIFPData.h"
+#include "src/world/LoadManager.h"
 #include "src/world/models/airport/Airport.h"
-#include "src/libxdata/XWorld.h"
+#include "../parsers/objects/CIFPData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class CIFPLoader {
 public:
-    CIFPLoader(std::shared_ptr<XWorld> worldPtr);
+    CIFPLoader(world::LoadManager *mgr);
     void load(std::shared_ptr<world::Airport> airport, const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onProcedureLoaded(std::shared_ptr<world::Airport> airport, const CIFPData &procedure);

--- a/src/libxdata/loaders/CMakeLists.txt
+++ b/src/libxdata/loaders/CMakeLists.txt
@@ -5,5 +5,4 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/AirwayLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/CIFPLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MetarLoader.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/UserFixLoader.cpp
 )

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-FixLoader::FixLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+FixLoader::FixLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void FixLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse fix %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -52,7 +52,7 @@ void FixLoader::onFixLoaded(const FixData& fix) {
 void FixLoader::loadEnrouteFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->findOrCreateRegion(fix.icaoRegion);
+    auto region = world->getRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);
@@ -62,7 +62,7 @@ void FixLoader::loadEnrouteFix(const FixData& fix) {
 void FixLoader::loadTerminalFix(const FixData& fix) {
     auto fixModel = world->findFixByRegionAndID(fix.icaoRegion, fix.id);
 
-    auto region = world->findOrCreateRegion(fix.icaoRegion);
+    auto region = world->getRegion(fix.icaoRegion);
     world::Location loc(fix.latitude, fix.longitude);
 
     fixModel = std::make_shared<world::Fix>(region, fix.id, loc);

--- a/src/libxdata/loaders/FixLoader.h
+++ b/src/libxdata/loaders/FixLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_FIXLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/FixParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "src/libxdata/parsers/objects/FixData.h"
 
 namespace xdata {
 
 class FixLoader {
 public:
-    FixLoader(std::shared_ptr<XWorld> worldPtr);
+    FixLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onFixLoaded(const FixData &fix);

--- a/src/libxdata/loaders/MetarLoader.cpp
+++ b/src/libxdata/loaders/MetarLoader.cpp
@@ -21,8 +21,8 @@
 
 namespace xdata {
 
-MetarLoader::MetarLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+MetarLoader::MetarLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -34,7 +34,7 @@ void MetarLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse METAR for %s: %s", data.icaoCode.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/MetarLoader.h
+++ b/src/libxdata/loaders/MetarLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_METARLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/objects/MetarData.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "../parsers/objects/MetarData.h"
 
 namespace xdata {
 
 class MetarLoader {
 public:
-    MetarLoader(std::shared_ptr<XWorld> worldPtr);
+    MetarLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onMetarLoaded(const MetarData &metar);

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -55,7 +55,7 @@ void NavaidLoader::onNavaidLoaded(const NavaidData& navaid) {
     }
     if (!fix || dontPair) {
         world::Location location(navaid.latitude, navaid.longitude);
-        auto region = world->findOrCreateRegion(navaid.icaoRegion);
+        auto region = world->getRegion(navaid.icaoRegion);
         fix = std::make_shared<world::Fix>(region, navaid.id, location);
         world->addFix(fix);
     }

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -22,8 +22,8 @@
 
 namespace xdata {
 
-NavaidLoader::NavaidLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+NavaidLoader::NavaidLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -35,7 +35,7 @@ void NavaidLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse navaid %s: %s", data.id.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/NavaidLoader.h
+++ b/src/libxdata/loaders/NavaidLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_NAVAIDLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/NavaidParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../XWorld.h"
+#include "../parsers/NavaidParser.h"
 
 namespace xdata {
 
 class NavaidLoader {
 public:
-    NavaidLoader(std::shared_ptr<XWorld> worldPtr);
+    NavaidLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onNavaidLoaded(const NavaidData &navaid);

--- a/src/libxdata/loaders/UserFixLoader.cpp
+++ b/src/libxdata/loaders/UserFixLoader.cpp
@@ -22,8 +22,8 @@
 
 namespace xdata {
 
-UserFixLoader::UserFixLoader(std::shared_ptr<XWorld> worldPtr):
-    world(worldPtr)
+UserFixLoader::UserFixLoader(world::LoadManager *mgr):
+    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }
 
@@ -35,7 +35,7 @@ void UserFixLoader::load(const std::string& file) {
         } catch (const std::exception &e) {
             logger::warn("Can't parse userfix %s: %s", data.ident.c_str(), e.what());
         }
-        if (world->shouldCancelLoading()) {
+        if (loadMgr->shouldCancelLoading()) {
             throw std::runtime_error("Cancelled");
         }
     });

--- a/src/libxdata/loaders/UserFixLoader.h
+++ b/src/libxdata/loaders/UserFixLoader.h
@@ -19,16 +19,18 @@
 #define SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
 
 #include <memory>
-#include "src/libxdata/parsers/UserFixParser.h"
-#include "src/libxdata/XWorld.h"
+#include "src/world/LoadManager.h"
+#include "../parsers/objects/UserFixData.h"
+#include "../XWorld.h"
 
 namespace xdata {
 
 class UserFixLoader {
 public:
-    UserFixLoader(std::shared_ptr<XWorld> worldPtr);
+    UserFixLoader(world::LoadManager *mgr);
     void load(const std::string &file);
 private:
+    world::LoadManager * const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onUserFixLoaded(const UserFixData &navaid);

--- a/src/libxdata/parsers/CMakeLists.txt
+++ b/src/libxdata/parsers/CMakeLists.txt
@@ -6,5 +6,4 @@ target_sources(xdata PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/AirwayParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MetarParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/CustomSceneryParser.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/UserFixParser.cpp
 )

--- a/src/maps/CMakeLists.txt
+++ b/src/maps/CMakeLists.txt
@@ -13,4 +13,5 @@ target_sources(avitab_common PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/OverlayedWaypoint.cpp
     ${CMAKE_CURRENT_LIST_DIR}/OverlayedUserFix.cpp
     ${CMAKE_CURRENT_LIST_DIR}/OverlayedRoute.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/OverlayHighlight.cpp
 )

--- a/src/maps/OverlayHelper.h
+++ b/src/maps/OverlayHelper.h
@@ -27,19 +27,16 @@ namespace maps {
 
 class IOverlayHelper {
 public:
-    virtual std::shared_ptr<img::Image> getMapImage() = 0;
-    virtual void positionToPixel(double lat, double lon, int &px, int &py) const = 0;
-    virtual void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const = 0;
+    virtual int getMapDensity() const = 0;
     virtual double getMapWidthNM() const = 0;
-    virtual int getNumAerodromesVisible() const = 0;
-    virtual OverlayConfig &getOverlayConfig() const = 0;
-    virtual bool isLocVisibleWithMargin(const world::Location &loc, int margin) const = 0;
-    virtual bool isVisibleWithMargin(int x, int y, int margin) const = 0;
-    virtual bool isAreaVisible(int xmin, int ymin, int xmax, int ymax) const = 0;
-    virtual void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const = 0;
     virtual int getZoomLevel() const = 0;
     virtual int getMaxZoomLevel() const = 0;
     virtual double getNorthOffset() const = 0;
+    virtual std::shared_ptr<img::Image> getMapImage() = 0;
+    virtual bool isAreaVisible(int xmin, int ymin, int xmax, int ymax) const = 0;
+    virtual void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const = 0;
+    virtual void positionToPixel(double lat, double lon, int &px, int &py) const = 0;
+    virtual void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const = 0;
 
     virtual ~IOverlayHelper() = default;
 };

--- a/src/maps/OverlayHighlight.cpp
+++ b/src/maps/OverlayHighlight.cpp
@@ -1,0 +1,64 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2023 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "OverlayHighlight.h"
+
+namespace maps {
+
+static constexpr const int FAR_FAR_AWAY = 1 << 15;
+
+void OverlayHighlight::reset()
+{
+    active = false;
+    distance = FAR_FAR_AWAY;
+}
+
+void OverlayHighlight::activate(int x, int y)
+{
+    active = true;
+    refX = x;
+    refY = y;
+}
+
+void OverlayHighlight::update(std::shared_ptr<OverlayedNode> on)
+{
+    if (!active) return;
+    auto d = on->getHotspotDistance(refX, refY);
+    if (d < distance) {
+        distance = d;
+        node = on;
+    }
+}
+
+void OverlayHighlight::select()
+{
+    if (!active || !node) return;
+    node->setHighlighted();
+}
+
+void OverlayHighlight::highlight()
+{
+    if (!active || !node) return;
+    if (node->isHighlighted()) {
+        node->drawText(true);
+        node->clearHighlighted();
+    }
+}
+
+} /* namespace maps */
+

--- a/src/maps/OverlayHighlight.h
+++ b/src/maps/OverlayHighlight.h
@@ -1,6 +1,6 @@
 /*
  *   AviTab - Aviator's Virtual Tablet
- *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2023 Folke Will <folko@solhost.org>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Affero General Public License as published by
@@ -15,26 +15,29 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_MAPS_OVERLAYED_WAYPOINT_H_
-#define SRC_MAPS_OVERLAYED_WAYPOINT_H_
+#pragma once
 
-#include "OverlayedFix.h"
+#include "OverlayedNode.h"
 
 namespace maps {
 
-class OverlayedWaypoint : public OverlayedFix {
-
+class OverlayHighlight
+{
 public:
-    OverlayedWaypoint(IOverlayHelper *h, const world::Fix *f);
+    void reset();
+    void activate(int x, int y);
+    void update(std::shared_ptr<OverlayedNode> on);
+    void select();
+    void highlight();
 
-    void drawGraphic() override;
-    void drawText(bool detailed) override;
+    virtual ~OverlayHighlight() = default;
 
 private:
-    static constexpr const uint32_t color = img::COLOR_BLACK;
-    static constexpr const int MARGIN = 50;
+    bool active;
+    int refX, refY;
+    int distance;
+    std::shared_ptr<OverlayedNode> node;
+
 };
 
 } /* namespace maps */
-
-#endif /* SRC_MAPS_OVERLAYED_WAYPOINT_H_ */

--- a/src/maps/OverlayedAirport.h
+++ b/src/maps/OverlayedAirport.h
@@ -26,14 +26,12 @@ namespace maps {
 class OverlayedAirport : public OverlayedNode {
 
 public:
-    static std::shared_ptr<OverlayedAirport> getInstanceIfVisible(OverlayHelper helper, const world::Airport *airport);
-
-    OverlayedAirport(OverlayHelper helper, const world::Airport *airport);
+    OverlayedAirport(IOverlayHelper *, const world::Airport *);
     virtual ~OverlayedAirport() = default;
 
-    void drawGraphics();
-    void drawText(bool detailed);
-    virtual std::string getID();
+    std::string getID() const override;
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
 private:
 
@@ -48,10 +46,8 @@ private:
     AerodromeType type = AerodromeType::AIRPORT;
     uint32_t color = 0;
 
-    static bool isVisible(OverlayHelper helper, const world::Airport *airport);
-    static bool isEnabled(OverlayHelper helper, const world::Airport *airport);
-    static AerodromeType getAerodromeType(const world::Airport *airport);
-    static uint32_t getAirportColor(const world::Airport *airport);
+    AerodromeType getAerodromeType();
+    uint32_t getAirportColor();
 
     void drawAirportBlob();
     void drawAirportICAOCircleAndRwyPattern();
@@ -63,14 +59,13 @@ private:
     void drawRunwayRectangles(float size, uint32_t rectColor);
     bool isBlob();
 
-    static const int ICAO_CIRCLE_RADIUS = 15;
-    static const int SHOW_DETAILED_INFO_AT_MAPWIDTHNM = 40;
-    static const int DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM = 200;
-    static const int DRAW_BLOB_RUNWAYS_NUM_AERODROMES_VISIBLE = 100;
-    static const int MAX_BLOB_SIZE = 12;
-    static const int BLOB_SIZE_DIVIDEND = DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM * MAX_BLOB_SIZE;
-    static const int DRAW_GEOGRAPHIC_RUNWAYS_AT_MAPWIDTHNM = 5;
-    static const int ICAO_RING_RADIUS = 12;
+    static constexpr const int ICAO_CIRCLE_RADIUS = 15;
+    static constexpr const int DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM = 200;
+    static constexpr const int DRAW_BLOBS_ABOVE_NODE_DENSITY = 1200;
+    static constexpr const int MAX_BLOB_SIZE = 12;
+    static constexpr const int BLOB_SIZE_DIVIDEND = DRAW_BLOB_RUNWAYS_AT_MAPWIDTHNM * MAX_BLOB_SIZE;
+    static constexpr const int DRAW_GEOGRAPHIC_RUNWAYS_AT_MAPWIDTHNM = 5;
+    static constexpr const int ICAO_RING_RADIUS = 12;
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedDME.h
+++ b/src/maps/OverlayedDME.h
@@ -25,20 +25,18 @@ namespace maps {
 class OverlayedDME : public OverlayedFix {
 
 public:
-    static std::shared_ptr<OverlayedDME> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
+    OverlayedDME(IOverlayHelper *h, const world::Fix *f);
 
-    // Used by OverlayedVOR for paired VOR/DME
-    static void drawGraphicsStatic(OverlayHelper helper, const world::Fix *fix, int px, int py);
+    void configure(const OverlayConfig &cfg, const world::Location &loc) override;
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
-    OverlayedDME(OverlayHelper helper, const world::Fix *m_fix);
-
-    void drawGraphics();
-    void drawText(bool detailed);
-    int getHotspotX();
-    int getHotspotY();
+    Hotspot getClickHotspot() const override;
 
 private:
-    static const int MARGIN = 60;
+    const world::DME * const navDME;
+
+    static constexpr const int MARGIN = 60;
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedFix.h
+++ b/src/maps/OverlayedFix.h
@@ -27,29 +27,25 @@ namespace maps {
 class OverlayedFix : public OverlayedNode {
 
 public:
-    static std::shared_ptr<OverlayedFix> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
-
-    virtual void drawGraphics() = 0;
-    virtual void drawText(bool detailed) = 0;
-    virtual std::string getID();
+    std::string getID() const override;
 
 protected:
-    OverlayedFix(OverlayHelper helper, const world::Fix *fix);
+    OverlayedFix(IOverlayHelper *h, const world::Fix *f);
     virtual ~OverlayedFix() = default;
 
-    static void drawNavTextBox(OverlayHelper helper, const std::string &type, const std::string &id, const std::string &freq, int x, int y, uint32_t color,
-                               const std::string &ilsHeadingMagnetic = "");
+    void drawNavTextBox(const std::string &type, const std::string &id, const std::string &freq,
+                                int x, int y, uint32_t color,
+                                const std::string &ilsHeadingMagnetic = "");
+
+protected:
     const world::Fix *fix;
 
-    static const int TEXT_SIZE = 10;
+    static constexpr const int TEXT_SIZE = 10;
 
 private:
     static world::Morse morse;
 
-    static void drawMorse(OverlayHelper helper, int x, int y, std::string text, int size, uint32_t color);
-    static bool isDMEOnly(const world::Fix &fix);
-    static const int SHOW_NAVAIDS_AT_MAPWIDTHNM = 200;
-    static const int SHOW_USERFIXES_AT_MAPWIDTHNM = 1000;
+    void drawMorse(int x, int y, std::string text, int size, uint32_t color);
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedILSLocalizer.cpp
+++ b/src/maps/OverlayedILSLocalizer.cpp
@@ -24,77 +24,69 @@
 
 namespace maps {
 
-OverlayedILSLocalizer::OverlayedILSLocalizer(OverlayHelper helper, const world::Fix *fix,
-        int lx, int ly, int cx, int cy, int rx, int ry):
-    OverlayedFix(helper, fix),
-    lx(lx), ly(ly),
-    cx(cx), cy(cy),
-    rx(rx), ry(ry)
+OverlayedILSLocalizer::OverlayedILSLocalizer(IOverlayHelper *h, const world::Fix *f)
+:   OverlayedFix(h, f),
+    navILS(f->getILSLocalizer().get())
 {
-    textLocationX =  (px + 4 * cx) / 5;       // Draw NavTextBox 1/5 of the way from end of tail to airport
-    textLocationY = ((py + 4 * cy) / 5) - 20; // And up a bit
-}
-
-std::shared_ptr<OverlayedILSLocalizer> OverlayedILSLocalizer::getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix) {
-    if (!fix.getILSLocalizer() || !helper->getOverlayConfig().drawILSs) {
-        return nullptr;
-    }
-
-    int px, py, lx, ly, cx, cy, rx, ry;
-    auto &loc = fix.getLocation();
-    helper->positionToPixel(loc.latitude, loc.longitude, px, py);
-    getTailCoords(helper, &fix, lx, ly, cx, cy, rx, ry);
-
-    int xmin = std::min(px, (int)std::min(lx, rx));
-    int ymin = std::min(py, (int)std::min(ly, ry));
-    int xmax = std::max(px, (int)std::max(lx, rx));
-    int ymax = std::max(py, (int)std::max(ly, ry));
-
-    if (helper->isAreaVisible(xmin, ymin, xmax, ymax)) {
-        return std::make_shared<OverlayedILSLocalizer>(helper, &fix, lx, ly, cx, cy, rx, ry);
-    } else {
-        return nullptr;
+    if (fix->getDME()) {
+        linkedDME = std::make_unique<OverlayedDME>(h, f);
     }
 }
 
-int OverlayedILSLocalizer::getHotspotX() {
-    return textLocationX;
+void OverlayedILSLocalizer::configure(const OverlayConfig &cfg, const world::Location &loc)
+{
+    OverlayedFix::configure(cfg, loc);
+    if (linkedDME) {
+        linkedDME->configure(cfg, loc);
+    }
+    enabled = navILS && cfg.drawILSs && cfg.drawAirports;
+    if (enabled) {
+        setTailCoords();
+        textLocationX =  (posX + 4 * cx) / 5;       // Draw NavTextBox 1/5 of the way from end of tail to airport
+        textLocationY = ((posY + 4 * cy) / 5) - 20; // And up a bit
+    }
 }
 
-int OverlayedILSLocalizer::getHotspotY() {
-    return textLocationY;
-}
+void OverlayedILSLocalizer::drawGraphic()
+{
+    if (linkedDME) {
+        linkedDME->drawGraphic();
+    }
 
-void OverlayedILSLocalizer::drawGraphics() {
+    if (!enabled) return;
+
     auto mapImage = overlayHelper->getMapImage();
-    mapImage->drawLineAA(px, py, lx, ly, color);
-    mapImage->drawLineAA(px, py, cx, cy, color);
-    mapImage->drawLineAA(px, py, rx, ry, color);
+    mapImage->drawLineAA(posX, posY, lx, ly, color);
+    mapImage->drawLineAA(posX, posY, cx, cy, color);
+    mapImage->drawLineAA(posX, posY, rx, ry, color);
     mapImage->drawLineAA(cx, cy, lx, ly, color);
     mapImage->drawLineAA(cx, cy, rx, ry, color);
 }
 
-void OverlayedILSLocalizer::drawText(bool detailed) {
-    auto ils = fix->getILSLocalizer();
-    if (!ils) {
-        return;
-    }
-    std::string type = ils->isLocalizerOnly() ? "LOC" : "ILS";
-    type = fix->getDME() ? type + "/DME" : type;
+void OverlayedILSLocalizer::drawText(bool detailed)
+{
+    if (!enabled) return;
+
+    std::string type = navILS->isLocalizerOnly() ? "LOC" : "ILS";
+    type = linkedDME ? type + "/DME" : type;
     if (detailed) {
-        auto freqString = ils->getFrequency().getFrequencyString(false);
-        double headingMagnetic = ils->getRunwayHeadingMagnetic();
+        auto freqString = navILS->getFrequency().getFrequencyString(false);
+        double headingMagnetic = navILS->getRunwayHeadingMagnetic();
         std::ostringstream str;
         if (!std::isnan(headingMagnetic)) {
             str << std::setfill('0') << std::setw(3) << int(std::floor(headingMagnetic + 0.5));
         }
-        drawNavTextBox(overlayHelper, type, fix->getID(), freqString, textLocationX, textLocationY,
+        drawNavTextBox(type, getID(), freqString, textLocationX, textLocationY,
                        color, str.str());
     } else {
         auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawText(fix->getID(), 12, textLocationX, textLocationY,
+        mapImage->drawText(getID(), 12, textLocationX, textLocationY,
                            color, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
     }
+}
+
+OverlayedNode::Hotspot OverlayedILSLocalizer::getClickHotspot() const {
+    return Hotspot(textLocationX, textLocationY);
 }
 
 void OverlayedILSLocalizer::polarToCartesian(float radius, float angleDegrees, double& x, double& y) {
@@ -102,20 +94,15 @@ void OverlayedILSLocalizer::polarToCartesian(float radius, float angleDegrees, d
     y = -std::cos(angleDegrees * M_PI / 180.0) * radius; // 0 degrees is up, decreasing y values
 }
 
-void OverlayedILSLocalizer::getTailCoords(OverlayHelper helper, const world::Fix *fix, int &lx, int &ly, int &cx, int &cy, int &rx, int &ry) {
-    auto &loc = fix->getLocation();
-    int px, py;
-    helper->positionToPixel(loc.latitude, loc.longitude, px, py);
-    auto ils = fix->getILSLocalizer();
-    if (!ils) {
-        return;
-    }
-    double ilsHeading = std::fmod(ils->getRunwayHeading() + 180.0, 360);
-    ilsHeading += helper->getNorthOffset();
+void OverlayedILSLocalizer::setTailCoords()
+{
+    double ilsHeading = std::fmod(navILS->getRunwayHeading() + 180.0, 360);
+    ilsHeading += overlayHelper->getNorthOffset();
     double rangePixels = 0.0;
-    if (helper->getMapWidthNM() != 0) {
-        auto mapImage = helper->getMapImage();
-        rangePixels = (ils->getRange() * mapImage->getWidth()) / helper->getMapWidthNM();
+    auto mw = overlayHelper->getMapWidthNM();
+    if (mw != 0) {
+        auto mapImage = overlayHelper->getMapImage();
+        rangePixels = (navILS->getRange() * mapImage->getWidth()) / mw;
     }
     double dcx, dcy, dlx, dly, drx, dry;
     const double OUTER_ANGLE = 2.5;
@@ -123,12 +110,12 @@ void OverlayedILSLocalizer::getTailCoords(OverlayHelper helper, const world::Fix
     polarToCartesian(rangePixels * 0.95, ilsHeading, dcx, dcy);
     polarToCartesian(rangePixels, ilsHeading + OUTER_ANGLE, drx, dry);
 
-    lx = px + dlx;
-    ly = py + dly;
-    cx = px + dcx;
-    cy = py + dcy;
-    rx = px + drx;
-    ry = py + dry;
+    lx = posX + dlx;
+    ly = posY + dly;
+    cx = posX + dcx;
+    cy = posY + dcy;
+    rx = posX + drx;
+    ry = posY + dry;
 }
 
 } /* namespace maps */

--- a/src/maps/OverlayedILSLocalizer.h
+++ b/src/maps/OverlayedILSLocalizer.h
@@ -19,27 +19,29 @@
 #define SRC_MAPS_OVERLAYED_ILSLOCALIZER_H_
 
 #include "OverlayedFix.h"
+#include "OverlayedDME.h"
 
 namespace maps {
 
 class OverlayedILSLocalizer : public OverlayedFix {
 
 public:
-    static std::shared_ptr<OverlayedILSLocalizer> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
+    OverlayedILSLocalizer(IOverlayHelper *h, const world::Fix *f);
 
-    OverlayedILSLocalizer(OverlayHelper helper, const world::Fix *m_fix,
-                          int lx, int ly, int cx, int cy, int rx, int ry);
+    void configure(const OverlayConfig &cfg, const world::Location &loc) override;
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
-    void drawGraphics();
-    void drawText(bool detailed);
-    int getHotspotX();
-    int getHotspotY();
+    Hotspot getClickHotspot() const override;
 
 private:
-    static void getTailCoords(OverlayHelper helper, const world::Fix *fix, int &lx, int &ly, int &cx, int &cy, int &rx, int &ry);
-    static void polarToCartesian(float radius, float angleDegrees, double& x, double& y);
+    void setTailCoords();
+    void polarToCartesian(float radius, float angleDegrees, double& x, double& y);
 
-    static const uint32_t color = img::COLOR_DARK_GREEN;
+    const world::ILSLocalizer * const navILS;
+    std::unique_ptr<OverlayedDME> linkedDME;
+
+    static constexpr const uint32_t color = img::COLOR_DARK_GREEN;
     
     int textLocationX = 0;
     int textLocationY = 0;

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -29,10 +29,11 @@
 #include "OverlayConfig.h"
 #include "OverlayedNode.h"
 #include "OverlayedRoute.h"
+#include "OverlayHighlight.h"
 
 namespace maps {
 
-class OverlayedMap: public std::enable_shared_from_this<OverlayedMap>, public IOverlayHelper {
+class OverlayedMap : public IOverlayHelper {
 public:
     using OverlaysDrawnCallback = std::function<void(void)>;
     using GetRouteCallback = std::function<std::shared_ptr<world::Route>(void)>;
@@ -43,6 +44,7 @@ public:
     void setGetRouteCallback(GetRouteCallback cb);
     void setNavWorld(std::shared_ptr<world::World> world);
 
+    bool mouse(int px, int py, bool down);
     void pan(int dx, int dy, int relx = -1, int rely = -1);
 
     void centerOnWorldPos(double latitude, double longitude);
@@ -67,73 +69,89 @@ public:
     void doWork();
 
     // IOverlayHelper functions
-    std::shared_ptr<img::Image> getMapImage() override;
-    void positionToPixel(double lat, double lon, int &px, int &py) const override;
-    void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const override;
-    double getMapWidthNM() const override;
-    int getNumAerodromesVisible() const override;
-    OverlayConfig &getOverlayConfig() const override;
-    bool isLocVisibleWithMargin(const world::Location &loc, int margin) const override;
-    bool isVisibleWithMargin(int x, int y, int marginPixels) const override;
-    bool isAreaVisible(int xmin, int ymin, int xmax, int ymax) const override;
-    void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const override;
+    int getMapDensity() const override;
+    virtual double getMapWidthNM() const override;
     int getZoomLevel() const override;
     int getMaxZoomLevel() const override;
     double getNorthOffset() const override;
+    std::shared_ptr<img::Image> getMapImage() override;
+    bool isAreaVisible(int xmin, int ymin, int xmax, int ymax) const override;
+    void fastPolarToCartesian(float radius, int angleDegrees, double& x, double& y) const override;
+    void positionToPixel(double lat, double lon, int &px, int &py) const override;
+    void positionToPixel(double lat, double lon, int &px, int &py, int zoomLevel) const override;
 
 private:
-    // Data
+    // Highlighted nodes
+    enum { LAST_CLICK, USER_PLANE, MAP_CENTER, NUM_HIGHLIGHT_NODES }; // last click, user's plane, map-center
+    OverlayHighlight highlights[NUM_HIGHLIGHT_NODES]; // last click, user's plane, map-center
+
+private:
     std::shared_ptr<img::Image> mapImage;
     std::shared_ptr<img::TileSource> tileSource;
+    std::shared_ptr<img::Stitcher> stitcher;
+    std::shared_ptr<OverlayConfig> overlayConfig;
+    img::TTFStamper copyrightStamp;
+
+    // current map display attributes, updated on each frame
+    double leftLon, rightLon;
+    double bottomLat, topLat;
+    int maxNodeDensity;
+    double mapWidthNM;
+    double mapScaleNMperPixel;
+
+    int lastClickX, lastClickY;
+
     OverlaysDrawnCallback onOverlaysDrawn;
+
+    using NavNodeToOverlayMap = std::map<const world::NavNode *, std::shared_ptr<OverlayedNode>>;
+    std::shared_ptr<NavNodeToOverlayMap> overlayNodeCache;
+
     std::unique_ptr<OverlayedRoute> overlayedRoute;
     GetRouteCallback getRoute;
-    double mapWidthNM;
-    int numAerodromesVisible;
 
     float sinTable[360];
     float cosTable[360];
 
-    // Overlays
-    std::shared_ptr<OverlayConfig> overlayConfig;
     std::shared_ptr<world::World> navWorld;
     std::vector<avitab::Location> planeLocations;
     img::Image planeIcon;
     enum RelativeHeight { below, same, above, total };
     uint32_t otherAircraftColors[RelativeHeight::total];
-    img::Image ndbIcon;
+
     int calibrationStep = 0;
-    img::TTFStamper copyrightStamp;
-    bool dbg;
-    double lastLatClicked = 0;
-    double lastLongClicked = 0;
-
-    std::shared_ptr<OverlayedNode> closestNodeToLastClicked;
-    std::shared_ptr<OverlayedNode> closestNodeToPlane;
-    std::shared_ptr<OverlayedNode> closestNodeToCentre;
-
-    // Tiles
-    std::shared_ptr<img::Stitcher> stitcher;
 
     void drawOverlays();
     void drawAircraftOverlay();
     void drawOtherAircraftOverlay();
-    void drawDataOverlays();
+    void drawNavWorldOverlays();
     void drawCalibrationOverlay();
-    void drawScale(double nmPerPixel);
+    void drawScale();
     void drawCompass();
     void drawRoute();
 
+    std::shared_ptr<OverlayedNode> makeOverlayedNode(const world::NavNode *);
+    bool isOverlayConfigured(const world::NavNode *) const;
+
+    void updateMapAttributes();
     void pixelToPosition(int px, int py, double &lat, double &lon) const;
     float cosDegrees(int angleDegrees) const;
     float sinDegrees(int angleDegrees) const;
     void polarToCartesian(float radius, float angleRadians, double& x, double& y);
-    bool isHotspot(std::shared_ptr<OverlayedNode> node);
-    void showHotspotDetailedText();
 
-    static const int MAX_VISIT_OBJECTS_IN_FRAME = 5000;
-    static const int MAX_VISIBLE_OBJECTS_TO_SHOW_TEXT = 200;
-    static const int MAX_VISIBLE_OBJECTS_TO_SHOW_DETAILED_TEXT = 40;
+private:
+    // these numbers tune what and how overlays are displayed, mainly based on the
+    // densest region within the visible map.
+    static constexpr const int MAX_VISIT_OBJECTS_IN_FRAME = 30000;
+    static constexpr const int DENSITY_LIMIT_AIRFIELDS = 15000;
+    static constexpr const int DENSITY_LIMIT_NAVAIDS = 6000;
+    static constexpr const int DENSITY_LIMIT_FIXES = 3000;
+    static constexpr const int DENSITY_LIMIT_SHOW_TEXT = 400;
+    static constexpr const int DENSITY_LIMIT_DETAILED_TEXT = 200;
+    // user fixes are generally shown unless significantly zoomed out
+    static constexpr const int MAPWIDTH_LIMIT_USERFIXES = 2000;
+
+    static constexpr const int MAX_NM_PER_DEGREE = 60; // at the equator, OK for our needs
+    static constexpr const int MAX_ILS_RANGE_NM = 18; // 18nm is max ILS range in XP11 dataset
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedNDB.h
+++ b/src/maps/OverlayedNDB.h
@@ -25,16 +25,17 @@ namespace maps {
 class OverlayedNDB : public OverlayedFix {
 
 public:
-    static std::shared_ptr<OverlayedNDB> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
+    OverlayedNDB(IOverlayHelper *h, const world::Fix *f);
 
-    OverlayedNDB(OverlayHelper helper, const world::Fix *m_fix);
+    void configure(const OverlayConfig &cfg, const world::Location &loc) override;
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
-    void drawGraphics();
-    void drawText(bool detailed);
-    int getHotspotX();
-    int getHotspotY();
+    Hotspot getClickHotspot() const override;
 
 private:
+    const world::NDB * const navNDB;
+
     static img::Image ndbIcon;
     static int radius;
     static void createNDBIcon();

--- a/src/maps/OverlayedNode.h
+++ b/src/maps/OverlayedNode.h
@@ -25,25 +25,39 @@
 
 namespace maps {
 
-using OverlayHelper = std::shared_ptr<IOverlayHelper>;
-
-class OverlayedNode {
+class OverlayedNode
+{
 public:
-    static std::shared_ptr<OverlayedNode> getInstanceIfVisible(OverlayHelper helper, const world::NavNode &node);
+    virtual ~OverlayedNode() = default;
 
-    virtual void drawGraphics() = 0;
+    virtual std::string getID() const = 0;
+
+    virtual void configure(const OverlayConfig &cfg, const world::Location &loc);
+    virtual void drawGraphic() = 0;
     virtual void drawText(bool detailed) = 0;
-    virtual int getDistanceFromHotspot(int x, int y);
-    virtual int getHotspotX();
-    virtual int getHotspotY();
-    virtual std::string getID() = 0;
-    bool isEqual(OverlayedNode &node);
-protected:
-    OverlayedNode(OverlayHelper helper);
 
-    OverlayHelper overlayHelper;
-    int px = 0;
-    int py = 0;
+    void setHighlighted() { highlight = true; }
+    void clearHighlighted() { highlight = false; }
+
+    bool isAirfield() const { return airfield; }
+    bool isHighlighted() const { return highlight; }
+
+    int getHotspotDistance(int x, int y) const;
+
+protected:
+    using Hotspot = std::pair<int, int>;
+    virtual Hotspot getClickHotspot() const { return Hotspot(posX, posY); }
+
+protected:
+    OverlayedNode() = delete;
+    OverlayedNode(IOverlayHelper *helper, bool airfield);
+
+protected:
+    IOverlayHelper * const overlayHelper;
+    bool enabled;           // true if overlay is enabled (some overlays are instantiated even when not configured)
+    bool const airfield;    // used when sorting for drawing order
+    bool highlight;         // true if the overlay is selected for highlighting
+    int posX, posY;         // pixel coordinates of the item, could be off-screen
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedRoute.cpp
+++ b/src/maps/OverlayedRoute.cpp
@@ -23,8 +23,8 @@
 
 namespace maps {
 
-OverlayedRoute::OverlayedRoute(OverlayHelper helper):
-    overlayHelper(helper)
+OverlayedRoute::OverlayedRoute(IOverlayHelper *h):
+    overlayHelper(h)
 {
 }
 

--- a/src/maps/OverlayedRoute.h
+++ b/src/maps/OverlayedRoute.h
@@ -26,15 +26,13 @@
 
 namespace maps {
 
-using OverlayHelper = std::shared_ptr<IOverlayHelper>;
-
 class OverlayedRoute {
 public:
-    OverlayedRoute(OverlayHelper helper);
+    OverlayedRoute(IOverlayHelper *h);
     void draw(std::shared_ptr<world::Route> route);
 
 private:
-    OverlayHelper overlayHelper;
+    IOverlayHelper * const overlayHelper;
     std::map<uint32_t, std::shared_ptr<img::Image>> routeAnnotationCache;
 
     void drawLeg(world::Location &from, world::Location &to, double distance,

--- a/src/maps/OverlayedUserFix.cpp
+++ b/src/maps/OverlayedUserFix.cpp
@@ -26,28 +26,10 @@ img::Image OverlayedUserFix::VRPIcon;
 img::Image OverlayedUserFix::MarkerIcon;
 std::vector<std::string> OverlayedUserFix::textLines;
 
-OverlayedUserFix::OverlayedUserFix(OverlayHelper helper, const world::Fix *fix):
-    OverlayedFix(helper, fix){
+OverlayedUserFix::OverlayedUserFix(IOverlayHelper *h, const world::Fix *f):
+    OverlayedFix(h, f){
     if (POIIcon.getHeight() == 0) {
         createIcons();
-    }
-}
-
-std::shared_ptr<OverlayedUserFix> OverlayedUserFix::getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix) {
-    auto userFix = fix.getUserFix();
-    if (!userFix) {
-        return nullptr;
-    }
-    auto cfg = helper->getOverlayConfig();
-    auto type = userFix->getType();
-    bool drawUserFixes = (cfg.drawPOIs && (type == world::UserFix::Type::POI)) ||
-                         (cfg.drawVRPs && (type == world::UserFix::Type::VRP)) ||
-                         (cfg.drawMarkers && (type == world::UserFix::Type::MARKER));
-
-    if (drawUserFixes && helper->isLocVisibleWithMargin(fix.getLocation(), 100)) {
-        return std::make_shared<OverlayedUserFix>(helper, &fix);
-    } else {
-        return nullptr;
     }
 }
 
@@ -76,15 +58,15 @@ void OverlayedUserFix::createIcons() {
     MarkerIcon.drawCircle(xc, yc, r / 2, MARKER_COLOR);
 }
 
-void OverlayedUserFix::drawGraphics() {
+void OverlayedUserFix::drawGraphic() {
     auto type = fix->getUserFix()->getType();
     auto mapImage = overlayHelper->getMapImage();
     if (type == world::UserFix::Type::POI) {
-        mapImage->blendImage0(POIIcon, px - RADIUS, py - RADIUS);
+        mapImage->blendImage0(POIIcon, posX - RADIUS, posY - RADIUS);
     } else if (type == world::UserFix::Type::VRP) {
-        mapImage->blendImage0(VRPIcon, px - RADIUS, py - RADIUS);
+        mapImage->blendImage0(VRPIcon, posX - RADIUS, posY - RADIUS);
     } else if (type == world::UserFix::Type::MARKER) {
-        mapImage->blendImage0(MarkerIcon, px - RADIUS, py - RADIUS);
+        mapImage->blendImage0(MarkerIcon, posX - RADIUS, posY - RADIUS);
     }
 }
 
@@ -105,8 +87,8 @@ void OverlayedUserFix::drawText(bool detailed) {
     if (textLines.size() == 2) {
         textWidth = std::max(mapImage->getTextWidth(textLines[1], TEXT_SIZE), textWidth);
     }
-    int x = px + DIAG + 1;
-    int y = py + DIAG + 1;
+    int x = posX + DIAG + 1;
+    int y = posY + DIAG + 1;
     int yo = TEXT_SIZE / 2;
     int borderWidth = textWidth + 4;
     int borderHeight = (TEXT_SIZE * (textLines.size() + 0.5)) + 1;

--- a/src/maps/OverlayedUserFix.h
+++ b/src/maps/OverlayedUserFix.h
@@ -27,12 +27,10 @@ namespace maps {
 class OverlayedUserFix : public OverlayedFix {
 
 public:
-    static std::shared_ptr<OverlayedUserFix> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
+    OverlayedUserFix(IOverlayHelper *h, const world::Fix *f);
 
-    OverlayedUserFix(OverlayHelper helper, const world::Fix *m_fix);
-
-    void drawGraphics();
-    void drawText(bool detailed);
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
 private:
     void splitNameToLines();

--- a/src/maps/OverlayedVOR.cpp
+++ b/src/maps/OverlayedVOR.cpp
@@ -17,91 +17,95 @@
  */
 
 #include "OverlayedVOR.h"
-#include "OverlayedDME.h"
 
 namespace maps {
 
-OverlayedVOR::OverlayedVOR(OverlayHelper helper, const world::Fix *fix):
-    OverlayedFix(helper, fix)
+OverlayedVOR::OverlayedVOR(IOverlayHelper *h, const world::Fix *f):
+    OverlayedFix(h, f),
+    navVOR(f->getVOR().get())
 {
-}
-
-std::shared_ptr<OverlayedVOR> OverlayedVOR::getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix) {
-    if (fix.getVOR() && helper->getOverlayConfig().drawVORs && helper->isLocVisibleWithMargin(fix.getLocation(), MARGIN)) {
-        return std::make_shared<OverlayedVOR>(helper, &fix);
-    } else {
-        return nullptr;
+    if (fix->getDME()) {
+        linkedDME = std::make_unique<OverlayedDME>(h, f);
     }
 }
 
-int OverlayedVOR::getHotspotX() {
-    return px - 20;
+void OverlayedVOR::configure(const OverlayConfig &cfg, const world::Location &loc)
+{
+    OverlayedFix::configure(cfg, loc);
+    if (linkedDME) {
+        linkedDME->configure(cfg, loc);
+    }
+    enabled = navVOR && cfg.drawVORs;
 }
 
-int OverlayedVOR::getHotspotY() {
-    return py - 20;
-}
+void OverlayedVOR::drawGraphic()
+{
+    if (!enabled) return;
 
-void OverlayedVOR::drawGraphics() {
-    auto vor = fix->getVOR();
     double r = 8;
 
-    if (fix->getDME()) {
-        OverlayedDME::drawGraphicsStatic(overlayHelper, fix, px, py);
+    if (linkedDME) {
+        linkedDME->drawGraphic();
     }
 
-    if (fix->getVOR()) {
-        auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawLine(px - r / 20, py - r / 20, px + r / 20, py + r / 20, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px - r / 20, py + r / 20, px + r / 20, py - r / 20, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px + r / 2, py - r, px + r, py, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px + r, py, px + r / 2, py + r, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px + r / 2, py + r, px - r / 2, py + r, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px - r / 2, py + r, px - r, py, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px - r, py, px - r / 2, py - r, img::COLOR_ICAO_VOR_DME);
-        mapImage->drawLine(px - r / 2, py - r, px + r / 2, py - r, img::COLOR_ICAO_VOR_DME);
+    auto mapImage = overlayHelper->getMapImage();
+    mapImage->drawLine(posX - r / 20, posY - r / 20, posX + r / 20, posY + r / 20, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX - r / 20, posY + r / 20, posX + r / 20, posY - r / 20, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX + r / 2, posY - r, posX + r, posY, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX + r, posY, posX + r / 2, posY + r, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX + r / 2, posY + r, posX - r / 2, posY + r, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX - r / 2, posY + r, posX - r, posY, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX - r, posY, posX - r / 2, posY - r, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawLine(posX - r / 2, posY - r, posX + r / 2, posY - r, img::COLOR_ICAO_VOR_DME);
 
-        mapImage->drawCircle(px, py, CIRCLE_RADIUS, img::COLOR_ICAO_VOR_DME);
+    mapImage->drawCircle(posX, posY, CIRCLE_RADIUS, img::COLOR_ICAO_VOR_DME);
 
-        // Draw ticks
-        const float BIG_TICK_SCALE = 0.84;
-        const float SMALL_TICK_SCALE = 0.92;
-        int bearing = (int)vor->getBearing();
-        bearing += overlayHelper->getNorthOffset();
-        for (int deg = 0; deg <= 360; deg += 10) {
-            double inner_x, inner_y, outer_x, outer_y;
-            float tickScale = (deg%30 == 0) ? BIG_TICK_SCALE : SMALL_TICK_SCALE;
-            overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * tickScale, deg + bearing, inner_x, inner_y);
-            overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS, deg + bearing, outer_x, outer_y);
+    // Draw ticks
+    const float BIG_TICK_SCALE = 0.84;
+    const float SMALL_TICK_SCALE = 0.92;
+    int bearing = (int)navVOR->getBearing();
+    bearing += overlayHelper->getNorthOffset();
+    for (int deg = 0; deg <= 360; deg += 10) {
+        double inner_x, inner_y, outer_x, outer_y;
+        float tickScale = (deg%30 == 0) ? BIG_TICK_SCALE : SMALL_TICK_SCALE;
+        overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * tickScale, deg + bearing, inner_x, inner_y);
+        overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS, deg + bearing, outer_x, outer_y);
 
-            if (deg == 0) {
-                mapImage->drawLineAA(px, py, px + outer_x, py + outer_y, img::COLOR_ICAO_VOR_DME);
-            } else {
-                mapImage->drawLineAA(px + inner_x, py + inner_y, px + outer_x, py + outer_y, img::COLOR_ICAO_VOR_DME);
-            }
+        if (deg == 0) {
+            mapImage->drawLineAA(posX, posY, posX + outer_x, posY + outer_y, img::COLOR_ICAO_VOR_DME);
+        } else {
+            mapImage->drawLineAA(posX + inner_x, posY + inner_y, posX + outer_x, posY + outer_y, img::COLOR_ICAO_VOR_DME);
+        }
 
-            if ((deg % 90) == 0) {
-                double inner1_x, inner1_y, inner2_x, inner2_y;
-                overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * BIG_TICK_SCALE, deg + bearing - 2, inner1_x, inner1_y);
-                overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * BIG_TICK_SCALE, deg + bearing + 2, inner2_x, inner2_y);
-                mapImage->drawLineAA(px + inner1_x, py + inner1_y, px + outer_x,  py + outer_y,  img::COLOR_ICAO_VOR_DME);
-                mapImage->drawLineAA(px + inner2_x, py + inner2_y, px + outer_x,  py + outer_y,  img::COLOR_ICAO_VOR_DME);
-                mapImage->drawLineAA(px + inner1_x, py + inner1_y, px + inner2_x, py + inner2_y, img::COLOR_ICAO_VOR_DME);
-            }
+        if ((deg % 90) == 0) {
+            double inner1_x, inner1_y, inner2_x, inner2_y;
+            overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * BIG_TICK_SCALE, deg + bearing - 2, inner1_x, inner1_y);
+            overlayHelper->fastPolarToCartesian(CIRCLE_RADIUS * BIG_TICK_SCALE, deg + bearing + 2, inner2_x, inner2_y);
+            mapImage->drawLineAA(posX + inner1_x, posY + inner1_y, posX + outer_x,  posY + outer_y,  img::COLOR_ICAO_VOR_DME);
+            mapImage->drawLineAA(posX + inner2_x, posY + inner2_y, posX + outer_x,  posY + outer_y,  img::COLOR_ICAO_VOR_DME);
+            mapImage->drawLineAA(posX + inner1_x, posY + inner1_y, posX + inner2_x, posY + inner2_y, img::COLOR_ICAO_VOR_DME);
         }
     }
 }
 
-void OverlayedVOR::drawText(bool detailed) {
-    std::string type = fix->getDME() ? "VOR/DME" : "VOR";
+void OverlayedVOR::drawText(bool detailed)
+{
+    if (!enabled) return;
+
+    std::string type = linkedDME ? "VOR/DME" : "VOR";
     if (detailed) {
-        auto freqString = fix->getVOR()->getFrequency().getFrequencyString(false);
-        drawNavTextBox(overlayHelper, type, fix->getID(), freqString, px - 47, py - 37, img::COLOR_ICAO_VOR_DME);
+        auto freqString = navVOR->getFrequency().getFrequencyString(false);
+        drawNavTextBox(type, getID(), freqString, posX - 47, posY - 37, img::COLOR_ICAO_VOR_DME);
     } else {
         auto mapImage = overlayHelper->getMapImage();
-        mapImage->drawText(fix->getID(), 12, getHotspotX(), getHotspotY(),
+        auto hs = getClickHotspot();
+        mapImage->drawText(getID(), 12, hs.first, hs.second,
             img::COLOR_ICAO_VOR_DME, img::COLOR_TRANSPARENT_WHITE, img::Align::CENTRE);
     }
+}
+
+OverlayedNode::Hotspot OverlayedVOR::getClickHotspot() const {
+    return Hotspot(posX - 20, posY - 20);
 }
 
 } /* namespace maps */

--- a/src/maps/OverlayedVOR.h
+++ b/src/maps/OverlayedVOR.h
@@ -19,24 +19,27 @@
 #define SRC_MAPS_OVERLAYED_VOR_H_
 
 #include "OverlayedFix.h"
+#include "OverlayedDME.h"
 
 namespace maps {
 
 class OverlayedVOR : public OverlayedFix {
 
 public:
-    static std::shared_ptr<OverlayedVOR> getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix);
+    OverlayedVOR(IOverlayHelper *h, const world::Fix *f);
 
-    OverlayedVOR(OverlayHelper helper, const world::Fix *m_fix);
+    void configure(const OverlayConfig &cfg, const world::Location &loc) override;
+    void drawGraphic() override;
+    void drawText(bool detailed) override;
 
-    void drawGraphics();
-    void drawText(bool detailed);
-    int getHotspotX();
-    int getHotspotY();
+    Hotspot getClickHotspot() const override;
 
 private:
-    static const int CIRCLE_RADIUS = 70;
-    static const int MARGIN = CIRCLE_RADIUS;
+    const world::VOR * const navVOR;
+    std::unique_ptr<OverlayedDME> linkedDME;
+
+    static constexpr const int CIRCLE_RADIUS = 70;
+    static constexpr const int MARGIN = CIRCLE_RADIUS;
 };
 
 } /* namespace maps */

--- a/src/maps/OverlayedWaypoint.cpp
+++ b/src/maps/OverlayedWaypoint.cpp
@@ -20,29 +20,21 @@
 
 namespace maps {
 
-OverlayedWaypoint::OverlayedWaypoint(OverlayHelper helper, const world::Fix *fix):
-    OverlayedFix(helper, fix)
+OverlayedWaypoint::OverlayedWaypoint(IOverlayHelper *h, const world::Fix *f):
+    OverlayedFix(h, f)
 {
 }
 
-std::shared_ptr<OverlayedWaypoint> OverlayedWaypoint::getInstanceIfVisible(OverlayHelper helper, const world::Fix &fix) {
-    if (helper->getOverlayConfig().drawWaypoints && helper->isLocVisibleWithMargin(fix.getLocation(), MARGIN)) {
-        return std::make_shared<OverlayedWaypoint>(helper, &fix);
-    } else {
-        return nullptr;
-    }
-}
-
-void OverlayedWaypoint::drawGraphics() {
+void OverlayedWaypoint::drawGraphic() {
     auto mapImage = overlayHelper->getMapImage();
-    mapImage->drawLine(px, py - 6, px + 5, py + 3, color);
-    mapImage->drawLine(px + 5, py + 3, px - 5, py + 3, color);
-    mapImage->drawLine(px - 5, py + 3, px, py - 6, color);
+    mapImage->drawLine(posX, posY - 6, posX + 5, posY + 3, color);
+    mapImage->drawLine(posX + 5, posY + 3, posX - 5, posY + 3, color);
+    mapImage->drawLine(posX - 5, posY + 3, posX, posY - 6, color);
 }
 
 void OverlayedWaypoint::drawText(bool detailed) {
     auto mapImage = overlayHelper->getMapImage();
-    mapImage->drawText(fix->getID(), 10, px + 6, py - 6, color, 0, img::Align::LEFT);
+    mapImage->drawText(fix->getID(), 10, posX + 6, posY - 6, color, 0, img::Align::LEFT);
 }
 
 } /* namespace maps */

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -7,5 +7,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/parsers/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/router/CMakeLists.txt)
 
 target_sources(world PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/Manager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/LoadManager.cpp
 )

--- a/src/world/LoadManager.cpp
+++ b/src/world/LoadManager.cpp
@@ -15,28 +15,31 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_WORLD_MANAGER_H_
-#define SRC_WORLD_MANAGER_H_
-
-#include "src/world/World.h"
+#include "LoadManager.h"
+#include "loaders/FMSLoader.h"
+#include "src/Logger.h"
 
 namespace world {
 
-class Manager {
-public:
+void LoadManager::cancelLoading() {
+    loadCancelled = true;
+}
 
-    virtual void discoverSceneries() = 0;
-    virtual void load() = 0;
-    virtual void cancelLoading() = 0;
-    virtual void reloadMetar() = 0;
-    virtual void loadUserFixes(std::string filename) = 0;
-    virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
-    virtual std::shared_ptr<World> getWorld() = 0;
-    virtual void setUserFixesFilename(std::string filename) = 0;
+bool LoadManager::shouldCancelLoading() const {
+    return loadCancelled;
+}
 
-};
+std::vector<std::shared_ptr<NavNode>> LoadManager::loadFlightPlan(const std::string filename)
+{
+    try {
+        FMSLoader loader(getWorld());
+        auto res = loader.load(filename);
+        return res;
 
-} /* namespace world */
+    } catch (const std::exception &e) {
+        logger::warn("Unable to load/parse flight plan file '%s' %s", filename.c_str(), e.what());
+        return std::vector<std::shared_ptr<NavNode>>();
+    }
+}
 
-#endif /* SRC_WORLD_MANAGER_H_ */
-
+}

--- a/src/world/LoadManager.cpp
+++ b/src/world/LoadManager.cpp
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "LoadManager.h"
+#include "loaders/UserFixLoader.h"
 #include "loaders/FMSLoader.h"
 #include "src/Logger.h"
 
@@ -27,6 +28,31 @@ void LoadManager::cancelLoading() {
 
 bool LoadManager::shouldCancelLoading() const {
     return loadCancelled;
+}
+
+void LoadManager::setUserFixesFilename(std::string &filename) {
+    userFixesFilename = filename;
+}
+
+void LoadManager::loadUserFixes(std::string &userFixesFilename) {
+    try {
+        UserFixLoader loader(this);
+        loader.load(userFixesFilename);
+        logger::info("Loaded %s", userFixesFilename.c_str());
+
+    } catch (const std::exception &e) {
+        // User fixes are optional, so could be no CSV file or parse error
+        logger::warn("Unable to load/parse user fixes file '%s' %s", userFixesFilename.c_str(), e.what());
+    }
+}
+
+void LoadManager::loadUserFixes() {
+    if (userFixesFilename == "") {
+        logger::info("No user fixes file specified");
+        return;
+    } else {
+        loadUserFixes(userFixesFilename);
+    }
 }
 
 std::vector<std::shared_ptr<NavNode>> LoadManager::loadFlightPlan(const std::string filename)

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -24,21 +24,27 @@ namespace world {
 
 class LoadManager {
 public:
-
     virtual std::shared_ptr<World> getWorld() = 0;
 
     virtual void discoverSceneries() = 0;
     virtual void load() = 0;
     virtual void reloadMetar() = 0;
-    virtual void loadUserFixes(std::string filename) = 0;
-    virtual void setUserFixesFilename(std::string filename) = 0;
+
     virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
+
+    void setUserFixesFilename(std::string &filename);
+    void loadUserFixes(std::string &filename);
 
     void cancelLoading();
     bool shouldCancelLoading() const;
 
 protected:
+    void loadUserFixes();
+
+protected:
     std::atomic_bool loadCancelled { false };
+    std::string userFixesFilename;
+
 };
 
 } /* namespace world */

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -15,23 +15,32 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "Manager.h"
-#include "loaders/FMSLoader.h"
-#include "src/Logger.h"
+#ifndef SRC_WORLD_LOADMANAGER_H_
+#define SRC_WORLD_LOADMANAGER_H_
+
+#include "src/world/World.h"
 
 namespace world {
 
-std::vector<std::shared_ptr<NavNode>> Manager::loadFlightPlan(const std::string filename)
-{
-    try {
-        FMSLoader loader(getWorld());
-        auto res = loader.load(filename);
-        return res;
+class LoadManager {
+public:
 
-    } catch (const std::exception &e) {
-        logger::warn("Unable to load/parse flight plan file '%s' %s", filename.c_str(), e.what());
-        return std::vector<std::shared_ptr<NavNode>>();
-    }
-}
+    virtual std::shared_ptr<World> getWorld() = 0;
 
-}
+    virtual void discoverSceneries() = 0;
+    virtual void load() = 0;
+    virtual void reloadMetar() = 0;
+    virtual void loadUserFixes(std::string filename) = 0;
+    virtual void setUserFixesFilename(std::string filename) = 0;
+    virtual std::vector<std::shared_ptr<world::NavNode>> loadFlightPlan(const std::string filename);
+
+    void cancelLoading();
+    bool shouldCancelLoading() const;
+
+protected:
+    std::atomic_bool loadCancelled { false };
+};
+
+} /* namespace world */
+
+#endif /* SRC_WORLD_LOADMANAGER_H_ */

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -56,6 +56,10 @@ public:
 
     virtual std::vector<Connection> &getConnections(std::shared_ptr<NavNode> from) = 0;
     virtual bool areConnected(std::shared_ptr<NavNode> from, const std::shared_ptr<NavNode> to) = 0;
+
+    virtual std::shared_ptr<Region> getRegion(const std::string &code) = 0;
+
+    virtual void addFix(std::shared_ptr<Fix> f) = 0;
 };
 
 

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -37,17 +37,17 @@ class World {
 public:
     static constexpr const int MAX_SEARCH_RESULTS = 10;
 
-    static constexpr const int VISIT_AIRPORTS =    0b1;
-    static constexpr const int VISIT_AIRFIELDS =   0b10;
-    static constexpr const int VISIT_FIXES =       0b100;
-    static constexpr const int VISIT_NAVAIDS =     0b1000;
-    static constexpr const int VISIT_USER_FIXES =  0b10000;
-    static constexpr const int VISIT_EVERYTHING = (VISIT_AIRPORTS | VISIT_AIRFIELDS | VISIT_NAVAIDS | VISIT_FIXES | VISIT_USER_FIXES);
+    static constexpr const int VISIT_TOWERED_AIRPORTS = 0b1;
+    static constexpr const int VISIT_OTHER_AIRPORTS =   0b10;
+    static constexpr const int VISIT_FIXES =            0b100;
+    static constexpr const int VISIT_NAVAIDS =          0b1000;
+    static constexpr const int VISIT_USER_FIXES =       0b10000;
+    static constexpr const int VISIT_EVERYTHING = (VISIT_TOWERED_AIRPORTS | VISIT_OTHER_AIRPORTS | VISIT_NAVAIDS | VISIT_FIXES | VISIT_USER_FIXES);
 
-    using NodeAcceptor = std::function<void(const world::NavNode &node)>;
+    using NodeAcceptor = std::function<void(const world::NavNode *)>;
     using Connection = std::pair<std::shared_ptr<NavEdge>, std::shared_ptr<NavNode>>;
 
-    virtual int countNodes(const world::Location &bottomLeft, const world::Location &topRight) = 0;
+    virtual int maxDensity(const world::Location &bottomLeft, const world::Location &topRight) = 0;
     virtual void visitNodes(const world::Location &bottomLeft, const world::Location &topRight, NodeAcceptor calllback, int filter) = 0;
 
     virtual std::shared_ptr<Airport> findAirportByID(const std::string &id) const = 0;

--- a/src/world/loaders/CMakeLists.txt
+++ b/src/world/loaders/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(world PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/UserFixLoader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FMSLoader.cpp
 )

--- a/src/world/loaders/UserFixLoader.cpp
+++ b/src/world/loaders/UserFixLoader.cpp
@@ -16,14 +16,14 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "UserFixLoader.h"
-#include "src/libxdata/parsers/UserFixParser.h"
-#include "src/world/models/navaids/Fix.h"
+#include "../parsers/UserFixParser.h"
+#include "../models/navaids/Fix.h"
 #include "src/Logger.h"
 
-namespace xdata {
+namespace world {
 
-UserFixLoader::UserFixLoader(world::LoadManager *mgr):
-    loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
+UserFixLoader::UserFixLoader(LoadManager *mgr):
+    loadMgr(mgr), world(mgr->getWorld())
 {
 }
 
@@ -45,14 +45,14 @@ void UserFixLoader::load(const std::string& file) {
 void UserFixLoader::onUserFixLoaded(const UserFixData& userfixdata) {
     // User fixes are unique, so create new fix each time
     // No region in LNM/PlanG csv format, so just use dummy one
-    auto region = world->findOrCreateRegion("USER_FIX");
-    world::Location location(userfixdata.latitude, userfixdata.longitude);
-    auto fix = std::make_shared<world::Fix>(region, userfixdata.ident, location);
-    auto userFix = std::make_shared<world::UserFix>();
+    auto region = world->getRegion("USER");
+    Location location(userfixdata.latitude, userfixdata.longitude);
+    auto fix = std::make_shared<Fix>(region, userfixdata.ident, location);
+    auto userFix = std::make_shared<UserFix>();
     userFix->setType(userfixdata.type);
     userFix->setName(userfixdata.name);
     fix->attachUserFix(userFix);
     world->addFix(fix);
 }
 
-} /* namespace xdata */
+} /* namespace world */

--- a/src/world/loaders/UserFixLoader.h
+++ b/src/world/loaders/UserFixLoader.h
@@ -15,27 +15,28 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
-#define SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_
+#ifndef SRC_WORLD_LOADERS_USERFIXLOADER_H_
+#define SRC_WORLD_LOADERS_USERFIXLOADER_H_
 
 #include <memory>
-#include "src/world/LoadManager.h"
-#include "../parsers/objects/UserFixData.h"
-#include "../XWorld.h"
+#include "../LoadManager.h"
+#include "../World.h"
 
-namespace xdata {
+namespace world {
+
+struct UserFixData;
 
 class UserFixLoader {
 public:
-    UserFixLoader(world::LoadManager *mgr);
+    UserFixLoader(LoadManager *mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
-    std::shared_ptr<XWorld> world;
+    LoadManager * const loadMgr;
+    std::shared_ptr<World> world;
 
     void onUserFixLoaded(const UserFixData &navaid);
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_LOADERS_USERFIXLOADER_H_ */
+#endif /* SRC_WORLD_LOADERS_USERFIXLOADER_H_ */

--- a/src/world/models/Location.cpp
+++ b/src/world/models/Location.cpp
@@ -59,4 +59,17 @@ double Location::distanceTo(const Location& other) const {
     return R * c;
 }
 
+bool Location::isInArea(const Location &bottomLeft, const Location &topRight) const {
+    if (latitude < bottomLeft.latitude) return false;
+    if (latitude > topRight.latitude) return false;
+    if (bottomLeft.longitude < topRight.longitude) {
+        if (longitude < bottomLeft.longitude) return false;
+        if (longitude > topRight.longitude) return false;
+        return true;
+    }
+    // if we get this far it's because the area spans the -180/+180 discontinuity
+    if ((longitude > bottomLeft.longitude) && (longitude < topRight.longitude)) return false;
+    return true;
+}
+
 } /* namespace world */

--- a/src/world/models/Location.h
+++ b/src/world/models/Location.h
@@ -32,8 +32,8 @@ struct Location {
     bool isValid() const;
 
     double bearingTo(const Location &other) const;
-
     double distanceTo(const Location &other) const;
+    bool isInArea(const Location &bottomLeft, const Location &topRight) const;
 };
 
 } /* namespace world */

--- a/src/world/parsers/CMakeLists.txt
+++ b/src/world/parsers/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(world PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/BaseParser.cpp
     ${CMAKE_CURRENT_LIST_DIR}/FMSParser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/UserFixParser.cpp
 )

--- a/src/world/parsers/UserFixParser.cpp
+++ b/src/world/parsers/UserFixParser.cpp
@@ -21,7 +21,7 @@
 #include <cmath>
 #include "src/platform/strtod.h"
 
-namespace xdata {
+namespace world {
 
 UserFixParser::UserFixParser(const std::string& file):
     parser(file)
@@ -48,7 +48,7 @@ void UserFixParser::parseLine() {
     // See online manual for Little Nav Map, and Manual in Plan G install folder for further info
 
     std::string typeString = parser.nextCSVValue();
-    if (parseType(typeString) == world::UserFix::Type::NONE) {
+    if (parseType(typeString) == UserFix::Type::NONE) {
         lineNum++;
         return;
     }
@@ -90,16 +90,16 @@ void UserFixParser::parseLine() {
     lineNum++;
 }
 
-world::UserFix::Type UserFixParser::parseType(std::string& typeString) {
+UserFix::Type UserFixParser::parseType(std::string& typeString) {
     if ((typeString == "VRP") || (typeString == "11")) {
-        return world::UserFix::Type::VRP;
+        return UserFix::Type::VRP;
     } else if ((typeString == "POI") || (typeString == "8")) {
-        return world::UserFix::Type::POI;
+        return UserFix::Type::POI;
     } else if ((typeString == "Marker") || (typeString == "9") || (typeString == "10")) {
-        return world::UserFix::Type::MARKER;
+        return UserFix::Type::MARKER;
     } else {
-        return world::UserFix::Type::NONE;
+        return UserFix::Type::NONE;
     }
 }
 
-} /* namespace xdata */
+} /* namespace world */

--- a/src/world/parsers/UserFixParser.h
+++ b/src/world/parsers/UserFixParser.h
@@ -15,23 +15,35 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_
-#define SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_
+#ifndef SRC_WORLD_PARSERS_USERFIXPARSER_H_
+#define SRC_WORLD_PARSERS_USERFIXPARSER_H_
 
 #include <string>
-#include <limits>
-#include "src/world/models/navaids/UserFix.h"
+#include <functional>
+#include "../models/navaids/UserFix.h"
+#include "objects/UserFixData.h"
+#include "BaseParser.h"
 
-namespace xdata {
+namespace world {
 
-struct UserFixData {
-    world::UserFix::Type type = world::UserFix::Type::NONE;
-    std::string name;
-    std::string ident;
-    double latitude = std::numeric_limits<double>::quiet_NaN();
-    double longitude = std::numeric_limits<double>::quiet_NaN();
+class UserFixParser {
+public:
+    using Acceptor = std::function<void(const UserFixData &)>;
+
+    UserFixParser(const std::string &file);
+    void setAcceptor(Acceptor a);
+    std::string getHeader() const;
+    void loadUserFixes();
+private:
+    Acceptor acceptor;
+    std::string header;
+    BaseParser parser;
+    int lineNum;
+
+    void parseLine();
+    UserFix::Type parseType(std::string& typeString);
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_PARSERS_OBJECTS_USERFIXDATA_H_ */
+#endif /* SRC_WORLD_PARSERS_USERFIXPARSER_H_ */

--- a/src/world/parsers/objects/UserFixData.h
+++ b/src/world/parsers/objects/UserFixData.h
@@ -15,35 +15,23 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_
-#define SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_
+#ifndef SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_
+#define SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_
 
 #include <string>
-#include <functional>
-#include "src/world/models/navaids/UserFix.h"
-#include "objects/UserFixData.h"
-#include "src/world/parsers/BaseParser.h"
+#include <limits>
+#include "../../models/navaids/UserFix.h"
 
-namespace xdata {
+namespace world {
 
-class UserFixParser {
-public:
-    using Acceptor = std::function<void(const UserFixData &)>;
-
-    UserFixParser(const std::string &file);
-    void setAcceptor(Acceptor a);
-    std::string getHeader() const;
-    void loadUserFixes();
-private:
-    Acceptor acceptor;
-    std::string header;
-    world::BaseParser parser;
-    int lineNum;
-
-    void parseLine();
-    world::UserFix::Type parseType(std::string& typeString);
+struct UserFixData {
+    UserFix::Type type = UserFix::Type::NONE;
+    std::string name;
+    std::string ident;
+    double latitude = std::numeric_limits<double>::quiet_NaN();
+    double longitude = std::numeric_limits<double>::quiet_NaN();
 };
 
-} /* namespace xdata */
+} /* namespace world */
 
-#endif /* SRC_LIBXDATA_PARSERS_USERFIXPARSER_H_ */
+#endif /* SRC_WORLD_PARSERS_OBJECTS_USERFIXDATA_H_ */


### PR DESCRIPTION
This change includes some refactoring and optimisation to the map overlays, partly inspired by separate development of a SQL-backed NAV database, which required API changes to the visit() interface, and resulted in this more extensive update.

The selection of nodes for display in the overlay has been partly delegated to the world's visit() function. (This capability was added to a previous refactoring PR, and is now being used.) This reduces the number of nodes that need to be processed in the OverlayMap class.

Each NAV node that is going to be displayed as a map overlay has a paired overlay node object created. These are now cached and reused in the next frame (if still selected for display) which reduces the overhead of overlay nodes that are destroyed and recreated on each frame.

Decisions on what to draw, and in what detail, are based on the density of NAV node information on the map, rather than the map width. The information density is estimated using the densenst lat/lon area within the visible map area. This particular update is also related to the future SQL-backed NAV database, where the reporting of NAV nodes over large areas will need to be completed over several (possibly many) display frames due to the time required to search the SQL database. But more on that later.

A change in mouse click behaviour has been added to support clicking near overlayed node information to show more detailed text about the node. Previously using the mouse to pan would also highlight the node nearest the pan start location. The update now means that only a stationary (or small movement) mouse click is treated as a request to highlight the nearest node.

The branch used for this PR is based on a previous PR, and therefore currently also includes 3 duplicated commits. I'm assuming the other PR will be separately approved first, and then this PR can be merged afterwards.