### PR TITLE
Fix Plane Manual app file browsing initialisation.

### DIFF
--- a/src/avitab/AviTab.cpp
+++ b/src/avitab/AviTab.cpp
@@ -123,6 +123,9 @@ void AviTab::onPlaneLoad() {
     createPanel();
 
     guiLib->executeLater([this] () {
+        if (appLauncher) {
+            appLauncher->onPlaneLoad();
+        }
         auto screen = guiLib->screen();
         if (hideHeader) {
             headerApp.reset();

--- a/src/avitab/apps/App.cpp
+++ b/src/avitab/apps/App.cpp
@@ -57,6 +57,9 @@ void App::resume() {
 void App::suspend() {
 }
 
+void App::onPlaneLoad() {
+}
+
 void App::onMouseWheel(int dir, int x, int y) {
 }
 

--- a/src/avitab/apps/App.h
+++ b/src/avitab/apps/App.h
@@ -38,6 +38,7 @@ public:
     void setOnExit(ExitFunct onExitFunct);
     ContPtr getUIContainer();
     virtual void show();
+    virtual void onPlaneLoad();
     virtual void onMouseWheel(int dir, int x, int y);
     virtual void recentre();
     virtual void pan(int x, int y);

--- a/src/avitab/apps/AppLauncher.cpp
+++ b/src/avitab/apps/AppLauncher.cpp
@@ -105,6 +105,12 @@ void AppLauncher::addEntry(const std::string& name, const std::string& icon, App
     });
 }
 
+void AppLauncher::onPlaneLoad() {
+    for (auto &entry: entries) {
+        entry.app->onPlaneLoad();
+    }
+}
+
 void AppLauncher::onMouseWheel(int dir, int x, int y) {
     if (activeApp) {
         activeApp->onMouseWheel(dir, x, y);

--- a/src/avitab/apps/AppLauncher.h
+++ b/src/avitab/apps/AppLauncher.h
@@ -38,6 +38,7 @@ public:
 
     AppLauncher(FuncsPtr appFuncs);
     void onScreenResize(int width, int height) override;
+    void onPlaneLoad() override;
     void onMouseWheel(int dir, int x, int y) override;
     void recentre() override;
     void pan(int x, int y) override;

--- a/src/avitab/apps/ChartsApp.cpp
+++ b/src/avitab/apps/ChartsApp.cpp
@@ -22,8 +22,7 @@ namespace avitab {
 ChartsApp::ChartsApp(FuncsPtr appFuncs):
     DocumentsApp(appFuncs, "Charts", "chartsapp", "\\.(pdf|png|jpg|jpeg|bmp)$")
 {
-    browseStartDirectory = api().getDataPath() + "charts";
-    Run();
+    Run(api().getDataPath() + "charts");
 }
 
 } /* namespace avitab */

--- a/src/avitab/apps/DocumentsApp.cpp
+++ b/src/avitab/apps/DocumentsApp.cpp
@@ -29,11 +29,18 @@ DocumentsApp::DocumentsApp(FuncsPtr appFuncs, const std::string &title, const st
     setFilterRegex(fileRegex);
 }
 
-void DocumentsApp::Run() {
+void DocumentsApp::Run(const std::string &dir) {
     api().getSettings()->loadPdfReadingConfig(configGroup, settings);
+    browseStartDirectory = dir;
     fsBrowser.goTo(browseStartDirectory);
     overlays = std::make_shared<maps::OverlayConfig>();
     resetLayout();
+    showDirectory();
+}
+
+void DocumentsApp::ChangeBrowseDirectory(const std::string &dir) {
+    browseStartDirectory = dir;
+    fsBrowser.goTo(browseStartDirectory);
     showDirectory();
 }
 

--- a/src/avitab/apps/DocumentsApp.h
+++ b/src/avitab/apps/DocumentsApp.h
@@ -44,7 +44,9 @@ public:
     DocumentsApp(FuncsPtr appFuncs, const std::string &title, const std::string &group, const std::string &fileRegex);
     void onMouseWheel(int dir, int x, int y) override;
 protected:
-    void Run();
+    void Run(const std::string &dir);
+    void ChangeBrowseDirectory(const std::string &dir);
+private:
     std::string browseStartDirectory;
 private:
     const std::string appTitle;

--- a/src/avitab/apps/PlaneManualApp.h
+++ b/src/avitab/apps/PlaneManualApp.h
@@ -26,8 +26,8 @@ namespace avitab {
 class PlaneManualApp: public DocumentsApp {
 public:
     PlaneManualApp(FuncsPtr appFuncs);
+    void onPlaneLoad() override;
 private:
-    bool findStartDirectory(std::string &startDir);
     void ShowMessage();
     std::shared_ptr<MessageBox> errorMsg;
 };


### PR DESCRIPTION
This change fixes the bug in the Plane app, which attempts to start the file browser in a subdirectory of the aircraft directory when looking for manuals for the current aircraft.

The browse start directory was being initialised too early, before the aircraft was loaded. This is now done whenever the plane is loaded, so will work correctly if a new plane is selected during a simulation run.

(It is possible (probable?) that I broke this behaviour some long time ago when I was modifying mouse wheel and document scrolling behaviour in multi-page PDF files. I'm slightly surprised that no one has reported the issue before!)