### PR TITLE
Flight plan overlay phase 3 - procedures

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -89,10 +89,12 @@ void logger::error(const std::string format, ...) {
     va_end(args);
 }
 
+#define MAX_LOG_SIZE 1024
+
 void logger::log_info(bool enable, const char *file, const char *function, const int line, const char *format, ... ) {
     if (enable) {
-        char fileNonConst[256];
-        char message[256];
+        char fileNonConst[MAX_LOG_SIZE];
+        char message[MAX_LOG_SIZE];
         va_list ap;
         strncpy(fileNonConst, file, sizeof(fileNonConst) - 1);
         va_start(ap, format);
@@ -104,8 +106,8 @@ void logger::log_info(bool enable, const char *file, const char *function, const
 
 void logger::log_verbose(bool enable, const char *file, const char *function, const int line, const char *format, ... ) {
     if (enable) {
-        char fileNonConst[256];
-        char message[256];
+        char fileNonConst[MAX_LOG_SIZE];
+        char message[MAX_LOG_SIZE];
         va_list ap;
         strncpy(fileNonConst, file, sizeof(fileNonConst) - 1);
         va_start(ap, format);
@@ -116,8 +118,8 @@ void logger::log_verbose(bool enable, const char *file, const char *function, co
 }
 
 void logger::log_warn(const char *file, const char *function, const int line, const char *format, ... ) {
-    char fileNonConst[256];
-    char message[256];
+    char fileNonConst[MAX_LOG_SIZE];
+    char message[MAX_LOG_SIZE];
     va_list ap;
     strncpy(fileNonConst, file, sizeof(fileNonConst) - 1);
     va_start(ap, format);
@@ -127,8 +129,8 @@ void logger::log_warn(const char *file, const char *function, const int line, co
 }
 
 void logger::log_error(const char *file, const char *function, const int line, const char *format, ... ) {
-    char fileNonConst[256];
-    char message[256];
+    char fileNonConst[MAX_LOG_SIZE];
+    char message[MAX_LOG_SIZE];
     va_list ap;
     strncpy(fileNonConst, file, sizeof(fileNonConst) - 1);
     va_start(ap, format);

--- a/src/environment/standalone/StandAloneEnvironment.cpp
+++ b/src/environment/standalone/StandAloneEnvironment.cpp
@@ -46,7 +46,10 @@ std::string StandAloneEnvironment::findXPlaneInstallationPath() {
 
     std::string installFile = installFilePath + "/x-plane_install_12.txt";
     if (!platform::fileExists(installFile.c_str())) {
-        return "";
+        installFile = installFilePath + "/x-plane_install_11.txt";
+        if (!platform::fileExists(installFile.c_str())) {
+            return "";
+        }
     }
 
     fs::ifstream file(fs::u8path(installFile));

--- a/src/world/loaders/FMSLoader.h
+++ b/src/world/loaders/FMSLoader.h
@@ -36,8 +36,6 @@ private:
     void appendArrival();
     void appendDepartureAirportOrRwy();
     void appendSID();
-    void appendSIDTransition();
-    void appendSTARTransition();
     void appendSTAR();
     void appendApproach();
     void appendArrivalAirportOrRwy();
@@ -48,18 +46,11 @@ private:
     std::shared_ptr<World> world;
     std::vector<std::shared_ptr<world::NavNode>> nodes;
     std::shared_ptr<world::Airport> departureAirport, arrivalAirport;
-    std::shared_ptr<world::Runway> departureRunway;
-    std::shared_ptr<world::Runway> arrivalRwy;
+    std::shared_ptr<world::Runway> departureRunway, arrivalRwy;
     std::string cycle;
-    std::string departureAirportName;
-    std::string arrivalAirportName;
-    std::string departureRwyName;
-    std::string arrivalRwyName;
-    std::string sidName;
-    std::string sidTransName;
-    std::string starName;
-    std::string starTransName;
-    std::string approachName;
+    std::string departureAirportName, departureRwyName, sidName, sidTransName;
+    std::string arrivalAirportName, arrivalRwyName, starName, starTransName;
+    std::string approachName, approachTransName;
 
     bool seenADEPWaypoint = false;
 };

--- a/src/world/models/airport/Airport.cpp
+++ b/src/world/models/airport/Airport.cpp
@@ -255,6 +255,14 @@ std::vector<std::shared_ptr<SID>> Airport::getSIDs() const {
     return res;
 }
 
+std::shared_ptr<SID> Airport::getSIDByName(std::string sidName) const {
+    auto sid = sids.find(sidName);
+    if (sid == sids.end()) {
+        return nullptr;
+    }
+    return sid->second;
+}
+
 std::vector<std::shared_ptr<STAR>> Airport::getSTARs() const {
     std::vector<std::shared_ptr<STAR>> res;
     for (auto &it: stars) {
@@ -263,12 +271,28 @@ std::vector<std::shared_ptr<STAR>> Airport::getSTARs() const {
     return res;
 }
 
+std::shared_ptr<STAR> Airport::getSTARByName(std::string starName) const {
+    auto star = stars.find(starName);
+    if (star == stars.end()) {
+        return nullptr;
+    }
+    return star->second;
+}
+
 std::vector<std::shared_ptr<Approach>> Airport::getApproaches() const {
     std::vector<std::shared_ptr<Approach>> res;
     for (auto &it: approaches) {
         res.push_back(it.second);
     }
     return res;
+}
+
+std::shared_ptr<Approach> Airport::getApproachByName(std::string appName) const {
+    auto approach = approaches.find(appName);
+    if (approach == approaches.end()) {
+        return nullptr;
+    }
+    return approach->second;
 }
 
 const std::string& Airport::getMetarTimestamp() const {

--- a/src/world/models/airport/Airport.cpp
+++ b/src/world/models/airport/Airport.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <stdexcept>
+#include <sstream>
 #include "Airport.h"
 #include "src/world/models/navaids/Fix.h"
 #include "src/Logger.h"
@@ -256,8 +257,17 @@ std::vector<std::shared_ptr<SID>> Airport::getSIDs() const {
 }
 
 std::shared_ptr<SID> Airport::getSIDByName(std::string sidName) const {
+    if (sidName.empty()) {
+        return nullptr;
+    }
     auto sid = sids.find(sidName);
     if (sid == sids.end()) {
+        std::stringstream ss;
+        for (auto &it: sids) {
+            ss << it.first << " ";
+        }
+        logger::warn("Couldn't find SID '%s', %s SIDs are %s",
+            sidName.c_str(), getID().c_str(), ss.str().c_str());
         return nullptr;
     }
     return sid->second;
@@ -272,8 +282,17 @@ std::vector<std::shared_ptr<STAR>> Airport::getSTARs() const {
 }
 
 std::shared_ptr<STAR> Airport::getSTARByName(std::string starName) const {
+    if (starName.empty()) {
+        return nullptr;
+    }
     auto star = stars.find(starName);
     if (star == stars.end()) {
+        std::stringstream ss;
+        for (auto &it: stars) {
+            ss << it.first << " ";
+        }
+        logger::warn("Couldn't find STAR '%s', %s STARs are %s",
+            starName.c_str(), getID().c_str(), ss.str().c_str());
         return nullptr;
     }
     return star->second;
@@ -288,8 +307,17 @@ std::vector<std::shared_ptr<Approach>> Airport::getApproaches() const {
 }
 
 std::shared_ptr<Approach> Airport::getApproachByName(std::string appName) const {
+    if (appName.empty()) {
+        return nullptr;
+    }
     auto approach = approaches.find(appName);
     if (approach == approaches.end()) {
+        std::stringstream ss;
+        for (auto &it: approaches) {
+            ss << it.first << " ";
+        }
+        logger::warn("Couldn't find APP '%s', %s APPs are %s",
+            appName.c_str(), getID().c_str(), ss.str().c_str());
         return nullptr;
     }
     return approach->second;

--- a/src/world/models/airport/Airport.h
+++ b/src/world/models/airport/Airport.h
@@ -95,6 +95,9 @@ public:
     std::vector<std::shared_ptr<SID>> getSIDs() const;
     std::vector<std::shared_ptr<STAR>> getSTARs() const;
     std::vector<std::shared_ptr<Approach>> getApproaches() const;
+    std::shared_ptr<SID> getSIDByName(std::string sidName) const;
+    std::shared_ptr<STAR> getSTARByName(std::string starName) const;
+    std::shared_ptr<Approach> getApproachByName(std::string appName) const;
     std::string getInitialATCContactInfo() const;
 
     Airport(const Airport &other) = delete;

--- a/src/world/models/airport/procs/Approach.cpp
+++ b/src/world/models/airport/procs/Approach.cpp
@@ -60,42 +60,36 @@ void Approach::iterateTransitions(std::function<void(const std::string&, std::sh
             f(it.first, std::dynamic_pointer_cast<Fix>(startFix), getRunway());
         }
     }
-
-    LOG_INFO(0, "\n%s", toDebugString().c_str());
 }
 
 std::vector<std::shared_ptr<world::NavNode>> Approach::getWaypoints(std::string appTransName) const {
     if ((transitions.size() + approach.size()) == 0) {
-        LOG_INFO(1, "Approach %s has no waypoints", getID().c_str());
+        logger::warn("Approach %s has no waypoints", getID().c_str());
         return std::vector<std::shared_ptr<world::NavNode>>();
     }
 
-    LOG_INFO(1, "Approach %s from fix '%s'", getID().c_str(), appTransName.c_str());
-    LOG_INFO(1, "\n%s", toDebugString().c_str());
+    logger::info("Approach %s from fix '%s'\n%s",
+        getID().c_str(), appTransName.c_str(), toDebugString().c_str());
 
-    if (transitions.empty() || appTransName.empty()) {
-        return approach;
-    }
-
-    // Populate waypoints from requested transition then the approach waypoints
     std::vector<std::shared_ptr<NavNode>> waypoints;
-    try {
-        waypoints = transitions.at(appTransName);
-    } catch (std::out_of_range &e) {
-        LOG_WARN("Couldn't find '%s' in approach transitions", appTransName);
-    }
-    if (waypoints.back() != approach.front()) {
-        LOG_WARN("Disconnect %s -> %s", waypoints.back()->getID().c_str(), approach.front()->getID().c_str());
-    }
-    waypoints.insert(waypoints.end(), approach.begin(), approach.end());
+    if (transitions.empty() || appTransName.empty()) {
+        waypoints = approach;
+    } else {
+        // Populate waypoints from requested transition then the approach waypoints
+        try {
+            waypoints = transitions.at(appTransName);
+        } catch (std::out_of_range &e) {
+            logger::warn("Couldn't find '%s' in approach transitions", appTransName);
+        }
+        waypoints.insert(waypoints.end(), approach.begin(), approach.end());
 
-    auto newEnd = std::unique(waypoints.begin(), waypoints.end());
-    waypoints.erase(newEnd, waypoints.end());
+        auto newEnd = std::unique(waypoints.begin(), waypoints.end());
+        waypoints.erase(newEnd, waypoints.end());
+    }
 
     // Remove all waypoints after any runway as these are missed approach
     for (auto it = waypoints.begin(); it != waypoints.end(); it++) {
         if ((*it)->isRunway()) {
-            LOG_INFO(1, "%s", (*it)->getID().c_str());
             waypoints.erase(it + 1, waypoints.end());
         }
     }
@@ -104,7 +98,7 @@ std::vector<std::shared_ptr<world::NavNode>> Approach::getWaypoints(std::string 
     for (auto w: waypoints) {
         ss << w->getID() << " ";
     }
-    LOG_INFO(1, " %s", ss.str().c_str());
+    logger::info("Approach waypoints: %s", ss.str().c_str());
 
     return waypoints;
 }

--- a/src/world/models/airport/procs/Approach.h
+++ b/src/world/models/airport/procs/Approach.h
@@ -32,6 +32,7 @@ public:
     const std::shared_ptr<Fix> getStartFix() const;
     const std::shared_ptr<Runway> getRunway() const;
     void iterateTransitions(std::function<void(const std::string &, std::shared_ptr<Fix>, std::shared_ptr<Runway>)> f);
+    std::vector<std::shared_ptr<world::NavNode>> getWaypoints(std::string appTransName) const;
 
 private:
     std::map<std::string, std::vector<std::shared_ptr<NavNode>>> transitions;

--- a/src/world/models/airport/procs/SID.cpp
+++ b/src/world/models/airport/procs/SID.cpp
@@ -89,112 +89,113 @@ std::vector<std::shared_ptr<world::NavNode>> SID::getWaypoints(
         std::shared_ptr<world::Runway> departureRwy, std::string sidTransName) const {
 
     std::string runwayID = departureRwy ? departureRwy->getID() : "";
-
     if ((runwayTransitions.size() + commonRoutes.size() + enrouteTransitions.size()) == 0) {
-        LOG_INFO(1, "SID %s has no waypoints", getID().c_str());
+        logger::warn("SID %s has no waypoints", getID().c_str());
         return std::vector<std::shared_ptr<world::NavNode>>();
     }
 
-    LOG_INFO(1, "SID %s from runway '%s' to fix '%s' ", getID().c_str(),
-            runwayID.c_str(), sidTransName.c_str());
-    LOG_INFO(1, "\n%s", toDebugString().c_str());
+    logger::info("SID %s:\n%s", getID().c_str(), toDebugString().c_str());
+    logger::info("Want from runway '%s' to fix '%s'", runwayID.c_str(), sidTransName.c_str());
 
-    std::map<std::shared_ptr<Runway>, std::vector<std::shared_ptr<NavNode>>> r;
-    std::map<std::shared_ptr<NavNode>, std::vector<std::shared_ptr<NavNode>>> c;
-    std::vector<std::vector<std::shared_ptr<NavNode>>> e;
-
-
-    std::shared_ptr<Runway> empty = std::make_shared<Runway>("EMPTY");
-    if (runwayTransitions.size() >= 1) {
-        r = runwayTransitions;
+    /* We're going to run a 3 tier (runway, common, enroute) nested loop through
+     * all permutations of a full SID route. So transform the structures into vector<vector>
+     * ensuring that all outer vectors have at least an empty vector inside so as to give the
+     * appropriate loop a once through. If the map key NavNode is not in the vector<NavNcde>
+     * then add it.
+     */
+    std::vector<std::vector<std::shared_ptr<NavNode>>> rr;
+    std::vector<std::vector<std::shared_ptr<NavNode>>> cc;
+    std::vector<std::vector<std::shared_ptr<NavNode>>> ee;
+    std::vector<std::shared_ptr<NavNode>> empty;
+    if (runwayTransitions.size() > 0) {
+        for (auto it: runwayTransitions) {
+            auto w = it.second;
+            if (std::find(w.begin(), w.end(), it.first) == w.end()) {
+                w.insert(w.begin(), it.first);
+            }
+            rr.push_back(w);
+        }
     } else {
-        r[empty] = std::vector<std::shared_ptr<NavNode>>();
+        rr.push_back(empty);
     }
-    if (commonRoutes.size() >= 1) {
-        c = commonRoutes;
+    if (commonRoutes.size() > 0) {
+        for (auto it: commonRoutes) {
+            auto w = it.second;
+            if (std::find(w.begin(), w.end(), it.first) == w.end()) {
+                w.insert(w.begin(), it.first);
+            }
+            cc.push_back(w);
+        }
     } else {
-        c[empty] = std::vector<std::shared_ptr<NavNode>>();
+        cc.push_back(empty);
     }
-    if (enrouteTransitions.size() >= 1) {
-        e = enrouteTransitions;
+    if (enrouteTransitions.size() > 0) {
+        ee = enrouteTransitions;
     } else {
-        std::vector<std::shared_ptr<NavNode>> emptyList;
-        emptyList.push_back(empty);
-        e.push_back(emptyList);
+        ee.push_back(empty);
     }
 
+    /* 3 tier loop through all permutations of (runway, common, enroute)
+     * Check if a permutation meets the constraints of runway and enroute that may or may
+     * not have been specified in the flight plan.
+     * Maintain a list of common waypoints in each of the successive validated permutations.
+     * This will often end up the same as one of the entries in the commonRoutes map.
+     * But sometimes there may be a common route even if there are no entries in the commonRoute map.
+     * And sometimes the common route returned can be larger than an entry in the commonRoute map.
+     */
     std::vector<std::vector<std::shared_ptr<NavNode>>> routePermutations;
-    std::vector<std::shared_ptr<NavNode>> common;
-    LOG_INFO(1, "Possible routes are:");
-    for (auto rr: r) {
-        for (auto cc: c) {
-            for (auto ee: e) {
+    std::vector<std::shared_ptr<NavNode>> repeatedWaypoints;
+    logger::info("Possible routes are:");
+    for (auto r: rr) {
+        for (auto c: cc) {
+            for (auto e: ee) {
                 std::vector<std::shared_ptr<NavNode>> waypoints;
-                std::shared_ptr<NavNode> lastNode = nullptr;
-                if (runwayTransitions.size() > 0) {
-                    waypoints.push_back(rr.first);
-                    for (auto node: rr.second) {
-                        waypoints.push_back(node);
-                        lastNode = node;
-                    }
-                }
-                if (commonRoutes.size() > 0) {
-                    if (lastNode) {
-                        if (lastNode != cc.first) {
-                            LOG_WARN("Disconnect %s -> %s", lastNode->getID().c_str(), cc.first->getID().c_str());
-                        }
-                    }
-                    waypoints.push_back(cc.first);
-                    for (auto node: cc.second) {
-                        waypoints.push_back(node);
-                        lastNode = node;
-                    }
-                }
-                if (enrouteTransitions.size() > 0) {
-                    if (lastNode) {
-                        if (lastNode != ee.front()) {
-                            LOG_WARN("Disconnect %s -> %s", lastNode->getID().c_str(), ee.front()->getID().c_str());
-                        }
-                    }
-                    waypoints.insert(waypoints.end(), ee.begin(), ee.end());
-                }
-
+                waypoints.insert(waypoints.end(), r.begin(), r.end());
+                waypoints.insert(waypoints.end(), c.begin(), c.end());
+                waypoints.insert(waypoints.end(), e.begin(), e.end());
                 auto newEnd = std::unique(waypoints.begin(), waypoints.end());
                 waypoints.erase(newEnd, waypoints.end());
+
+                if (!waypoints.empty() && waypoints.front()->isRunway() &&
+                    departureRwy && (waypoints.front() != departureRwy)) {
+                    // Specified departure runway doesn't match - unsuitable
+                    continue;
+                }
+                if (!waypoints.empty() && !sidTransName.empty() && (waypoints.back()->getID() != sidTransName)) {
+                    // Specified transition doesn't match - unsuitable
+                    continue;
+                }
+                if (repeatedWaypoints.empty()) {
+                    // Initialise
+                    repeatedWaypoints = waypoints;
+                } else {
+                    // Filter the list of repeated waypoints using new valid permutation
+                    auto iter = std::remove_if(std::begin(repeatedWaypoints), std::end(repeatedWaypoints), [&waypoints] (const auto &a) -> bool {
+                        return (find(waypoints.begin(), waypoints.end(), a) == waypoints.end());
+                    });
+                    repeatedWaypoints.erase(iter, std::end(repeatedWaypoints));
+                }
+                routePermutations.push_back(waypoints);
+
                 std::stringstream ss;
                 for (auto w: waypoints) {
                     ss << w->getID() << " ";
                 }
-                if (departureRwy && waypoints[0]->isRunway() && (waypoints[0] != departureRwy)) {
-                    continue;
-                }
-                if (!sidTransName.empty() && (waypoints.back()->getID() != sidTransName)) {
-                    continue;
-                }
-                if (common.empty()) {
-                    common = waypoints;
-                } else {
-                    auto iter = std::remove_if(std::begin(common), std::end(common), [&waypoints] (const auto &a) -> bool {
-                        return (find(waypoints.begin(), waypoints.end(), a) == waypoints.end());
-                    });
-                    common.erase(iter, std::end(common));
-                }
-                routePermutations.push_back(waypoints);
-                LOG_INFO(1, " %s", ss.str().c_str());
+                logger::info(" %s", ss.str().c_str());
             }
         }
     }
 
     switch(routePermutations.size()) {
-    case 0:  LOG_INFO(1, "No waypoints found");
+    case 0:  logger::warn("No waypoints found");
              return std::vector<std::shared_ptr<world::NavNode>>();
-    case 1:  return routePermutations[0];
+    case 1:  return routePermutations.front();
     default: std::stringstream ss;
-             for (auto w: common) {
+             for (auto w: repeatedWaypoints) {
                  ss << w->getID() << " ";
              }
-             LOG_INFO(1, "Using common waypoints: %s", ss.str().c_str());
-             return common;
+             logger::info("Using common waypoints: %s", ss.str().c_str());
+             return repeatedWaypoints;
     }
 }
 

--- a/src/world/models/airport/procs/SID.h
+++ b/src/world/models/airport/procs/SID.h
@@ -26,6 +26,8 @@ class SID: public Procedure {
 public:
     SID(const std::string &id);
     void iterate(std::function<void(std::shared_ptr<Runway>, std::shared_ptr<Fix>)> f) const;
+    std::vector<std::shared_ptr<world::NavNode>> getWaypoints(
+            std::shared_ptr<world::Runway> departureRwy, std::string sidTransName) const;
 };
 
 } /* namespace world */

--- a/src/world/models/airport/procs/STAR.cpp
+++ b/src/world/models/airport/procs/STAR.cpp
@@ -95,109 +95,112 @@ std::vector<std::shared_ptr<world::NavNode>> STAR::getWaypoints(
     std::string runwayID = arrivalRwy ? arrivalRwy->getID() : "";
 
     if ((runwayTransitions.size() + commonRoutes.size() + enrouteTransitions.size()) == 0) {
-        LOG_INFO(1, "STAR %s has no waypoints", getID().c_str());
+        logger::warn("STAR %s has no waypoints", getID().c_str());
         return std::vector<std::shared_ptr<world::NavNode>>();
     }
 
-    LOG_INFO(1, "STAR %s from fix '%s' to runway '%s'", getID().c_str(),
-            starTransName.c_str(), runwayID.c_str());
-    LOG_INFO(1, "\n%s", toDebugString().c_str());
+    logger::info("STAR %s:\n%s", getID().c_str(), toDebugString().c_str());
+    logger::info("Want from fix '%s' to runway '%s'", starTransName.c_str(), runwayID.c_str());
 
-    std::map<std::shared_ptr<Runway>, std::vector<std::shared_ptr<NavNode>>> r;
-    std::map<std::shared_ptr<NavNode>, std::vector<std::shared_ptr<NavNode>>> c;
-    std::vector<std::vector<std::shared_ptr<NavNode>>> e;
+    /* We're going to run a 3 tier (enroute, common, runway) nested loop through
+     * all permutations of a full STAR route. So transform the structures into vector<vector>
+     * ensuring that all outer vectors have at least an empty vector inside so as to give the
+     * appropriate loop a once through. If the map key NavNode is not in the vector<NavNcde>
+     * then add it.
+     */
+    std::vector<std::vector<std::shared_ptr<NavNode>>> ee;
+    std::vector<std::vector<std::shared_ptr<NavNode>>> cc;
+    std::vector<std::vector<std::shared_ptr<NavNode>>> rr;
+    std::vector<std::shared_ptr<NavNode>> empty;
+    if (enrouteTransitions.size() > 0) {
+        ee = enrouteTransitions;
+    } else {
+        ee.push_back(empty);
+    }
+    if (commonRoutes.size() > 0) {
+        for (auto it: commonRoutes) {
+            auto w = it.second;
+            if (std::find(w.begin(), w.end(), it.first) == w.end()) {
+                w.push_back(it.first);
+            }
+            cc.push_back(w);
+        }
+    } else {
+        cc.push_back(empty);
+    }
+    if (runwayTransitions.size() > 0) {
+        for (auto it: runwayTransitions) {
+            auto w = it.second;
+            if (std::find(w.begin(), w.end(), it.first) == w.end()) {
+                // Put runway at end of list
+                w.push_back(it.first);
+            }
+            rr.push_back(w);
+        }
+    } else {
+        rr.push_back(empty);
+    }
 
-    std::shared_ptr<Runway> empty = std::make_shared<Runway>("EMPTY");
-    if (runwayTransitions.size() >= 1) {
-        r = runwayTransitions;
-    } else {
-        r[empty] = std::vector<std::shared_ptr<NavNode>>();
-    }
-    if (commonRoutes.size() >= 1) {
-        c = commonRoutes;
-    } else {
-        c[empty] = std::vector<std::shared_ptr<NavNode>>();
-    }
-    if (enrouteTransitions.size() >= 1) {
-        e = enrouteTransitions;
-    } else {
-        std::vector<std::shared_ptr<NavNode>> emptyList;
-        emptyList.push_back(empty);
-        e.push_back(emptyList);
-    }
-
+    /* 3 tier loop through all permutations of (common, enroute, runway)
+     * Check if a permutation meets the constraints of enroute and runway that may or may
+     * not have been specified in the flight plan.
+     * Maintain a list of common waypoints in each of the successive validated permutations.
+     * This will often end up the same as one of the entries in the commonRoutes map.
+     * But sometimes there may be a common route even if there are no entries in the commonRoute map.
+     * And sometimes the common route returned can be larger than an entry in the commonRoute map.
+     */
     std::vector<std::vector<std::shared_ptr<NavNode>>> routePermutations;
-    std::vector<std::shared_ptr<NavNode>> common;
-    LOG_INFO(1, "Possible routes are:");
-    for (auto cc: c) {
-        for (auto ee: e) {
-            for (auto rr: r) {
+    std::vector<std::shared_ptr<NavNode>> repeatedWaypoints;
+    logger::info("Possible routes are:");
+    for (auto c: cc) {
+        for (auto e: ee) {
+            for (auto r: rr) {
                 std::vector<std::shared_ptr<NavNode>> waypoints;
-                std::shared_ptr<NavNode> lastNode = nullptr;
-                if (enrouteTransitions.size() > 0) {
-                    waypoints.insert(waypoints.end(), ee.begin(), ee.end());
-                    lastNode = waypoints.back();
-                }
-                if (commonRoutes.size() > 0) {
-                    if (lastNode) {
-                        if (lastNode != cc.first) {
-                            LOG_WARN("Disconnect %s -> %s", lastNode->getID().c_str(), cc.first->getID().c_str());
-                        }
-                    }
-                    waypoints.push_back(cc.first);
-                    for (auto node: cc.second) {
-                        waypoints.push_back(node);
-                        lastNode = node;
-                    }
-                }
-                if (runwayTransitions.size() > 0) {
-                    if (lastNode) {
-                        if (lastNode != rr.second.front()) {
-                            LOG_WARN("Disconnect %s -> %s", lastNode->getID().c_str(), rr.second.front()->getID().c_str());
-                        }
-                    }
-                    for (auto node: rr.second) {
-                        waypoints.push_back(node);
-                    }
-                    waypoints.push_back(rr.first);
-                }
-
+                waypoints.insert(waypoints.end(), e.begin(), e.end());
+                waypoints.insert(waypoints.end(), c.begin(), c.end());
+                waypoints.insert(waypoints.end(), r.begin(), r.end());
                 auto newEnd = std::unique(waypoints.begin(), waypoints.end());
                 waypoints.erase(newEnd, waypoints.end());
+
+                if (!waypoints.empty() && !starTransName.empty() && (waypoints.front()->getID() != starTransName)) {
+                    // Specified transition doesn't match - unsuitable
+                    continue;
+                }
+                if (!waypoints.empty() && waypoints.back()->isRunway() && arrivalRwy && (waypoints.back() != arrivalRwy)) {
+                    // Specified arrival runway doesn't match - unsuitable
+                    continue;
+                }
+                if (repeatedWaypoints.empty()) {
+                    // Initialise
+                    repeatedWaypoints = waypoints;
+                } else {
+                    // Filter the list of repeated waypoints using new valid permutation
+                    auto iter = std::remove_if(std::begin(repeatedWaypoints), std::end(repeatedWaypoints), [&waypoints] (const auto &a) -> bool {
+                        return (find(waypoints.begin(), waypoints.end(), a) == waypoints.end());
+                    });
+                    repeatedWaypoints.erase(iter, std::end(repeatedWaypoints));
+                }
+                routePermutations.push_back(waypoints);
+
                 std::stringstream ss;
                 for (auto w: waypoints) {
                     ss << w->getID() << " ";
                 }
-                if (!starTransName.empty() && (waypoints.front()->getID() != starTransName)) {
-                    continue;
-                }
-                if (arrivalRwy && waypoints.back()->isRunway() && (waypoints.back() != arrivalRwy)) {
-                    continue;
-                }
-                if (common.empty()) {
-                    common = waypoints;
-                } else {
-                    auto iter = std::remove_if(std::begin(common), std::end(common), [&waypoints] (const auto &a) -> bool {
-                        return (find(waypoints.begin(), waypoints.end(), a) == waypoints.end());
-                    });
-                    common.erase(iter, std::end(common));
-                }
-                routePermutations.push_back(waypoints);
-                LOG_INFO(1, " %s", ss.str().c_str());
+                logger::info(" %s", ss.str().c_str());
             }
         }
     }
 
     switch(routePermutations.size()) {
-    case 0:  LOG_INFO(1, "No waypoints found");
+    case 0:  logger::warn("No waypoints found");
              return std::vector<std::shared_ptr<world::NavNode>>();
-    case 1:  return routePermutations[0];
+    case 1:  return routePermutations.front();
     default: std::stringstream ss;
-             for (auto w: common) {
+             for (auto w: repeatedWaypoints) {
                  ss << w->getID() << " ";
              }
-             LOG_INFO(1, "Using common waypoints: %s", ss.str().c_str());
-             return common;
+             logger::info("Using common waypoints: %s", ss.str().c_str());
+             return repeatedWaypoints;
     }
 
     return std::vector<std::shared_ptr<world::NavNode>>();

--- a/src/world/models/airport/procs/STAR.h
+++ b/src/world/models/airport/procs/STAR.h
@@ -26,6 +26,8 @@ class STAR: public Procedure {
 public:
     STAR(const std::string &id);
     void iterate(std::function<void(std::shared_ptr<Runway>, std::shared_ptr<Fix>, std::shared_ptr<NavNode>)> f) const;
+    std::vector<std::shared_ptr<world::NavNode>> getWaypoints(
+            std::shared_ptr<world::Runway> arrivayRwy, std::string starTransName) const;
 };
 
 } /* namespace world */

--- a/src/world/parsers/FMSParser.cpp
+++ b/src/world/parsers/FMSParser.cpp
@@ -97,6 +97,8 @@ void FMSParser::parseIntroBlocks() {
             node.type = FlightPlanNodeData::Type::SIDTRANS;
         } else if (prefix == "APP") {
             node.type = FlightPlanNodeData::Type::APP;
+        } else if (prefix == "APPTRANS") {
+            node.type = FlightPlanNodeData::Type::APPTRANS;
         } else if (prefix == "ADES") {
             node.type = FlightPlanNodeData::Type::ADES;
         } else if (prefix == "DESRWY") {

--- a/src/world/parsers/objects/FlightPlanNodeData.h
+++ b/src/world/parsers/objects/FlightPlanNodeData.h
@@ -41,7 +41,8 @@ struct FlightPlanNodeData {
         DESRWY,
         STAR,
         STARTRANS,
-        APP
+        APP,
+        APPTRANS
     };
 
     Type type;


### PR DESCRIPTION
This adds functionality to decompose into waypoints any SIDs, STARs and Approaches named in the FMS.
The waypoints for procedures are not present in the FMS - just the name, so the NavData database is queried to get them.

Note that
- A SID/STAR can have 0, 1 or more entries in each of the runwayTransitions, commonRoutes and enrouteTransitions structures and the commonRoutes entries may be associated with runways too.
- If a SID/STAR is specified in the FMS, associated runway and transitions are optional, and should be treated as don't care. If they are omitted, then Avitab should determine a common set of waypoints. This may be the same as a commonRoute from the database, particularly for the USA. But not always.

As a result of the above, code to attempt to linearly trace through waypoints (similar to the iterate method) was perceived as becoming an unreadable, bug-prone mess of multidimensional if/then statements. So the approach (no pun intended) here is to loop through all possible permutations of concatenated segments and check whether the permutation meets the constraints of the (possibly don't care) runway and transition in the FMS. This provides a more complete version of common waypoints and the code has a much cleaner flow.
