### PR TITLE
don't load closed airports ([X]). remove [H]/[S] from name

### DIFF
--- a/src/libxdata/parsers/AirportParser.cpp
+++ b/src/libxdata/parsers/AirportParser.cpp
@@ -199,14 +199,14 @@ void AirportParser::parseFrequency(int code) {
 void AirportParser::finishAirport() {
     if (!curPort.id.empty()) {
         size_t pos;
-        for (auto prefix : {"[H] ", "[S] "} ) {
+        for (auto prefix : {"[H]", "[S]"} ) {
             pos = curPort.name.find(prefix);
             if (pos != std::string::npos) {
-                curPort.name.erase(pos, 4);
+                curPort.name.erase(pos, 3);
                 break;
             }
         }
-        pos = curPort.name.find("[X] ");
+        pos = curPort.name.find("[X]");
         if (pos == std::string::npos) {
             acceptor(curPort);
         }


### PR DESCRIPTION
the [H],[S] indicators in the airport name are useless nowadays. airport types are identified by analysing runway types.
[X] indicates a closed airport, don't load them at all.