### PR TITLE
Fix compile errors on Windows MinGW

### DIFF
--- a/src/libxdata/models/airports/procs/XApproach.h
+++ b/src/libxdata/models/airports/procs/XApproach.h
@@ -20,6 +20,7 @@
 #include "src/world/models/airport/procs/Approach.h"
 #include "ProcedureOptions.h"
 #include <string>
+#include <functional>
 
 namespace xdata {
 

--- a/src/libxdata/models/airports/procs/XSID.h
+++ b/src/libxdata/models/airports/procs/XSID.h
@@ -21,6 +21,7 @@
 #include "ProcedureOptions.h"
 #include "src/world/models/navaids/Fix.h"
 #include <string>
+#include <functional>
 
 namespace xdata {
 

--- a/src/libxdata/models/airports/procs/XSTAR.h
+++ b/src/libxdata/models/airports/procs/XSTAR.h
@@ -21,6 +21,7 @@
 #include "ProcedureOptions.h"
 #include "src/world/models/navaids/Fix.h"
 #include <string>
+#include <functional>
 
 namespace xdata {
 

--- a/src/world/LoadManager.h
+++ b/src/world/LoadManager.h
@@ -20,6 +20,7 @@
 
 #include "src/world/World.h"
 #include <memory>
+#include <atomic>
 
 namespace world {
 

--- a/src/world/routing/Route.h
+++ b/src/world/routing/Route.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <functional>
+#include <cmath>
 #include "../World.h"
 
 namespace world {


### PR DESCRIPTION
These missing headers were not detected when developing with Mac Xcode, and I did not test the recent PR on my Windows development machine. Apologies for this. This PR resolves the issue, and should ensure clean build on all platforms!