### PR TITLE
Use Chartfox georef if available

### DIFF
--- a/src/avitab/apps/AirportApp.cpp
+++ b/src/avitab/apps/AirportApp.cpp
@@ -524,9 +524,11 @@ void AirportApp::onMouseWheel(int dir, int x, int y) {
 bool AirportApp::onTimer() {
     for (auto &tab: pages) {
         if (tab.map) {
-            std::vector<avitab::Location> loc;
-            loc.push_back(api().getAircraftLocation(0));
-            tab.map->setPlaneLocations(loc);
+            std::vector<avitab::Location> locs;
+            for (AircraftID i = 0; i < api().getActiveAircraftCount(); ++i) {
+                locs.push_back(api().getAircraftLocation(i));
+            }
+            tab.map->setPlaneLocations(locs);
             if (tab.trackPlane) {
                 tab.map->centerOnPlane();
             }

--- a/src/avitab/apps/DocumentsApp.cpp
+++ b/src/avitab/apps/DocumentsApp.cpp
@@ -329,9 +329,11 @@ void DocumentsApp::onRotate() {
 bool DocumentsApp::onTimer() {
     auto tab = getActiveDocPage();
     if (tab && tab->map) {
-        std::vector<avitab::Location> loc;
-        loc.push_back(api().getAircraftLocation(0));
-        tab->map->setPlaneLocations(loc);
+        std::vector<avitab::Location> locs;
+        for (AircraftID i = 0; i < api().getActiveAircraftCount(); ++i) {
+            locs.push_back(api().getAircraftLocation(i));
+        }
+        tab->map->setPlaneLocations(locs);
         tab->map->doWork();
     }
     return true;

--- a/src/charts/ChartService.cpp
+++ b/src/charts/ChartService.cpp
@@ -116,8 +116,11 @@ std::shared_ptr<APICall<std::shared_ptr<Chart>>> ChartService::loadChart(std::sh
             auto blob = bgChart->getChartData();
             auto in = std::string((char *)blob.data(), blob.size());
             auto hash = crypto.sha256String(in);
-            std::string calibrationMetadata = getCalibrationMetadataForHash(hash);
-            bgChart->setCalibrationMetadata(calibrationMetadata);
+            std::string localCalibrationMetadata = getCalibrationMetadataForHash(hash);
+            if (localCalibrationMetadata != "") {
+                // Use local calibration metadata, overriding any Chartfox georef
+                bgChart->setCalibrationMetadata(localCalibrationMetadata);
+            }
         }
 
         auto nvChart = std::dynamic_pointer_cast<navigraph::NavigraphChart>(chart);

--- a/src/charts/libchartfox/ChartFoxChart.cpp
+++ b/src/charts/libchartfox/ChartFoxChart.cpp
@@ -67,7 +67,11 @@ apis::ChartCategory ChartFoxChart::getCategory() const {
 }
 
 void ChartFoxChart::setCalibrationMetadata(std::string metadata) {
-    calibrationMetadata = metadata;
+    chartGeoref = metadata;
+}
+
+std::string ChartFoxChart::getCalibrationMetadata() const {
+    return chartGeoref;
 }
 
 std::string ChartFoxChart::getID() const {
@@ -87,7 +91,7 @@ std::shared_ptr<img::TileSource> ChartFoxChart::createTileSource(bool nightMode)
         throw std::runtime_error("Chart not loaded");
     }
 
-    auto docSource = std::make_shared<maps::DownloadedSource>(chartData, chartType, calibrationMetadata);
+    auto docSource = std::make_shared<maps::DownloadedSource>(chartData, chartType, chartGeoref);
     docSource->setNightMode(nightMode);
     return docSource;
 }
@@ -101,9 +105,10 @@ void ChartFoxChart::changeNightMode(std::shared_ptr<img::TileSource> src, bool n
     docSource->setNightMode(nightMode);
 }
 
-void ChartFoxChart::setChartData(const std::vector<uint8_t> &blob, const std::string type) {
+void ChartFoxChart::setChartData(const std::vector<uint8_t> &blob, const std::string type, const std::string &georef) {
     chartData = blob;
     chartType = type;
+    chartGeoref = georef;
 }
 
 const std::vector<uint8_t> ChartFoxChart::getChartData() const {

--- a/src/charts/libchartfox/ChartFoxChart.h
+++ b/src/charts/libchartfox/ChartFoxChart.h
@@ -25,12 +25,6 @@
 
 namespace chartfox {
 
-struct ChartGEOReference {
-    double lon1, x1, lon2, x2;
-    double lat1, y1, lat2, y2;
-    bool valid = false;
-};
-
 class ChartFoxChart: public apis::Chart {
 public:
     ChartFoxChart(const nlohmann::json &json, int code);
@@ -44,17 +38,17 @@ public:
     virtual std::shared_ptr<img::TileSource> createTileSource(bool nightMode) override;
     virtual void changeNightMode(std::shared_ptr<img::TileSource> src, bool nightMode) override;
     virtual void setCalibrationMetadata(std::string metadata) override;
+    std::string getCalibrationMetadata() const;
 
     std::string getID() const;
 
     void setURL(const std::string url);
     std::string getURL() const;
 
-    void setChartData(const std::vector<uint8_t> &blob, const std::string type);
+    void setChartData(const std::vector<uint8_t> &blob, const std::string type, const std::string &georef);
     const std::vector<uint8_t> getChartData() const;
 
 private:
-    ChartGEOReference geoRef;
     std::string icao;
     std::string id;
     std::string name;
@@ -63,7 +57,7 @@ private:
     std::string url;
     std::vector<uint8_t> chartData;
     std::string chartType;
-    std::string calibrationMetadata;
+    std::string chartGeoref = "";
 };
 
 } /* namespace chartfox */

--- a/src/environment/Settings.cpp
+++ b/src/environment/Settings.cpp
@@ -120,8 +120,8 @@ void Settings::init() {
     // full init not required, just defaults that aren't zero/false/empty
     *database = { { "general", { { "prefs_version", PREFS_VERSION },
                                  { "show_calibration_msg_on_load", true },
-                                 { "show_overlays_in_airport_app", true },
-                                 { "show_overlays_in_charts_app", true },
+                                 { "show_overlays_in_airport_app", false },
+                                 { "show_overlays_in_charts_app", false },
                                  { "show_fps", true } } },
                   { "overlay", { { "my_aircraft", true } } } };
 }

--- a/src/libimg/Rasterizer.cpp
+++ b/src/libimg/Rasterizer.cpp
@@ -106,6 +106,11 @@ int Rasterizer::getTileSize() {
     return tileSize;
 }
 
+double Rasterizer::getAspectRatio(int page) {
+    auto &rect = pageRects.at(page);
+    return (rect.x1 - rect.x0) / (rect.y1 - rect.y0);
+}
+
 int Rasterizer::getPageWidth(int page, int zoom) {
     bool swapXY = (preRotateAngle % 180) == 90;
     auto &rect = pageRects.at(page);

--- a/src/libimg/Rasterizer.h
+++ b/src/libimg/Rasterizer.h
@@ -35,6 +35,7 @@ public:
     int getTileSize();
     int getPageWidth(int page, int zoom);
     int getPageHeight(int page, int zoom);
+    double getAspectRatio(int page);
     std::unique_ptr<Image> loadTile(int page, int x, int y, int zoom, bool nightMode);
     void setPreRotate(int angle);
 

--- a/src/maps/sources/Calibration.h
+++ b/src/maps/sources/Calibration.h
@@ -22,6 +22,7 @@
 #include <string>
 #include "src/libimg/stitcher/TileSource.h"
 #include "LinearEquation.h"
+#include <nlohmann/json.hpp>
 
 namespace maps {
 
@@ -35,8 +36,10 @@ public:
     void setHash(const std::string &s);
 
     std::string toString()const;
-    void fromJsonString(const std::string &s);
+    void fromJsonString(const std::string &s, double aspectRatio);
     void fromKmlString(const std::string &s);
+    void fromLocalJson(const nlohmann::json &json);
+    void fromChartfoxJson(const nlohmann::json &json, double aspectRatio);
 
     bool hasCalibration() const;
 
@@ -54,6 +57,7 @@ private:
     std::string regHash{};
     double northOffsetAngle{};
     bool isCalibrated = false;
+    bool isChartfoxGeoreferenced = false;
     bool offsetAngleDefined = false;
     std::string report{"No calibration"};
     bool dbg = false;
@@ -61,10 +65,13 @@ private:
     LinearEquation leWorldToPixels;
     LinearEquation lePixelsToWorld;
 
-    void calculateCalibration();
+    void calculateLocalCalibration();
+    void calculateChartfoxCalibration(double k, double transformAngle, double tx, double ty, double aspectRatio);
     std::pair<double, double> rotate(double x, double y, double angleDegrees) const;
     std::string getKmlTagData(const std::string kml, const std::string tag) const;
     std::pair<double, double> mercator(double lat, double lon) const;
+    std::pair<double, double> latLonToEPSG3857(double lat, double lon) const;
+    std::pair<double, double> EPSG3857toLatLon(double lat3857, double lon3857) const;
     double invMercator(double lat) const;
     void define2PAThirdVertex();
     double getTriangleInnerAngleA(double a, double b, double c) const;

--- a/src/maps/sources/DocumentSource.cpp
+++ b/src/maps/sources/DocumentSource.cpp
@@ -34,13 +34,12 @@ DocumentSource::DocumentSource(const std::vector<uint8_t> &data, const std::stri
 }
 
 void DocumentSource::loadProvidedCalibrationMetadata(std::string calibrationMetadata) {
-    if (calibrationMetadata != "") {
-        logger::info("Using hash-matched calibration metadata");
-        calibration.fromJsonString(calibrationMetadata);
+    if ((calibrationMetadata == "") || (calibrationMetadata == "[]")) {
+        logger::warn("No calibration metadata");
+    } else {
+        calibration.fromJsonString(calibrationMetadata, rasterizer.getAspectRatio(0));
         rotateAngle = calibration.getPreRotate();
         rasterizer.setPreRotate(rotateAngle);
-    } else {
-        logger::warn("No calibration metadata");
     }
 
 }

--- a/src/maps/sources/LinearEquation.h
+++ b/src/maps/sources/LinearEquation.h
@@ -40,6 +40,9 @@ public:
                                             double px2, double py2, double wx2, double wy2,
                                             double northOffsetAngleDegrees);
 
+    void   initialiseFromChartfoxP2W(double k, double transformAngle, double tx, double ty, double aspectRatio);
+    void   initialiseFromChartfoxW2P(double k, double transformAngle, double tx, double ty, double aspectRatio);
+
     void   calculateReverseCoeffs(const LinearEquation & l);
 
     std::pair<double, double> getResult(double x, double y) const;

--- a/src/maps/sources/LocalFileSource.cpp
+++ b/src/maps/sources/LocalFileSource.cpp
@@ -89,7 +89,7 @@ void LocalFileSource::findAndLoadCalibration() {
         logger::info("Loaded co-located json calibration file for %s", utf8FileName.c_str());
         std::string jsonStr((std::istreambuf_iterator<char>(jsonFile)),
                              std::istreambuf_iterator<char>());
-        calibration.fromJsonString(jsonStr);
+        calibration.fromJsonString(jsonStr, rasterizer.getAspectRatio(0));
     } else {
         // Try a co-located name-matched Google Earth KML file for calibration
         std::string kmlFileName = utf8FileName + ".kml";
@@ -109,7 +109,7 @@ void LocalFileSource::findAndLoadCalibration() {
             std::string calibrationMetadata = chartService->getCalibrationMetadataForFile(utf8FileName);
             if (calibrationMetadata != "") {
                 logger::info("Loaded hash-mapped json calibration file for %s", utf8FileName.c_str());
-                calibration.fromJsonString(calibrationMetadata);
+                calibration.fromJsonString(calibrationMetadata, rasterizer.getAspectRatio(0));
             } else {
                 logger::warn("No json or kml calibration file for %s", utf8FileName.c_str());
                 return;


### PR DESCRIPTION
There is no prerotate attribute in Chartfox georef, so charts may have incorrect default orientation. Rotating unfortunately then also rotates any overlay, including e.g. the scale. The pdf_page_rotation attribute in Chartfox georef is not equivalent to the avitab prerotate so cannot be used for this. Nothing can be done about this until Chartfox add a "prerotate" attribute, which has been talked about by myself and others on email and the Chartfox Discord channel.

Although overlays can be shown in Airport and Charts app, the default behaviour is to not show overlays. The rationale is that all the info a pilot needs from a georeferenced chart at that stage of flight is typically already shown. And overlays just clutter the chart. However, overlays are useful if debugging local/chartfox calibration, so behaviour can be changed in avitab.prf

Local calibration metadata for a chart overrides any Chartfox georef metadata