### PR TITLE
Implement datarefs to report map coordinates, zoom and range

### DIFF
--- a/src/avitab/AviTab.cpp
+++ b/src/avitab/AviTab.cpp
@@ -421,6 +421,10 @@ std::shared_ptr<world::RouteFinder> AviTab::getRouteFinder() {
     return getNavWorld()->getRouteFinder();
 }
 
+void AviTab::updateMapExports(float lat, float lon, int zoom, float vrange) {
+    env->updateMapExports(lat, lon, zoom, vrange);
+}
+
 AircraftID AviTab::getActiveAircraftCount() {
     return env->getActiveAircraftCount();
 }

--- a/src/avitab/AviTab.h
+++ b/src/avitab/AviTab.h
@@ -75,6 +75,7 @@ public:
     std::shared_ptr<world::Route> getRoute() override;
     void setRoute(std::shared_ptr<world::Route> route) override;
     std::shared_ptr<world::RouteFinder> getRouteFinder() override;
+    void updateMapExports(float lat, float lon, int zoom, float vrange) override;
 
     ~AviTab();
 

--- a/src/avitab/apps/AppFunctions.h
+++ b/src/avitab/apps/AppFunctions.h
@@ -67,6 +67,7 @@ public:
     virtual void setRoute(std::shared_ptr<world::Route> route) = 0;
     virtual std::shared_ptr<world::Route> getRoute() = 0;
     virtual std::shared_ptr<world::RouteFinder> getRouteFinder() = 0;
+    virtual void updateMapExports(float lat, float lon, int zoom, float vrange) = 0;
     virtual ~AppFunctions() = default;
 };
 

--- a/src/avitab/apps/MapApp.cpp
+++ b/src/avitab/apps/MapApp.cpp
@@ -915,6 +915,10 @@ bool MapApp::onTimer() {
 
     map->doWork();
 
+    double lat, lon;
+    map->getCenterLocation(lat, lon);
+    api().updateMapExports(lat, lon, map->getZoomLevel(), map->getVerticalRange());
+
     return true;
 }
 

--- a/src/environment/Environment.cpp
+++ b/src/environment/Environment.cpp
@@ -72,9 +72,7 @@ void Environment::setLastFrameTime(float t) {
     lastFrameTime = t;
 }
 
-float Environment::getLastFrameTime() {
-    return lastFrameTime;
-}
+float Environment::getLastFrameTime() { return lastFrameTime; }
 
 void Environment::reloadMetar() {
     worldManager->reloadMetar();

--- a/src/environment/Environment.h
+++ b/src/environment/Environment.h
@@ -96,6 +96,7 @@ public:
     virtual void setIsInMenu(bool menu);
     virtual AircraftID getActiveAircraftCount() = 0;
     virtual Location getAircraftLocation(AircraftID id) = 0;
+    virtual void updateMapExports(float lat, float lon, int zoom, float vrange) { /* default is no operation */ }
     float getLastFrameTime();
 
     virtual ~Environment() = default;

--- a/src/environment/xplane/CMakeLists.txt
+++ b/src/environment/xplane/CMakeLists.txt
@@ -1,7 +1,8 @@
 target_sources(avitab_xplane PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/XPlaneEnvironment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/XPlaneGUIDriver.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/DataRef.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/DataRefImport.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/DataRefExport.cpp
     ${CMAKE_CURRENT_LIST_DIR}/DataCache.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MonitorBoundsDecider.cpp
 )

--- a/src/environment/xplane/DataRefExport.cpp
+++ b/src/environment/xplane/DataRefExport.cpp
@@ -57,6 +57,19 @@ DataRefExport<float>::DataRefExport(const std::string &name, void *ref, std::fun
     );
 }
 
+template <>
+DataRefExport<float>::DataRefExport(const std::string &name, void *ref, std::function<float(void *)> onRd)
+:   ownerRef(ref), onRead(onRd), onWrite(nullptr)
+{
+    xpDataRef = XPLMRegisterDataAccessor(name.c_str(), xplmType_Float, false,
+        nullptr, nullptr,
+        [] (void *r) { auto self = reinterpret_cast<DataRefExport<float> *>(r); return self->onRead(self->ownerRef); },
+        nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        this, nullptr
+    );
+}
+
 template <typename T>
 DataRefExport<T>::~DataRefExport()
 {

--- a/src/environment/xplane/DataRefExport.cpp
+++ b/src/environment/xplane/DataRefExport.cpp
@@ -1,0 +1,70 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2024 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DataRefExport.h"
+
+namespace avitab {
+
+template <>
+DataRefExport<int>::DataRefExport(const std::string &name, void *ref, std::function<int(void *)> onRd, std::function<void(void *, int)> onWr)
+:   ownerRef(ref), onRead(onRd), onWrite(onWr)
+{
+    xpDataRef = XPLMRegisterDataAccessor(name.c_str(), xplmType_Int, true,
+        [] (void *r) { auto self = reinterpret_cast<DataRefExport<int> *>(r); return self->onRead(self->ownerRef); },
+        [] (void *r, int v) { auto self = reinterpret_cast<DataRefExport<int> *>(r); self->onWrite(self->ownerRef, v); },
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        this, this
+    );
+}
+
+template <>
+DataRefExport<int>::DataRefExport(const std::string &name, void *ref, std::function<int(void *)> onRd)
+:   ownerRef(ref), onRead(onRd), onWrite(nullptr)
+{
+    xpDataRef = XPLMRegisterDataAccessor(name.c_str(), xplmType_Int, false,
+        [] (void *r) { auto self = reinterpret_cast<DataRefExport<int> *>(r); return self->onRead(self->ownerRef); },
+        nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        this, nullptr
+    );
+}
+
+template <>
+DataRefExport<float>::DataRefExport(const std::string &name, void *ref, std::function<float(void *)> onRd, std::function<void(void *, float)> onWr)
+:   ownerRef(ref), onRead(onRd), onWrite(onWr)
+{
+    xpDataRef = XPLMRegisterDataAccessor(name.c_str(), xplmType_Float, true,
+        nullptr, nullptr,
+        [] (void *r) { auto self = reinterpret_cast<DataRefExport<float> *>(r); return self->onRead(self->ownerRef); },
+        [] (void *r, float v) { auto self = reinterpret_cast<DataRefExport<float> *>(r); self->onWrite(self->ownerRef, v); },
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        this, this
+    );
+}
+
+template <typename T>
+DataRefExport<T>::~DataRefExport()
+{
+    XPLMUnregisterDataAccessor(xpDataRef);
+}
+
+
+template class DataRefExport<int>;
+template class DataRefExport<float>;
+
+}

--- a/src/environment/xplane/DataRefExport.h
+++ b/src/environment/xplane/DataRefExport.h
@@ -1,0 +1,42 @@
+/*
+ *   AviTab - Aviator's Virtual Tablet
+ *   Copyright (C) 2018-2024 Folke Will <folko@solhost.org>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <XPLM/XPLMDataAccess.h>
+#include <string>
+#include <functional>
+
+namespace avitab {
+
+template<typename T>
+class DataRefExport final {
+public:
+    DataRefExport(const std::string& name, void *owner, std::function<T(void *)>);
+    DataRefExport(const std::string& name, void *owner, std::function<T(void *)>, std::function<void(void *, T)>);
+
+    ~DataRefExport();
+
+private:
+    void *                          ownerRef;
+    std::function<T(void *)>        onRead;
+    std::function<void(void *, T)>  onWrite;
+    XPLMDataRef                     xpDataRef;
+
+};
+
+} // namespace avitab

--- a/src/environment/xplane/DataRefImport.cpp
+++ b/src/environment/xplane/DataRefImport.cpp
@@ -16,13 +16,13 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdexcept>
-#include "DataRef.h"
+#include "DataRefImport.h"
 #include "src/Logger.h"
 
 namespace avitab {
 
 template<typename T>
-DataRef<T>::DataRef(const std::string& name) {
+DataRefImport<T>::DataRefImport(const std::string& name) {
     handle = XPLMFindDataRef(name.c_str());
     if (!handle) {
         throw std::runtime_error("Invalid DataRef: " + name);
@@ -30,7 +30,7 @@ DataRef<T>::DataRef(const std::string& name) {
 }
 
 template<typename T>
-DataRef<T>::DataRef(const std::string& name, T defaultValue) {
+DataRefImport<T>::DataRefImport(const std::string& name, T defaultValue) {
     handle = XPLMFindDataRef(name.c_str());
     if (!handle) {
         logger::warn("DataRef '%s' not available, using defaults");
@@ -39,7 +39,7 @@ DataRef<T>::DataRef(const std::string& name, T defaultValue) {
 }
 
 template<>
-DataRef<int>::operator int() {
+DataRefImport<int>::operator int() {
     if (handle) {
         return XPLMGetDatai(handle);
     } else {
@@ -48,7 +48,7 @@ DataRef<int>::operator int() {
 }
 
 template<>
-DataRef<bool>::operator bool() {
+DataRefImport<bool>::operator bool() {
     if (handle) {
         return XPLMGetDatai(handle) != 0;
     } else {
@@ -57,7 +57,7 @@ DataRef<bool>::operator bool() {
 }
 
 template<>
-DataRef<float>::operator float() {
+DataRefImport<float>::operator float() {
     if (handle) {
         return XPLMGetDataf(handle);
     } else {
@@ -65,8 +65,8 @@ DataRef<float>::operator float() {
     }
 }
 
-template class DataRef<int>;
-template class DataRef<bool>;
-template class DataRef<float>;
+template class DataRefImport<int>;
+template class DataRefImport<bool>;
+template class DataRefImport<float>;
 
 }

--- a/src/environment/xplane/DataRefImport.h
+++ b/src/environment/xplane/DataRefImport.h
@@ -1,6 +1,6 @@
 /*
  *   AviTab - Aviator's Virtual Tablet
- *   Copyright (C) 2018 Folke Will <folko@solhost.org>
+ *   Copyright (C) 2018-2024 Folke Will <folko@solhost.org>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Affero General Public License as published by
@@ -15,8 +15,7 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef SRC_ENVIRONMENT_XPLANE_DATAREF_H_
-#define SRC_ENVIRONMENT_XPLANE_DATAREF_H_
+#pragma once
 
 #include <XPLM/XPLMDataAccess.h>
 #include <string>
@@ -24,10 +23,10 @@
 namespace avitab {
 
 template<typename T>
-class DataRef final {
+class DataRefImport final {
 public:
-    DataRef(const std::string& name);
-    DataRef(const std::string& name, T defaultValue);
+    DataRefImport(const std::string& name);
+    DataRefImport(const std::string& name, T defaultValue);
 
     operator T();
 private:
@@ -36,5 +35,3 @@ private:
 };
 
 }
-
-#endif /* SRC_ENVIRONMENT_XPLANE_DATAREF_H_ */

--- a/src/environment/xplane/XPlaneEnvironment.cpp
+++ b/src/environment/xplane/XPlaneEnvironment.cpp
@@ -72,6 +72,18 @@ XPlaneEnvironment::XPlaneEnvironment() {
     isInMenuRef = std::make_unique<DataRefExport<int>>("avitab/is_in_menu", this,
         [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->isInMenu; });
 
+    mapLatitudeRef = std::make_unique<DataRefExport<float>>("avitab/map/latitude", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->getMapLatitude(); });
+
+    mapLongitudeRef = std::make_unique<DataRefExport<float>>("avitab/map/longitude", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->getMapLongitude(); });
+
+    mapZoomRef = std::make_unique<DataRefExport<int>>("avitab/map/zoom", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->getMapZoom(); });
+
+    mapVerticalRangeRef = std::make_unique<DataRefExport<float>>("avitab/map/vertical_range", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->getMapVerticalRange(); });
+
     XPLMScheduleFlightLoop(flightLoopId, -1, true);
 }
 
@@ -363,6 +375,34 @@ XPlaneEnvironment::~XPlaneEnvironment() {
 
     destroyMenu();
     logger::verbose("~XPlaneEnvironment");
+}
+
+void XPlaneEnvironment::updateMapExports(float lat, float lon, int zoom, float vrange) {
+    std::lock_guard<std::mutex> lock(stateMutex);
+    mapLatitude = lat;
+    mapLongitude = lon;
+    mapZoom = zoom;
+    mapVerticalRange = vrange;
+}
+
+float XPlaneEnvironment::getMapLatitude() {
+    std::lock_guard<std::mutex> lock(stateMutex);
+    return mapLatitude;
+}
+
+float XPlaneEnvironment::getMapLongitude() {
+    std::lock_guard<std::mutex> lock(stateMutex);
+    return mapLongitude;
+}
+
+int XPlaneEnvironment::getMapZoom() {
+    std::lock_guard<std::mutex> lock(stateMutex);
+    return mapZoom;
+}
+
+float XPlaneEnvironment::getMapVerticalRange() {
+    std::lock_guard<std::mutex> lock(stateMutex);
+    return mapVerticalRange;
 }
 
 void XPlaneEnvironment::reloadAircraftPath() {

--- a/src/environment/xplane/XPlaneEnvironment.cpp
+++ b/src/environment/xplane/XPlaneEnvironment.cpp
@@ -57,70 +57,20 @@ XPlaneEnvironment::XPlaneEnvironment() {
 
     reloadAircraftPath();
 
-    panelEnabledRef = XPLMRegisterDataAccessor("avitab/panel_enabled", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                return *(us->panelEnabled);
-            },
-            [] (void *ref, int newVal) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                *(us->panelEnabled) = newVal;
-            },
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            this, this
-            );
+    panelEnabledRef = std::make_unique<DataRefExport<int>>("avitab/panel_enabled", this,
+        [] (void *self) { return *((reinterpret_cast<XPlaneEnvironment *>(self))->panelEnabled); },
+        [] (void *self, int v) { *((reinterpret_cast<XPlaneEnvironment *>(self))->panelEnabled) = v; });
 
-    panelPoweredRef = XPLMRegisterDataAccessor("avitab/panel_powered", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                return *(us->panelPowered);
-            },
-            [] (void *ref, int newVal) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                *(us->panelPowered) = newVal;
-            },
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            this, this
-            );
+    panelPoweredRef = std::make_unique<DataRefExport<int>>("avitab/panel_powered", this,
+        [] (void *self) { return *((reinterpret_cast<XPlaneEnvironment *>(self))->panelPowered); },
+        [] (void *self, int v) { *((reinterpret_cast<XPlaneEnvironment *>(self))->panelPowered) = v; });
 
-    brightnessRef = XPLMRegisterDataAccessor("avitab/brightness", xplmType_Float, true,
-            nullptr, nullptr,
-            [] (void *ref) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                return *(us->brightness);
-            },
-            [] (void *ref, float newVal) {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                *(us->brightness) = newVal;
-            },
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            this, this
-            );
+    brightnessRef = std::make_unique<DataRefExport<float>>("avitab/brightness", this,
+        [] (void *self) { return *((reinterpret_cast<XPlaneEnvironment *>(self))->brightness); },
+        [] (void *self, float v) { *((reinterpret_cast<XPlaneEnvironment *>(self))->brightness) = v; });
 
-    isInMenuRef = XPLMRegisterDataAccessor("avitab/is_in_menu", xplmType_Int, false,
-            [] (void *ref) -> int {
-                XPlaneEnvironment *us = reinterpret_cast<XPlaneEnvironment *>(ref);
-                return us->isInMenu;
-            },
-            nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            nullptr, nullptr,
-            this, this
-            );
+    isInMenuRef = std::make_unique<DataRefExport<int>>("avitab/is_in_menu", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneEnvironment *>(self))->isInMenu; });
 
     XPLMScheduleFlightLoop(flightLoopId, -1, true);
 }
@@ -410,10 +360,6 @@ XPlaneEnvironment::~XPlaneEnvironment() {
     if (flightLoopId) {
         XPLMDestroyFlightLoop(flightLoopId);
     }
-    XPLMUnregisterDataAccessor(panelEnabledRef);
-    XPLMUnregisterDataAccessor(panelPoweredRef);
-    XPLMUnregisterDataAccessor(brightnessRef);
-    XPLMUnregisterDataAccessor(isInMenuRef);
 
     destroyMenu();
     logger::verbose("~XPlaneEnvironment");

--- a/src/environment/xplane/XPlaneEnvironment.h
+++ b/src/environment/xplane/XPlaneEnvironment.h
@@ -59,8 +59,25 @@ public:
     void setIsInMenu(bool menu) override;
     AircraftID getActiveAircraftCount() override;
     Location getAircraftLocation(AircraftID id) override;
+    void updateMapExports(float lat, float lon, int zoom, float vrange) override;
 
     ~XPlaneEnvironment();
+
+private:
+    // Exported datarefs relating to the overlayed map status
+    float getMapLatitude();
+    float getMapLongitude();
+    int getMapZoom();
+    float getMapVerticalRange();
+    float mapLatitude { 0.0f };
+    float mapLongitude { 0.0f };
+    int mapZoom { 0 };
+    float mapVerticalRange { 0.0f };
+    std::unique_ptr<DataRefExport<float>> mapLatitudeRef;
+    std::unique_ptr<DataRefExport<float>> mapLongitudeRef;
+    std::unique_ptr<DataRefExport<int>> mapZoomRef;
+    std::unique_ptr<DataRefExport<float>> mapVerticalRangeRef;
+
 private:
     using GetMetarPtr = void(*)(const char *id, XPLMFixedString150_t *outMETAR);
 

--- a/src/environment/xplane/XPlaneEnvironment.h
+++ b/src/environment/xplane/XPlaneEnvironment.h
@@ -29,6 +29,7 @@
 #include "src/gui_toolkit/LVGLToolkit.h"
 #include "src/environment/Environment.h"
 #include "DataCache.h"
+#include "DataRefExport.h"
 
 namespace avitab {
 
@@ -86,7 +87,9 @@ private:
     XPLMMenuID subMenu = nullptr;
     std::shared_ptr<int> panelPowered, panelEnabled;
     std::shared_ptr<float> brightness;
-    XPLMDataRef panelPoweredRef{}, panelEnabledRef{}, brightnessRef{}, isInMenuRef{};
+    std::unique_ptr<DataRefExport<int>> panelPoweredRef, panelEnabledRef, isInMenuRef;
+    std::unique_ptr<DataRefExport<float>> brightnessRef;
+
     bool isInMenu = false;
 
     std::string getXPlanePath();

--- a/src/environment/xplane/XPlaneGUIDriver.cpp
+++ b/src/environment/xplane/XPlaneGUIDriver.cpp
@@ -37,57 +37,21 @@ XPlaneGUIDriver::XPlaneGUIDriver():
     clickX("sim/graphics/view/click_3d_x_pixels", -1),
     clickY("sim/graphics/view/click_3d_y_pixels", -1)
 {
-    panelLeftRef = XPLMRegisterDataAccessor("avitab/panel_left", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                return us->panelLeft;
-            },
-            [] (void *ref, int newVal) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                us->panelLeft = newVal;
-            },
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-            this, this
-            );
+    panelLeftRef = std::make_unique<DataRefExport<int>>("avitab/panel_left", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneGUIDriver *>(self))->panelLeft; },
+        [] (void *self, int v) { (reinterpret_cast<XPlaneGUIDriver *>(self))->panelLeft = v; });
 
-    panelWidthRef = XPLMRegisterDataAccessor("avitab/panel_width", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                return us->panelWidth;
-            },
-            [] (void *ref, int newVal) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                us->panelWidth = newVal;
-            },
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-            this, this
-            );
+    panelWidthRef = std::make_unique<DataRefExport<int>>("avitab/panel_width", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneGUIDriver *>(self))->panelWidth; },
+        [] (void *self, int v) { (reinterpret_cast<XPlaneGUIDriver *>(self))->panelWidth = v; });
 
-    panelBottomRef = XPLMRegisterDataAccessor("avitab/panel_bottom", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                return us->panelBottom;
-            },
-            [] (void *ref, int newVal) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                us->panelBottom = newVal;
-            },
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-            this, this
-            );
+    panelBottomRef = std::make_unique<DataRefExport<int>>("avitab/panel_bottom", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneGUIDriver *>(self))->panelBottom; },
+        [] (void *self, int v) { (reinterpret_cast<XPlaneGUIDriver *>(self))->panelBottom = v; });
 
-    panelHeightRef = XPLMRegisterDataAccessor("avitab/panel_height", xplmType_Int, true,
-            [] (void *ref) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                return us->panelHeight;
-            },
-            [] (void *ref, int newVal) {
-                XPlaneGUIDriver *us = reinterpret_cast<XPlaneGUIDriver *>(ref);
-                us->panelHeight = newVal;
-            },
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-            this, this
-            );
+    panelHeightRef = std::make_unique<DataRefExport<int>>("avitab/panel_height", this,
+        [] (void *self) { return (reinterpret_cast<XPlaneGUIDriver *>(self))->panelHeight; },
+        [] (void *self, int v) { (reinterpret_cast<XPlaneGUIDriver *>(self))->panelHeight = v; });
 }
 
 void XPlaneGUIDriver::init(int width, int height) {
@@ -676,11 +640,6 @@ XPlaneGUIDriver::~XPlaneGUIDriver() {
 
     XPLMUnregisterDrawCallback(onDraw3D, xplm_Phase_Gauges, false, this);
     XPLMUnregisterKeySniffer(onKeyPress, 0, this);
-
-    XPLMUnregisterDataAccessor(panelLeftRef);
-    XPLMUnregisterDataAccessor(panelWidthRef);
-    XPLMUnregisterDataAccessor(panelBottomRef);
-    XPLMUnregisterDataAccessor(panelHeightRef);
 
     if (captureWindow) {
         XPLMDestroyWindow(captureWindow);

--- a/src/environment/xplane/XPlaneGUIDriver.h
+++ b/src/environment/xplane/XPlaneGUIDriver.h
@@ -26,7 +26,8 @@
 #include <memory>
 #include <vector>
 #include "src/environment/GUIDriver.h"
-#include "DataRef.h"
+#include "DataRefImport.h"
+#include "DataRefExport.h"
 
 namespace avitab {
 
@@ -59,8 +60,8 @@ public:
 private:
     WindowRect lastRect{};
     std::shared_ptr<float> brightness;
-    DataRef<bool> isVrEnabled;
-    DataRef<float> clickX, clickY;
+    DataRefImport<bool> isVrEnabled;
+    DataRefImport<float> clickX, clickY;
     XPLMDataRef buttonRef{};
     std::shared_ptr<int> panelPowered, panelEnabled;
     int textureId = -1;
@@ -71,7 +72,7 @@ private:
     std::atomic_int mouseWheel {0};
     std::mutex drawMutex;
     bool needsRedraw = false;
-    XPLMDataRef panelLeftRef{}, panelBottomRef{}, panelWidthRef{}, panelHeightRef{};
+    std::unique_ptr<DataRefExport<int>> panelLeftRef, panelBottomRef, panelWidthRef, panelHeightRef;
     int panelLeft = 0, panelBottom = 0, panelWidth = 0, panelHeight = 0;
     std::vector<int> vrTriggerIndices;
     bool mouseDownFromTrigger = false;

--- a/src/maps/OverlayedMap.cpp
+++ b/src/maps/OverlayedMap.cpp
@@ -146,6 +146,12 @@ void OverlayedMap::getCenterLocation(double& latitude, double& longitude) {
     pixelToPosition(mapImage->getWidth() / 2, mapImage->getHeight() / 2, latitude, longitude);
 }
 
+float OverlayedMap::getVerticalRange() const {
+    auto rangeLat = (topLat - bottomLat) * stitcher->getTargetImage()->getHeight() / mapImage->getHeight();
+    auto rangeKM = rangeLat * world::LAT_TO_KM;
+    return (float)rangeKM * 1000;
+}
+
 bool OverlayedMap::mouse(int x, int y, bool down)
 {
     bool wasClick = false;
@@ -527,7 +533,6 @@ void OverlayedMap::updateMapAttributes()
     double kmPerPixel = (bl.distanceTo(tr) / diagonalPixels) / 1000;
     mapScaleNMperPixel = kmPerPixel * world::KM_TO_NM;
     mapWidthNM = mapScaleNMperPixel * mapImage->getWidth();
-
 }
 
 void OverlayedMap::pixelToPosition(int px, int py, double &lat,

--- a/src/maps/OverlayedMap.h
+++ b/src/maps/OverlayedMap.h
@@ -22,7 +22,6 @@
 #include <functional>
 #include "src/libimg/stitcher/Stitcher.h"
 #include "src/world/World.h"
-//#include "src/world/router/Route.h"
 #include "src/libimg/TTFStamper.h"
 #include "src/environment/Environment.h"
 #include "OverlayHelper.h"
@@ -51,6 +50,7 @@ public:
     void centerOnPlane();
     void setPlaneLocations(std::vector<avitab::Location> &locs);
     void getCenterLocation(double &latitude, double &longitude);
+    float getVerticalRange() const;
 
     void updateImage();
     void zoomIn();
@@ -94,7 +94,7 @@ private:
 
     // current map display attributes, updated on each frame
     double leftLon, rightLon;
-    double bottomLat, topLat;
+    double bottomLat {0.0f}, topLat {0.0f};
     int maxNodeDensity;
     double mapWidthNM;
     double mapScaleNMperPixel;

--- a/src/world/World.h
+++ b/src/world/World.h
@@ -33,6 +33,7 @@ namespace world {
 
 constexpr const double KM_TO_NM = 0.539957;
 constexpr const double M_TO_FT = 3.28084;
+constexpr const double LAT_TO_KM = 111.133f;
 
 class RouteFinder;
 


### PR DESCRIPTION
This PR implements the enhancement requested in https://github.com/fpw/avitab/issues/198.

The first commit refactors some existing code to put a small wrapper class around the X-Plane API calls. Despite this, the callbacks are still a little more 'C' than 'C++' (reinterpret casts are used), and perhaps could be improved by some more complex (and less readable?) template code.

The second commit adds 4 new datarefs to allow other X-Plane components to obtain the Avitab map coordinates (map centre), the zoom level, and an approximation of the distance from top to bottom of the visible map.