### PR TITLE
Convert raw pointers to LoadManager into shared pointers.

### DIFF
--- a/src/libxdata/XData.cpp
+++ b/src/libxdata/XData.cpp
@@ -97,7 +97,7 @@ void XData::load() {
 }
 
 void XData::loadAirports() {
-    const AirportLoader loader(this);
+    const AirportLoader loader(shared_from_this());
 
     loadCustomScenery(loader);
 
@@ -127,22 +127,22 @@ void XData::loadCustomScenery(const AirportLoader& loader) {
 }
 
 void XData::loadFixes() {
-    FixLoader loader(this);
+    FixLoader loader(shared_from_this());
     loader.load(navDataPath + "earth_fix.dat");
 }
 
 void XData::loadNavaids() {
-    NavaidLoader loader(this);
+    NavaidLoader loader(shared_from_this());
     loader.load(navDataPath + "earth_nav.dat");
 }
 
 void XData::loadAirways() {
-    AirwayLoader loader(this);
+    AirwayLoader loader(shared_from_this());
     loader.load(navDataPath + "earth_awy.dat");
 }
 
 void XData::loadProcedures() {
-    CIFPLoader loader(this);
+    CIFPLoader loader(shared_from_this());
     xworld->forEachAirport([this, &loader] (std::shared_ptr<world::Airport> ap) {
         try {
             loader.load(ap, navDataPath + "CIFP/" + ap->getID() + ".dat");
@@ -161,7 +161,7 @@ void XData::loadMetar() {
     logger::verbose("Loading METAR...");
 
     try {
-        MetarLoader loader(this);
+        MetarLoader loader(shared_from_this());
         loader.load(xplaneRoot + "METAR.rwx");
     } catch (const std::exception &e) {
         // metar is optional, so only log

--- a/src/libxdata/loaders/AirportLoader.cpp
+++ b/src/libxdata/loaders/AirportLoader.cpp
@@ -47,7 +47,7 @@ inline world::Runway::SurfaceMaterial mapToSurfaceMaterial(AirportData::SurfaceC
     return runwaySurfaceMap[(size_t)c];
 }
 
-AirportLoader::AirportLoader(world::LoadManager *mgr):
+AirportLoader::AirportLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/AirportLoader.h
+++ b/src/libxdata/loaders/AirportLoader.h
@@ -27,10 +27,10 @@ namespace xdata {
 
 class AirportLoader {
 public:
-    AirportLoader(world::LoadManager *mgr);
+    AirportLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(const std::string &file) const;
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirportLoaded(const AirportData &port) const;

--- a/src/libxdata/loaders/AirwayLoader.cpp
+++ b/src/libxdata/loaders/AirwayLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-AirwayLoader::AirwayLoader(world::LoadManager *mgr):
+AirwayLoader::AirwayLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/AirwayLoader.h
+++ b/src/libxdata/loaders/AirwayLoader.h
@@ -27,10 +27,10 @@ namespace xdata {
 
 class AirwayLoader {
 public:
-    AirwayLoader(world::LoadManager *mgr);
+    AirwayLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onAirwayLoaded(const AirwayData &airway);

--- a/src/libxdata/loaders/CIFPLoader.cpp
+++ b/src/libxdata/loaders/CIFPLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-CIFPLoader::CIFPLoader(world::LoadManager *mgr):
+CIFPLoader::CIFPLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/CIFPLoader.h
+++ b/src/libxdata/loaders/CIFPLoader.h
@@ -28,10 +28,10 @@ namespace xdata {
 
 class CIFPLoader {
 public:
-    CIFPLoader(world::LoadManager *mgr);
+    CIFPLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(std::shared_ptr<world::Airport> airport, const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onProcedureLoaded(std::shared_ptr<world::Airport> airport, const CIFPData &procedure);

--- a/src/libxdata/loaders/FixLoader.cpp
+++ b/src/libxdata/loaders/FixLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-FixLoader::FixLoader(world::LoadManager *mgr):
+FixLoader::FixLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/FixLoader.h
+++ b/src/libxdata/loaders/FixLoader.h
@@ -27,10 +27,10 @@ namespace xdata {
 
 class FixLoader {
 public:
-    FixLoader(world::LoadManager *mgr);
+    FixLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onFixLoaded(const FixData &fix);

--- a/src/libxdata/loaders/MetarLoader.cpp
+++ b/src/libxdata/loaders/MetarLoader.cpp
@@ -21,7 +21,7 @@
 
 namespace xdata {
 
-MetarLoader::MetarLoader(world::LoadManager *mgr):
+MetarLoader::MetarLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/MetarLoader.h
+++ b/src/libxdata/loaders/MetarLoader.h
@@ -27,10 +27,10 @@ namespace xdata {
 
 class MetarLoader {
 public:
-    MetarLoader(world::LoadManager *mgr);
+    MetarLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onMetarLoaded(const MetarData &metar);

--- a/src/libxdata/loaders/NavaidLoader.cpp
+++ b/src/libxdata/loaders/NavaidLoader.cpp
@@ -22,7 +22,7 @@
 
 namespace xdata {
 
-NavaidLoader::NavaidLoader(world::LoadManager *mgr):
+NavaidLoader::NavaidLoader(std::shared_ptr<world::LoadManager> mgr):
     loadMgr(mgr), world(std::dynamic_pointer_cast<XWorld>(mgr->getWorld()))
 {
 }

--- a/src/libxdata/loaders/NavaidLoader.h
+++ b/src/libxdata/loaders/NavaidLoader.h
@@ -27,10 +27,10 @@ namespace xdata {
 
 class NavaidLoader {
 public:
-    NavaidLoader(world::LoadManager *mgr);
+    NavaidLoader(std::shared_ptr<world::LoadManager> mgr);
     void load(const std::string &file);
 private:
-    world::LoadManager * const loadMgr;
+    std::shared_ptr<world::LoadManager> const loadMgr;
     std::shared_ptr<XWorld> world;
 
     void onNavaidLoaded(const NavaidData &navaid);

--- a/src/world/LoadManager.cpp
+++ b/src/world/LoadManager.cpp
@@ -36,7 +36,7 @@ void LoadManager::setUserFixesFilename(std::string &filename) {
 
 void LoadManager::loadUserFixes(std::string &userFixesFilename) {
     try {
-        UserFixLoader loader(this);
+        UserFixLoader loader(shared_from_this());
         loader.load(userFixesFilename);
         logger::info("Loaded %s", userFixesFilename.c_str());
 

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -19,10 +19,11 @@
 #define SRC_WORLD_LOADMANAGER_H_
 
 #include "src/world/World.h"
+#include <memory>
 
 namespace world {
 
-class LoadManager {
+class LoadManager : public std::enable_shared_from_this<LoadManager> {
 public:
     virtual std::shared_ptr<World> getWorld() = 0;
 

--- a/src/world/loaders/UserFixLoader.cpp
+++ b/src/world/loaders/UserFixLoader.cpp
@@ -24,7 +24,7 @@ namespace world {
 
 constexpr const char *USER_REGION = "USER";
 
-UserFixLoader::UserFixLoader(LoadManager *mgr):
+UserFixLoader::UserFixLoader(std::shared_ptr<LoadManager> mgr):
     loadMgr(mgr), world(mgr->getWorld())
 {
     // Create a dummy region for user fixes (they are normally not region coded)

--- a/src/world/loaders/UserFixLoader.h
+++ b/src/world/loaders/UserFixLoader.h
@@ -28,10 +28,10 @@ struct UserFixData;
 
 class UserFixLoader {
 public:
-    UserFixLoader(LoadManager *mgr);
+    UserFixLoader(std::shared_ptr<LoadManager> mgr);
     void load(const std::string &file);
 private:
-    LoadManager * const loadMgr;
+    std::shared_ptr<LoadManager> const loadMgr;
     std::shared_ptr<World> world;
 
     void onUserFixLoaded(const UserFixData &navaid);


### PR DESCRIPTION
Following discussions in a separate PR, this update changes the xdata loaders to be given a shared pointer to the LoadManager, rather than the raw pointer that was previously supplied. This is mainly to fix a C++ style concern, since the loaders have a relatively short lifespan and never outlive the LoadManager.