### PR TITLE
Fix build settings for Apple clang compiler.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-conversion -Wno-unused-function -Wno-stringop-overflow -fPIC")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+string(REPLACE "-Wno-stringop-overflow" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endif()
 
 add_library(avitab_common "${CMAKE_CURRENT_LIST_DIR}/Logger.cpp")
 add_library(avitab_xplane "")


### PR DESCRIPTION
The recently added build flag no-stringop-overflow is not supported by Apple clang (bundled with Xcode). This update removes the flag if Apple clang is the detected compiler.