### PR TITLE
Update nlohmann/json submodule to v3.11.3.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-conversion -fPIC")
-if (APPLE)
-# This should be considered as a temporary fix until resolved in the nlohmann/json submodule
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-endif()
 
 add_library(avitab_common "${CMAKE_CURRENT_LIST_DIR}/Logger.cpp")
 add_library(avitab_xplane "")


### PR DESCRIPTION
This update to the json library resolves some deprecation warnings that were treated as errors in the Apple clang build, and had been worked-around with a temporary setting in the CMake configuration.

Merging this change will require 'git submodule update' and then a forced rebuild of the 3rd party dependencies (or a removal of build-third/include/nlohmann followed by an incremental build).

This PR addresses https://github.com/fpw/avitab/issues/181 which can now be closed.